### PR TITLE
fix(file-tree): show dotfiles and dot-directories

### DIFF
--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -64,8 +64,7 @@ impl FileTree {
 
         for entry in entries.flatten() {
             let name = entry.file_name().to_string_lossy().to_string();
-            // Skip hidden files and .git
-            if name.starts_with('.') {
+            if name == ".git" {
                 continue;
             }
             let path = entry.path();

--- a/tests/ui_snapshots.rs
+++ b/tests/ui_snapshots.rs
@@ -74,7 +74,10 @@ fn with_filters<F: FnOnce()>(body: F) {
 fn snapshot_empty_repo() {
     let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let (tmp, _raw) = tempdir_repo();
-    let _h = HomeGuard::enter(tmp.path());
+    // HOME must point outside the workdir — prefs creates `.config/reef`
+    // and the file tree now shows dotfiles.
+    let home = tempfile::TempDir::new().expect("home tempdir");
+    let _h = HomeGuard::enter(home.path());
     let _g = CwdGuard::enter(tmp.path());
 
     let mut app = App::new();
@@ -89,7 +92,8 @@ fn snapshot_with_staged_and_unstaged() {
     commit_file(&raw, "tracked.txt", "v1\n", "init");
     write_file(&raw, "tracked.txt", "v2\n"); // unstaged modification
     write_file(&raw, "new.txt", "new\n"); // untracked
-    let _h = HomeGuard::enter(tmp.path());
+    let home = tempfile::TempDir::new().expect("home tempdir");
+    let _h = HomeGuard::enter(home.path());
     let _g = CwdGuard::enter(tmp.path());
 
     let mut app = App::new();


### PR DESCRIPTION
## Summary
- The file tree was skipping any entry whose name starts with `.`, hiding useful dirs/files like `.github`, `.cargo`, `.gitignore`.
- Narrow the skip to `.git` only so hidden entries are visible.

## Test plan
- [ ] Run reef in a repo that contains `.github/` and confirm it shows up in the tree
- [ ] Confirm `.git/` is still hidden
- [ ] Existing tree tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)