### PR TITLE
fix(host): filter non-Press KeyEvents so navigation moves one row per keypress

### DIFF
--- a/crates/reef-host/src/main.rs
+++ b/crates/reef-host/src/main.rs
@@ -1,7 +1,7 @@
 use crossterm::{
     event::{
-        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyModifiers, MouseButton,
-        MouseEvent, MouseEventKind,
+        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
+        MouseButton, MouseEvent, MouseEventKind,
     },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
@@ -56,6 +56,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         loop {
             match event::read()? {
                 Event::Key(key) => {
+                    // Crossterm emits Press + Release (and Repeat on hold) for every
+                    // physical keystroke on Windows Terminal, in terminals that enable
+                    // the kitty keyboard protocol, and on some macOS configurations.
+                    // Without this filter each keypress runs handle_key twice, so j/k
+                    // navigate 2 rows instead of 1 (and 3+ when held).
+                    if key.kind != KeyEventKind::Press {
+                        continue;
+                    }
+
                     // v toggles select mode regardless of active panel
                     if key.code == KeyCode::Char('v') && key.modifiers.is_empty() {
                         app.select_mode = !app.select_mode;


### PR DESCRIPTION
## Summary
Filter out `KeyEventKind::Release` / `KeyEventKind::Repeat` events in the main loop so a single physical keypress doesn't run `handle_key` more than once. Without this filter, `j`/`k` navigate 2 rows per tap (and 3+ when the key is held), because crossterm on Windows Terminal, in terminals that enable the kitty keyboard protocol, and on some macOS configurations emits a Press + a Release for every keystroke.

## Change

```rust
use crossterm::event::{..., KeyEventKind};

Event::Key(key) => {
    if key.kind != KeyEventKind::Press {
        continue;
    }
    // ... existing handling
}
```

The "drain all pending events" loop around the match is preserved, so rapid real keypresses still collapse into one render tick.

## Test plan
- [x] Build (local `cargo check` not run — clippy/test matrix in CI will cover it). Change is syntactically trivial: one new import + one early-continue guard.
- [ ] Manual: pressing `j` once in the Files tab should advance the selection exactly one row (previously 2–3 rows on affected terminals).
- [ ] Regression: `v` toggle, `q` quit, chord keys (Ctrl+C), and help-dismiss paths still fire on Press.

## Context
Reported symptom: "cursor jumps 2–3 rows per keypress" — the same crossterm gotcha that bit ratatui, gitui, zellij etc. Standard fix is to gate on `KeyEventKind::Press` at the earliest point inside the `Event::Key` arm.