### PR TITLE
feat: light theme support (fixes #4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,6 +1820,7 @@ dependencies = [
  "similar 3.1.0",
  "syntect",
  "tempfile",
+ "terminal-colorsaurus",
  "test-support",
  "two-face",
  "unicode-width",
@@ -2148,6 +2149,32 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal-colorsaurus"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a46bb5364467da040298c573c8a95dbf9a512efc039630409a03126e3703e90"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "memchr",
+ "mio 1.2.0",
+ "terminal-trx",
+ "windows-sys 0.61.2",
+ "xterm-color",
+]
+
+[[package]]
+name = "terminal-trx"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3f27d9a8a177e57545481faec87acb45c6e854ed1e5a3658ad186c106f38ed"
+dependencies = [
+ "cfg-if",
+ "libc",
  "windows-sys 0.61.2",
 ]
 
@@ -2845,6 +2872,12 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xterm-color"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7008a9d8ba97a7e47d9b2df63fcdb8dade303010c5a7cd5bf2469d4da6eba673"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ two-face      = { version = "0.5", default-features = false, features = ["syntec
 notify        = "6"
 ignore        = "0.4"
 serde_json    = { workspace = true }
+terminal-colorsaurus = "1.0.3"
 
 [dev-dependencies]
 tempfile     = "3"

--- a/benches/highlight.rs
+++ b/benches/highlight.rs
@@ -15,7 +15,7 @@ fn synth_rust_lines(n: usize) -> Vec<String> {
 fn bench_highlight_rust(c: &mut Criterion) {
     let lines = synth_rust_lines(1000);
     c.bench_function("highlight_file/rust_1000_lines", |b| {
-        b.iter(|| highlight_file(black_box("bench.rs"), black_box(&lines)));
+        b.iter(|| highlight_file(black_box("bench.rs"), black_box(&lines), true));
     });
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,7 @@ use crate::fs_watcher;
 use crate::git::graph::GraphRow;
 use crate::git::{CommitDetail, DiffContent, FileEntry, GitRepo, RefLabel};
 use crate::ui::mouse::{ClickAction, HitTestRegistry};
+use crate::ui::theme::Theme;
 use crate::ui::toast::Toast;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -168,6 +169,10 @@ pub struct App {
     pub should_quit: bool,
     pub select_mode: bool,
     pub show_help: bool,
+
+    /// Active color theme. Chosen in `main.rs` before raw-mode entry (so the
+    /// OSC 11 probe doesn't leak onto the TUI) and passed into `App::new`.
+    pub theme: Theme,
 }
 
 #[derive(Debug, Clone)]
@@ -177,7 +182,7 @@ pub struct SelectedFile {
 }
 
 impl App {
-    pub fn new() -> Self {
+    pub fn new(theme: Theme) -> Self {
         // Fold pre-1.0 unprefixed keys (`layout=`, `mode=`) and the retired
         // `~/.config/reef/git.prefs` into the current prefixed namespace
         // BEFORE any `prefs::get` runs. Order matters: `load_prefs` below
@@ -245,6 +250,7 @@ impl App {
             should_quit: false,
             select_mode: false,
             show_help: false,
+            theme,
         };
         app.refresh_status();
         app
@@ -291,7 +297,8 @@ impl App {
     pub fn load_preview(&mut self) {
         if let Some(entry) = self.file_tree.selected_entry() {
             if !entry.is_dir {
-                let new_content = file_tree::load_preview(&self.file_tree.root, &entry.path);
+                let new_content =
+                    file_tree::load_preview(&self.file_tree.root, &entry.path, self.theme.is_dark);
                 // Preserve scroll when reloading the same file (fs-watcher refresh);
                 // reset only when the selected path actually changed (navigation).
                 let same_file = matches!(

--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -167,7 +167,10 @@ impl FileTree {
 }
 
 /// Load a file for preview. Returns None if the file can't be read.
-pub fn load_preview(root: &Path, rel_path: &Path) -> Option<PreviewContent> {
+///
+/// `dark` picks the syntect theme (OneHalfDark vs OneHalfLight) so the
+/// highlighted tokens read correctly against whichever UI theme is active.
+pub fn load_preview(root: &Path, rel_path: &Path, dark: bool) -> Option<PreviewContent> {
     let full = root.join(rel_path);
     if !full.is_file() {
         return None;
@@ -201,7 +204,7 @@ pub fn load_preview(root: &Path, rel_path: &Path) -> Option<PreviewContent> {
 
     let rel_str = rel_path.to_string_lossy().to_string();
     let highlighted = if raw.len() <= 512 * 1024 && lines.len() <= 5_000 {
-        crate::ui::highlight::highlight_file(&rel_str, &lines)
+        crate::ui::highlight::highlight_file(&rel_str, &lines, dark)
     } else {
         None
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use crossterm::{
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use reef::app::App;
+use reef::ui::theme::Theme;
 use reef::{input, ui};
 use std::io;
 use std::panic;
@@ -20,6 +21,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         original_hook(panic_info);
     }));
 
+    // Probe terminal background BEFORE raw mode / alt-screen so the OSC 11
+    // reply doesn't fragment onto the TUI. `Theme::resolve` also honours the
+    // `ui.theme` pref override and a non-TTY fallback.
+    let theme = Theme::resolve();
+
     // Terminal setup
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -28,7 +34,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut terminal = Terminal::new(backend)?;
 
     // App init
-    let mut app = App::new();
+    let mut app = App::new(theme);
 
     // Main loop
     loop {

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -9,6 +9,10 @@
 //!   - `commit.diff_layout` / `commit.diff_mode` — Graph tab commit-file diff
 //!   - `status.tree_mode`                       — Git tab left-side list/tree
 //!   - `commit.files_tree_mode`                 — Graph tab commit files list/tree
+//!   - `ui.theme`                               — `dark` | `light` | `auto` (default `auto`).
+//!                                                Read once in `main.rs` before raw-mode
+//!                                                entry; `auto` probes the terminal's
+//!                                                background via OSC 11.
 //!
 //! Writers must go through `set()` (not raw `std::fs::write`) so that
 //! updating one key doesn't erase all the others.

--- a/src/ui/commit_detail_panel.rs
+++ b/src/ui/commit_detail_panel.rs
@@ -6,6 +6,7 @@ use crate::git::tree::{self as gtree, Node};
 use crate::git::{DiffContent, FileEntry, FileStatus, LineTag};
 use crate::ui::git_graph_panel;
 use crate::ui::mouse::ClickAction;
+use crate::ui::theme::Theme;
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
@@ -19,7 +20,8 @@ const DIFF_GUTTER_WIDTH: usize = 15;
 const SBS_GUTTER_WIDTH: usize = 7;
 
 pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
-    let rows = build_rows(app, area.width);
+    let theme = app.theme;
+    let rows = build_rows(app, area.width, &theme);
     let total = rows.len();
 
     let max_scroll = total.saturating_sub(area.height as usize);
@@ -39,7 +41,12 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
         let spans: Vec<Span<'static>> = row
             .spans
             .iter()
-            .map(|s| Span::styled(s.text.clone(), crate::ui::hover::apply(s.style, hover)))
+            .map(|s| {
+                Span::styled(
+                    s.text.clone(),
+                    crate::ui::hover::apply(s.style, hover, app.theme.hover_bg),
+                )
+            })
             .collect();
         f.render_widget(Line::from(spans), Rect::new(area.x, y, area.width, 1));
 
@@ -224,14 +231,14 @@ fn from_ratatui_span(span: Span<'static>) -> RowSpan {
 
 // ─── Row construction ─────────────────────────────────────────────────────────
 
-fn build_rows(app: &App, width: u16) -> Vec<Row> {
+fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
     let mut rows: Vec<Row> = Vec::new();
     let cd = &app.commit_detail;
 
     let Some(detail) = &cd.detail else {
         rows.push(Row::new(vec![RowSpan::styled(
             "  选择一个 commit 查看详情",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.fg_secondary),
         )]));
         return rows;
     };
@@ -241,7 +248,7 @@ fn build_rows(app: &App, width: u16) -> Vec<Row> {
     let max_path = (width as usize).saturating_sub(6);
 
     rows.push(Row::new(vec![
-        RowSpan::styled("commit ", Style::default().fg(Color::DarkGray)),
+        RowSpan::styled("commit ", Style::default().fg(theme.fg_secondary)),
         RowSpan::styled(
             info.oid.clone(),
             Style::default()
@@ -250,24 +257,24 @@ fn build_rows(app: &App, width: u16) -> Vec<Row> {
         ),
     ]));
     rows.push(Row::new(vec![
-        RowSpan::styled("Author: ", Style::default().fg(Color::DarkGray)),
+        RowSpan::styled("Author: ", Style::default().fg(theme.fg_secondary)),
         RowSpan::styled(
             format!("{} <{}>", info.author_name, info.author_email),
-            Style::default().fg(Color::White),
+            Style::default().fg(theme.fg_primary),
         ),
     ]));
     rows.push(Row::new(vec![
-        RowSpan::styled("Date:   ", Style::default().fg(Color::DarkGray)),
+        RowSpan::styled("Date:   ", Style::default().fg(theme.fg_secondary)),
         RowSpan::styled(
             format_timestamp(info.time),
-            Style::default().fg(Color::White),
+            Style::default().fg(theme.fg_primary),
         ),
     ]));
 
     if let Some(labels) = app.git_graph.ref_map.get(&info.oid) {
         let mut spans: Vec<RowSpan> = vec![RowSpan::styled(
             "Refs:   ",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.fg_secondary),
         )];
         for label in labels {
             spans.push(from_ratatui_span(git_graph_panel::ref_label_span(label)));
@@ -283,7 +290,7 @@ fn build_rows(app: &App, width: u16) -> Vec<Row> {
         truncate_in_place(&mut msg, max_msg);
         rows.push(Row::new(vec![
             RowSpan::plain("    "),
-            RowSpan::styled(msg, Style::default().fg(Color::White)),
+            RowSpan::styled(msg, Style::default().fg(theme.fg_primary)),
         ]));
     }
 
@@ -303,22 +310,23 @@ fn build_rows(app: &App, width: u16) -> Vec<Row> {
         ),
         RowSpan::styled(
             format!("  [{}]  t 切换", view_label),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.fg_secondary),
         )
         .on_click("git.toggleCommitFilesView", Value::Null),
     ]));
 
     let ctx = CommitFilesCtx {
         selected_file: cd.file_diff.as_ref().map(|(p, _)| p.as_str()),
-        sel_bg: Color::Rgb(40, 60, 100),
+        sel_bg: theme.selection_bg,
         max_path,
         commit_oid: &info.oid,
         collapsed: &cd.files_collapsed,
+        fg: theme.fg_primary,
     };
 
     if cd.files_tree_mode {
         let nodes = gtree::build(&detail.files);
-        render_commit_file_tree(&nodes, 1, &ctx, &mut rows);
+        render_commit_file_tree(&nodes, 1, &ctx, &mut rows, theme);
     } else {
         for file in &detail.files {
             rows.push(commit_file_row(file, &file.path, "  ", &ctx));
@@ -327,9 +335,15 @@ fn build_rows(app: &App, width: u16) -> Vec<Row> {
 
     if let Some((path, diff)) = &cd.file_diff {
         rows.push(Row::blank());
-        rows.push(diff_header_row(path, cd.diff_layout, cd.diff_mode, width));
-        rows.push(diff_separator_row(width));
-        append_diff_rows(&mut rows, diff, cd.diff_layout, width);
+        rows.push(diff_header_row(
+            path,
+            cd.diff_layout,
+            cd.diff_mode,
+            width,
+            theme,
+        ));
+        rows.push(diff_separator_row(width, theme));
+        append_diff_rows(&mut rows, diff, cd.diff_layout, width, theme);
     }
 
     rows
@@ -341,6 +355,7 @@ struct CommitFilesCtx<'a> {
     max_path: usize,
     commit_oid: &'a str,
     collapsed: &'a std::collections::HashSet<String>,
+    fg: Color,
 }
 
 fn commit_file_row(
@@ -368,10 +383,7 @@ fn commit_file_row(
             format!("{} ", file.status.label()),
             apply_bg(Style::default().fg(status_color), base_bg),
         ),
-        RowSpan::styled(
-            display,
-            apply_bg(Style::default().fg(Color::White), base_bg),
-        ),
+        RowSpan::styled(display, apply_bg(Style::default().fg(ctx.fg), base_bg)),
     ];
 
     Row::new(spans).on_click(
@@ -385,6 +397,7 @@ fn render_commit_file_tree(
     depth: usize,
     ctx: &CommitFilesCtx,
     rows: &mut Vec<Row>,
+    theme: &Theme,
 ) {
     let mut entries: Vec<(&String, &Node)> = nodes.iter().collect();
     entries.sort_by(|a, b| {
@@ -408,19 +421,19 @@ fn render_commit_file_tree(
                         RowSpan::plain(indent),
                         RowSpan::styled(
                             format!("{} ", arrow),
-                            Style::default().fg(Color::DarkGray),
+                            Style::default().fg(theme.fg_secondary),
                         ),
                         RowSpan::styled(
                             format!("{}/", name),
                             Style::default()
-                                .fg(Color::Cyan)
+                                .fg(theme.accent)
                                 .add_modifier(Modifier::BOLD),
                         ),
                     ])
                     .on_click("git.toggleCommitDir", serde_json::json!({ "path": path })),
                 );
                 if !is_collapsed {
-                    render_commit_file_tree(children, depth + 1, ctx, rows);
+                    render_commit_file_tree(children, depth + 1, ctx, rows, theme);
                 }
             }
             Node::File(entry) => {
@@ -434,7 +447,13 @@ fn render_commit_file_tree(
 
 // ─── Inline diff rendering ────────────────────────────────────────────────────
 
-fn diff_header_row(path: &str, layout: DiffLayout, mode: DiffMode, width: u16) -> Row {
+fn diff_header_row(
+    path: &str,
+    layout: DiffLayout,
+    mode: DiffMode,
+    width: u16,
+    theme: &Theme,
+) -> Row {
     let layout_label = match layout {
         DiffLayout::Unified => "上下",
         DiffLayout::SideBySide => "左右",
@@ -452,48 +471,56 @@ fn diff_header_row(path: &str, layout: DiffLayout, mode: DiffMode, width: u16) -
         RowSpan::styled(
             path_display,
             Style::default()
-                .fg(Color::White)
+                .fg(theme.fg_primary)
                 .add_modifier(Modifier::BOLD),
         ),
-        RowSpan::styled(tag_str, Style::default().fg(Color::DarkGray)),
+        RowSpan::styled(tag_str, Style::default().fg(theme.fg_secondary)),
     ])
 }
 
-fn diff_separator_row(width: u16) -> Row {
+fn diff_separator_row(width: u16, theme: &Theme) -> Row {
     Row::new(vec![RowSpan::styled(
         "─".repeat(width as usize),
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(theme.fg_secondary),
     )])
 }
 
-fn append_diff_rows(rows: &mut Vec<Row>, diff: &DiffContent, layout: DiffLayout, width: u16) {
+fn append_diff_rows(
+    rows: &mut Vec<Row>,
+    diff: &DiffContent,
+    layout: DiffLayout,
+    width: u16,
+    theme: &Theme,
+) {
     match layout {
-        DiffLayout::Unified => append_unified_diff(rows, diff, width),
-        DiffLayout::SideBySide => append_side_by_side_diff(rows, diff, width),
+        DiffLayout::Unified => append_unified_diff(rows, diff, width, theme),
+        DiffLayout::SideBySide => append_side_by_side_diff(rows, diff, width, theme),
     }
 }
 
-fn append_unified_diff(rows: &mut Vec<Row>, diff: &DiffContent, width: u16) {
-    let added_bg = Color::Rgb(0, 40, 0);
-    let removed_bg = Color::Rgb(60, 0, 0);
+fn append_unified_diff(rows: &mut Vec<Row>, diff: &DiffContent, width: u16, theme: &Theme) {
+    let added_bg = theme.added_bg;
+    let removed_bg = theme.removed_bg;
 
     for (i, hunk) in diff.hunks.iter().enumerate() {
         if i > 0 {
             rows.push(Row::new(vec![RowSpan::styled(
                 format!(" {:>5}  {:>5}  ⋯", "", ""),
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme.fg_secondary),
             )]));
         }
         rows.push(Row::new(vec![RowSpan::styled(
             format!(" {:>5}  {:>5}  {}", "", "", hunk.header),
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM),
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::DIM),
         )]));
 
         for line in &hunk.lines {
             let (prefix, fg, bg) = match line.tag {
-                LineTag::Added => ("+", Color::Green, Some(added_bg)),
-                LineTag::Removed => ("-", Color::Red, Some(removed_bg)),
-                LineTag::Context => (" ", Color::White, None),
+                LineTag::Added => ("+", theme.added_accent, Some(added_bg)),
+                LineTag::Removed => ("-", theme.removed_accent, Some(removed_bg)),
+                LineTag::Context => (" ", theme.fg_primary, None),
             };
             let old_no = fmt_diff_lineno(line.old_lineno);
             let new_no = fmt_diff_lineno(line.new_lineno);
@@ -501,7 +528,7 @@ fn append_unified_diff(rows: &mut Vec<Row>, diff: &DiffContent, width: u16) {
             let content = truncate_to_display_width(&line.content, max_text).to_string();
             let pad = max_text.saturating_sub(UnicodeWidthStr::width(content.as_str()));
 
-            let gutter_style = Style::default().fg(Color::DarkGray);
+            let gutter_style = Style::default().fg(theme.fg_secondary);
             let mark_style = Style::default().fg(fg);
             let text_style = Style::default().fg(fg);
             let (g, m, t, p) = match bg {
@@ -523,7 +550,7 @@ fn append_unified_diff(rows: &mut Vec<Row>, diff: &DiffContent, width: u16) {
     }
 }
 
-fn append_side_by_side_diff(rows: &mut Vec<Row>, diff: &DiffContent, width: u16) {
+fn append_side_by_side_diff(rows: &mut Vec<Row>, diff: &DiffContent, width: u16, theme: &Theme) {
     let half = width.saturating_sub(1) / 2;
     let right_w = width.saturating_sub(half + 1);
 
@@ -531,16 +558,18 @@ fn append_side_by_side_diff(rows: &mut Vec<Row>, diff: &DiffContent, width: u16)
         if i > 0 {
             rows.push(Row::new(vec![RowSpan::styled(
                 format!(" {:>5}  ⋯", ""),
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme.fg_secondary),
             )]));
         }
         rows.push(Row::new(vec![RowSpan::styled(
             format!(" {:>5}  {}", "", hunk.header),
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM),
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::DIM),
         )]));
 
         for row in pair_hunk_lines(hunk) {
-            rows.push(render_sbs_row(&row, half, right_w));
+            rows.push(render_sbs_row(&row, half, right_w, theme));
         }
     }
 }
@@ -554,13 +583,10 @@ struct SbsRow {
     right_text: String,
 }
 
-fn render_sbs_row(row: &SbsRow, half_w: u16, right_w: u16) -> Row {
-    let added_bg = Color::Rgb(0, 40, 0);
-    let removed_bg = Color::Rgb(60, 0, 0);
-
+fn render_sbs_row(row: &SbsRow, half_w: u16, right_w: u16, theme: &Theme) -> Row {
     let mut spans: Vec<RowSpan> = Vec::new();
-    let (left_fg, left_bg) = side_style(row.left_tag, added_bg, removed_bg);
-    let (right_fg, right_bg) = side_style(row.right_tag, added_bg, removed_bg);
+    let (left_fg, left_bg) = side_style(row.left_tag, theme);
+    let (right_fg, right_bg) = side_style(row.right_tag, theme);
 
     push_sbs_half(
         &mut spans,
@@ -569,10 +595,11 @@ fn render_sbs_row(row: &SbsRow, half_w: u16, right_w: u16) -> Row {
         left_fg,
         left_bg,
         half_w,
+        theme,
     );
     spans.push(RowSpan::styled(
         "│".to_string(),
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(theme.fg_secondary),
     ));
     push_sbs_half(
         &mut spans,
@@ -581,6 +608,7 @@ fn render_sbs_row(row: &SbsRow, half_w: u16, right_w: u16) -> Row {
         right_fg,
         right_bg,
         right_w,
+        theme,
     );
     Row::new(spans)
 }
@@ -592,12 +620,13 @@ fn push_sbs_half(
     fg: Color,
     bg: Option<Color>,
     width: u16,
+    theme: &Theme,
 ) {
     let content_w = (width as usize).saturating_sub(SBS_GUTTER_WIDTH);
     let trimmed = truncate_to_display_width(text, content_w);
     let pad = content_w.saturating_sub(UnicodeWidthStr::width(trimmed));
 
-    let gutter_style = Style::default().fg(Color::DarkGray);
+    let gutter_style = Style::default().fg(theme.fg_secondary);
     let body_style = Style::default().fg(fg);
     let (g, b, p) = match bg {
         Some(bg) => (
@@ -612,11 +641,11 @@ fn push_sbs_half(
     spans.push(RowSpan::styled(" ".repeat(pad), p));
 }
 
-fn side_style(tag: LineTag, added_bg: Color, removed_bg: Color) -> (Color, Option<Color>) {
+fn side_style(tag: LineTag, theme: &Theme) -> (Color, Option<Color>) {
     match tag {
-        LineTag::Added => (Color::Green, Some(added_bg)),
-        LineTag::Removed => (Color::Red, Some(removed_bg)),
-        LineTag::Context => (Color::White, None),
+        LineTag::Added => (theme.added_accent, Some(theme.added_bg)),
+        LineTag::Removed => (theme.removed_accent, Some(theme.removed_bg)),
+        LineTag::Context => (theme.fg_primary, None),
     }
 }
 

--- a/src/ui/diff_panel.rs
+++ b/src/ui/diff_panel.rs
@@ -1,6 +1,7 @@
 use crate::app::{App, DiffLayout};
 use crate::git::{DiffContent, DiffHunk, LineTag};
 use crate::ui::text::{skip_n_columns, truncate_to_width};
+use crate::ui::theme::Theme;
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
@@ -15,7 +16,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
 
     match app.diff_content.take() {
         None => {
-            render_empty(f, inner);
+            render_empty(f, app, inner);
         }
         Some(diff) => {
             match app.diff_layout {
@@ -27,13 +28,13 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
     }
 }
 
-fn render_empty(f: &mut Frame, area: Rect) {
+fn render_empty(f: &mut Frame, app: &App, area: Rect) {
     if area.height < 1 {
         return;
     }
     let msg = Line::from(Span::styled(
         "选择一个文件查看 diff",
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(app.theme.fg_secondary),
     ));
     let y = area.y + area.height / 2;
     let x = area.x + area.width.saturating_sub(22) / 2;
@@ -45,6 +46,7 @@ fn render_empty(f: &mut Frame, area: Rect) {
 fn render_unified(f: &mut Frame, app: &mut App, area: Rect, diff: &DiffContent) {
     let mut y = area.y;
     let max_y = area.y + area.height;
+    let theme = app.theme;
 
     render_file_header(f, app, area, diff, &mut y, max_y);
 
@@ -89,24 +91,33 @@ fn render_unified(f: &mut Frame, app: &mut App, area: Rect, diff: &DiffContent) 
         if y >= max_y {
             break;
         }
-        render_unified_line(f, area, y, dl, h);
+        render_unified_line(f, area, y, dl, h, &theme);
         y += 1;
     }
 }
 
-fn render_unified_line(f: &mut Frame, area: Rect, y: u16, dl: &UnifiedLine, h_scroll: usize) {
+fn render_unified_line(
+    f: &mut Frame,
+    area: Rect,
+    y: u16,
+    dl: &UnifiedLine,
+    h_scroll: usize,
+    theme: &Theme,
+) {
     match dl {
         UnifiedLine::Separator => {
             let line = Line::from(Span::styled(
                 format!(" {:>5}  {:>5}  ⋯", "", ""),
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme.fg_secondary),
             ));
             f.render_widget(line, Rect::new(area.x, y, area.width, 1));
         }
         UnifiedLine::HunkHeader(header) => {
             let line = Line::from(Span::styled(
                 format!(" {}", header),
-                Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM),
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::DIM),
             ));
             f.render_widget(line, Rect::new(area.x, y, area.width, 1));
         }
@@ -116,7 +127,7 @@ fn render_unified_line(f: &mut Frame, area: Rect, y: u16, dl: &UnifiedLine, h_sc
             new_lineno,
             text,
         } => {
-            let (prefix, fg, bg) = line_style(*tag);
+            let (prefix, fg, bg) = line_style(*tag, theme);
             let old_num = fmt_lineno(*old_lineno);
             let new_num = fmt_lineno(*new_lineno);
 
@@ -129,7 +140,7 @@ fn render_unified_line(f: &mut Frame, area: Rect, y: u16, dl: &UnifiedLine, h_sc
             let line = Line::from(vec![
                 Span::styled(
                     format!(" {}  {} ", old_num, new_num),
-                    Style::default().fg(Color::DarkGray).bg(bg),
+                    Style::default().fg(theme.fg_secondary).bg(bg),
                 ),
                 Span::styled(format!("{} ", prefix), Style::default().fg(fg).bg(bg)),
                 Span::styled(display_text.to_string(), Style::default().fg(fg).bg(bg)),
@@ -248,6 +259,7 @@ fn build_sbs_lines(hunk: &DiffHunk) -> Vec<SbsDisplayLine> {
 fn render_side_by_side(f: &mut Frame, app: &mut App, area: Rect, diff: &DiffContent) {
     let mut y = area.y;
     let max_y = area.y + area.height;
+    let theme = app.theme;
 
     render_file_header(f, app, area, diff, &mut y, max_y);
 
@@ -302,25 +314,28 @@ fn render_side_by_side(f: &mut Frame, app: &mut App, area: Rect, diff: &DiffCont
                         "",
                         " ".repeat(area.width.saturating_sub(10) as usize)
                     ),
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(theme.fg_secondary),
                 ));
                 f.render_widget(line, Rect::new(area.x, y, area.width, 1));
             }
             SbsDisplayLine::HunkHeader(header) => {
                 let line = Line::from(Span::styled(
                     format!(" {}", header),
-                    Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM),
+                    Style::default()
+                        .fg(theme.accent)
+                        .add_modifier(Modifier::DIM),
                 ));
                 f.render_widget(line, Rect::new(area.x, y, area.width, 1));
             }
             SbsDisplayLine::Row(row) => {
-                render_sbs_row(f, area, y, row, half_w, right_w, h);
+                render_sbs_row(f, area, y, row, half_w, right_w, h, &theme);
             }
         }
         y += 1;
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_sbs_row(
     f: &mut Frame,
     area: Rect,
@@ -329,13 +344,14 @@ fn render_sbs_row(
     half_w: u16,
     right_w: u16,
     h_scroll: usize,
+    theme: &Theme,
 ) {
     // Gutter: " XXXXX " = 7 cols
     let gutter = 7usize;
 
     // ── Left half ──
     let left_content_w = (half_w as usize).saturating_sub(gutter);
-    let (_, left_fg, left_bg) = line_style(row.left_tag);
+    let (_, left_fg, left_bg) = line_style(row.left_tag, theme);
     let left_no = fmt_lineno(row.left_no);
     let left_shifted = skip_n_columns(&row.left_text, h_scroll);
     let left_text = truncate_to_width(left_shifted, left_content_w);
@@ -344,7 +360,7 @@ fn render_sbs_row(
     let left_line = Line::from(vec![
         Span::styled(
             format!(" {} ", left_no),
-            Style::default().fg(Color::DarkGray).bg(left_bg),
+            Style::default().fg(theme.fg_secondary).bg(left_bg),
         ),
         Span::styled(
             left_text.to_string(),
@@ -356,12 +372,12 @@ fn render_sbs_row(
 
     // ── Divider ──
     let div_x = area.x + half_w;
-    let div_line = Line::from(Span::styled("│", Style::default().fg(Color::DarkGray)));
+    let div_line = Line::from(Span::styled("│", Style::default().fg(theme.fg_secondary)));
     f.render_widget(div_line, Rect::new(div_x, y, 1, 1));
 
     // ── Right half ──
     let right_content_w = (right_w as usize).saturating_sub(gutter);
-    let (_, right_fg, right_bg) = line_style(row.right_tag);
+    let (_, right_fg, right_bg) = line_style(row.right_tag, theme);
     let right_no = fmt_lineno(row.right_no);
     let right_shifted = skip_n_columns(&row.right_text, h_scroll);
     let right_text = truncate_to_width(right_shifted, right_content_w);
@@ -370,7 +386,7 @@ fn render_sbs_row(
     let right_line = Line::from(vec![
         Span::styled(
             format!(" {} ", right_no),
-            Style::default().fg(Color::DarkGray).bg(right_bg),
+            Style::default().fg(theme.fg_secondary).bg(right_bg),
         ),
         Span::styled(
             right_text.to_string(),
@@ -395,6 +411,7 @@ fn render_file_header(
         return;
     }
 
+    let th = app.theme;
     let layout_label = match app.diff_layout {
         DiffLayout::Unified => "上下",
         DiffLayout::SideBySide => "左右",
@@ -413,10 +430,10 @@ fn render_file_header(
         Span::styled(
             path_display.to_string(),
             Style::default()
-                .fg(Color::White)
+                .fg(th.fg_primary)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(tag_str, Style::default().fg(Color::DarkGray)),
+        Span::styled(tag_str, Style::default().fg(th.fg_secondary)),
     ]);
     f.render_widget(header, Rect::new(area.x, *y, area.width, 1));
     *y += 1;
@@ -427,17 +444,17 @@ fn render_file_header(
     }
     let sep = Line::from(Span::styled(
         "─".repeat(area.width as usize),
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(th.fg_secondary),
     ));
     f.render_widget(sep, Rect::new(area.x, *y, area.width, 1));
     *y += 1;
 }
 
-fn line_style(tag: LineTag) -> (&'static str, Color, Color) {
+fn line_style(tag: LineTag, theme: &Theme) -> (&'static str, Color, Color) {
     match tag {
-        LineTag::Added => ("+", Color::Green, Color::Rgb(0, 40, 0)),
-        LineTag::Removed => ("-", Color::Red, Color::Rgb(60, 0, 0)),
-        LineTag::Context => (" ", Color::Gray, Color::Reset),
+        LineTag::Added => ("+", theme.added_accent, theme.added_bg),
+        LineTag::Removed => ("-", theme.removed_accent, theme.removed_bg),
+        LineTag::Context => (" ", theme.fg_primary, Color::Reset),
     }
 }
 
@@ -494,21 +511,24 @@ mod tests {
 
     #[test]
     fn line_style_added() {
-        let (prefix, fg, _bg) = line_style(LineTag::Added);
+        let theme = Theme::dark();
+        let (prefix, fg, _bg) = line_style(LineTag::Added, &theme);
         assert_eq!(prefix, "+");
         assert_eq!(fg, Color::Green);
     }
 
     #[test]
     fn line_style_removed() {
-        let (prefix, fg, _bg) = line_style(LineTag::Removed);
+        let theme = Theme::dark();
+        let (prefix, fg, _bg) = line_style(LineTag::Removed, &theme);
         assert_eq!(prefix, "-");
         assert_eq!(fg, Color::Red);
     }
 
     #[test]
     fn line_style_context() {
-        let (prefix, _fg, _bg) = line_style(LineTag::Context);
+        let theme = Theme::dark();
+        let (prefix, _fg, _bg) = line_style(LineTag::Context, &theme);
         assert_eq!(prefix, " ");
     }
 

--- a/src/ui/file_preview_panel.rs
+++ b/src/ui/file_preview_panel.rs
@@ -3,7 +3,7 @@ use crate::file_tree::PreviewContent;
 use crate::ui::text::{clip_spans, skip_n_columns, truncate_to_width};
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Padding};
 use unicode_width::UnicodeWidthStr;
@@ -15,14 +15,14 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
 
     let preview = match app.preview_content.take() {
         None => {
-            render_empty(f, inner);
+            render_empty(f, app, inner);
             return;
         }
         Some(preview) => preview,
     };
 
     if preview.is_binary {
-        render_binary(f, inner, &preview.file_path);
+        render_binary(f, app, inner, &preview.file_path);
     } else {
         render_content(f, app, inner, &preview);
     }
@@ -30,34 +30,35 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
     app.preview_content = Some(preview);
 }
 
-fn render_empty(f: &mut Frame, area: Rect) {
+fn render_empty(f: &mut Frame, app: &App, area: Rect) {
     if area.height < 1 {
         return;
     }
     let msg = Line::from(Span::styled(
         "选择一个文件预览内容",
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(app.theme.fg_secondary),
     ));
     let y = area.y + area.height / 2;
     let x = area.x + area.width.saturating_sub(20) / 2;
     f.render_widget(msg, Rect::new(x, y, area.width, 1));
 }
 
-fn render_binary(f: &mut Frame, area: Rect, path: &str) {
+fn render_binary(f: &mut Frame, app: &App, area: Rect, path: &str) {
     if area.height < 2 {
         return;
     }
+    let th = app.theme;
     let header = Line::from(Span::styled(
         path,
         Style::default()
-            .fg(Color::White)
+            .fg(th.fg_primary)
             .add_modifier(Modifier::BOLD),
     ));
     f.render_widget(header, Rect::new(area.x, area.y, area.width, 1));
 
     let msg = Line::from(Span::styled(
         "(binary file)",
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(th.fg_secondary),
     ));
     let y = area.y + area.height / 2;
     let x = area.x + area.width.saturating_sub(14) / 2;
@@ -65,6 +66,7 @@ fn render_binary(f: &mut Frame, area: Rect, path: &str) {
 }
 
 fn render_content(f: &mut Frame, app: &mut App, area: Rect, preview: &PreviewContent) {
+    let th = app.theme;
     let mut y = area.y;
     let max_y = area.y + area.height;
 
@@ -73,7 +75,7 @@ fn render_content(f: &mut Frame, app: &mut App, area: Rect, preview: &PreviewCon
         let header = Line::from(Span::styled(
             preview.file_path.as_str(),
             Style::default()
-                .fg(Color::White)
+                .fg(th.fg_primary)
                 .add_modifier(Modifier::BOLD),
         ));
         f.render_widget(header, Rect::new(area.x, y, area.width, 1));
@@ -84,7 +86,7 @@ fn render_content(f: &mut Frame, app: &mut App, area: Rect, preview: &PreviewCon
     if y < max_y {
         let sep = Line::from(Span::styled(
             "─".repeat(area.width as usize),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(th.fg_secondary),
         ));
         f.render_widget(sep, Rect::new(area.x, y, area.width, 1));
         y += 1;
@@ -120,7 +122,7 @@ fn render_content(f: &mut Frame, app: &mut App, area: Rect, preview: &PreviewCon
 
         let gutter = Span::styled(
             format!("{:>5} ", lineno),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(th.fg_secondary),
         );
 
         let mut spans = vec![gutter];
@@ -129,7 +131,7 @@ fn render_content(f: &mut Frame, app: &mut App, area: Rect, preview: &PreviewCon
             None => {
                 let shifted = skip_n_columns(line, h);
                 let display = truncate_to_width(shifted, content_w);
-                spans.push(Span::styled(display, Style::default().fg(Color::Gray)));
+                spans.push(Span::styled(display, Style::default().fg(th.fg_primary)));
             }
         }
 

--- a/src/ui/file_tree_panel.rs
+++ b/src/ui/file_tree_panel.rs
@@ -7,9 +7,10 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders};
 
 pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
+    let th = app.theme;
     let block = Block::default()
         .borders(Borders::RIGHT)
-        .border_style(Style::default().fg(Color::DarkGray));
+        .border_style(Style::default().fg(th.border));
     let inner = block.inner(area);
     f.render_widget(block, area);
 
@@ -24,7 +25,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
     if entries.is_empty() {
         let msg = Line::from(Span::styled(
             "(empty)",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(th.fg_secondary),
         ));
         f.render_widget(msg, Rect::new(padded.x, padded.y, padded.width, 1));
         return;
@@ -68,24 +69,22 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
         };
 
         let name_style = if entry.is_dir {
-            Style::default()
-                .fg(Color::Blue)
-                .add_modifier(Modifier::BOLD)
+            Style::default().fg(th.accent).add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(Color::White)
+            Style::default().fg(th.fg_primary)
         };
 
         let bg = if is_selected {
-            Color::Rgb(40, 60, 100)
+            th.selection_bg
         } else if is_hovered {
-            Color::Rgb(40, 40, 50)
+            th.hover_bg
         } else {
             Color::Reset
         };
 
         let mut spans = vec![
             Span::styled(&indent, Style::default().bg(bg)),
-            Span::styled(icon, Style::default().fg(Color::DarkGray).bg(bg)),
+            Span::styled(icon, Style::default().fg(th.fg_secondary).bg(bg)),
             Span::styled(&entry.name, name_style.bg(bg)),
         ];
 
@@ -96,7 +95,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
                 'A' => Color::Green,
                 'D' => Color::Red,
                 'U' | '?' => Color::Green,
-                _ => Color::DarkGray,
+                _ => th.fg_secondary,
             };
             spans.push(Span::styled(
                 format!(" {}", ch),

--- a/src/ui/git_graph_panel.rs
+++ b/src/ui/git_graph_panel.rs
@@ -21,7 +21,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
     if app.git_graph.rows.is_empty() {
         let line = Line::from(Span::styled(
             "  无 commit",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app.theme.fg_secondary),
         ));
         f.render_widget(line, area);
         return;
@@ -46,6 +46,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
     app.git_graph.scroll = scroll;
 
     let rows: Vec<&GraphRow> = app.git_graph.rows.iter().collect();
+    let theme = app.theme;
     for (i, row) in rows.iter().skip(scroll).take(height).enumerate() {
         let idx = scroll + i;
         let y = area.y + i as u16;
@@ -58,6 +59,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
             head_oid.as_deref(),
             &app.git_graph.ref_map,
             hover,
+            &theme,
         );
         f.render_widget(line, Rect::new(area.x, y, area.width, 1));
 
@@ -141,9 +143,10 @@ fn build_row_line(
     head_oid: Option<&str>,
     ref_map: &std::collections::HashMap<String, Vec<RefLabel>>,
     hover: bool,
+    theme: &crate::ui::theme::Theme,
 ) -> (Line<'static>, u16) {
     let oid = row.commit.oid.clone();
-    let sel_bg = Color::Rgb(40, 60, 100);
+    let sel_bg = theme.selection_bg;
     let is_head = head_oid == Some(oid.as_str());
 
     let mut spans: Vec<Span<'static>> = Vec::new();
@@ -174,13 +177,13 @@ fn build_row_line(
         truncate_in_place(&mut author, 12);
         spans.push(Span::styled(
             format!("{:<12}", author),
-            Style::default().fg(Color::Cyan),
+            Style::default().fg(theme.accent),
         ));
         spans.push(Span::raw(" "));
         let rel = relative_time(row.commit.time);
         spans.push(Span::styled(
             format!("{:>4}", rel),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.fg_secondary),
         ));
         spans.push(Span::raw(" "));
     }
@@ -194,7 +197,7 @@ fn build_row_line(
 
     let mut subject = row.commit.subject.clone();
     truncate_in_place(&mut subject, max_subject);
-    spans.push(Span::styled(subject, Style::default().fg(Color::White)));
+    spans.push(Span::styled(subject, Style::default().fg(theme.fg_primary)));
 
     if selected {
         spans = spans
@@ -207,7 +210,7 @@ fn build_row_line(
         spans = spans
             .into_iter()
             .map(|s| {
-                let style = crate::ui::hover::apply(s.style, true);
+                let style = crate::ui::hover::apply(s.style, true, theme.hover_bg);
                 Span::styled(s.content.into_owned(), style)
             })
             .collect();

--- a/src/ui/git_status_panel.rs
+++ b/src/ui/git_status_panel.rs
@@ -10,6 +10,7 @@ use crate::app::{App, Panel, SelectedFile};
 use crate::git::tree::{self as gtree, Node};
 use crate::git::{FileEntry, FileStatus};
 use crate::ui::mouse::ClickAction;
+use crate::ui::theme::Theme;
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
@@ -30,7 +31,8 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
     // do it while the Git tab is being drawn.
     app.refresh_status();
 
-    let rows = build_rows(app, area.width);
+    let theme = app.theme;
+    let rows = build_rows(app, area.width, &theme);
     let total = rows.len();
 
     // Clamp scroll to a valid range so content can't be scrolled past its end.
@@ -47,7 +49,12 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
         let spans: Vec<Span<'static>> = row
             .spans
             .iter()
-            .map(|s| Span::styled(s.text.clone(), crate::ui::hover::apply(s.style, hover)))
+            .map(|s| {
+                Span::styled(
+                    s.text.clone(),
+                    crate::ui::hover::apply(s.style, hover, app.theme.hover_bg),
+                )
+            })
             .collect();
         f.render_widget(Line::from(spans), Rect::new(area.x, y, area.width, 1));
 
@@ -407,7 +414,7 @@ impl Row {
 
 // ─── Row builders ─────────────────────────────────────────────────────────────
 
-fn build_rows(app: &App, width: u16) -> Vec<Row> {
+fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
     let mut rows: Vec<Row> = Vec::new();
     let status = &app.git_status;
     // Slightly narrower budget to accommodate the ↺ discard button on unstaged rows.
@@ -435,8 +442,8 @@ fn build_rows(app: &App, width: u16) -> Vec<Row> {
                     "  ✖ 推送失败: ",
                     Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
                 ),
-                RowSpan::styled(msg, Style::default().fg(Color::White)),
-                RowSpan::styled("  [关闭]", Style::default().fg(Color::DarkGray)),
+                RowSpan::styled(msg, Style::default().fg(theme.fg_primary)),
+                RowSpan::styled("  [关闭]", Style::default().fg(theme.fg_secondary)),
             ])
             .on_click("git.dismissPushError", Value::Null),
         );
@@ -475,7 +482,7 @@ fn build_rows(app: &App, width: u16) -> Vec<Row> {
             rows.push(Row::new(vec![RowSpan::styled(
                 msg,
                 Style::default()
-                    .fg(Color::White)
+                    .fg(theme.fg_primary)
                     .add_modifier(Modifier::BOLD),
             )]));
         }
@@ -503,11 +510,13 @@ fn build_rows(app: &App, width: u16) -> Vec<Row> {
             RowSpan::plain("  "),
             RowSpan::styled(
                 " 取消 ",
-                Style::default().fg(Color::White).bg(Color::DarkGray),
+                Style::default()
+                    .fg(theme.chrome_fg)
+                    .bg(theme.chrome_muted_fg),
             )
             .on_click(cancel_cmd, Value::Null),
             RowSpan::plain("  "),
-            RowSpan::styled("(y / Esc)", Style::default().fg(Color::DarkGray)),
+            RowSpan::styled("(y / Esc)", Style::default().fg(theme.fg_secondary)),
         ]));
         rows.push(Row::blank());
     }
@@ -578,7 +587,7 @@ fn build_rows(app: &App, width: u16) -> Vec<Row> {
     rows.push(
         Row::new(vec![RowSpan::styled(
             mode_label,
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.fg_secondary),
         )])
         .on_click("git.toggleTree", Value::Null),
     );
@@ -594,9 +603,10 @@ fn build_rows(app: &App, width: u16) -> Vec<Row> {
             "git.toggleStaged",
             Some(("取消全部", "git.unstageAll", Color::Red)),
             width,
+            theme,
         ));
         if !app.staged_collapsed {
-            render_files(&mut rows, app, &app.staged_files, true, max_path);
+            render_files(&mut rows, app, &app.staged_files, true, max_path, theme);
         }
         rows.push(Row::blank());
     }
@@ -615,13 +625,14 @@ fn build_rows(app: &App, width: u16) -> Vec<Row> {
         "git.toggleUnstaged",
         unstaged_button,
         width,
+        theme,
     ));
     if !app.unstaged_collapsed {
-        render_files(&mut rows, app, &app.unstaged_files, false, max_path);
+        render_files(&mut rows, app, &app.unstaged_files, false, max_path, theme);
         if app.unstaged_files.is_empty() {
             rows.push(Row::new(vec![RowSpan::styled(
                 "  无文件",
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme.fg_secondary),
             )]));
         }
     }
@@ -646,6 +657,7 @@ fn render_files(
     files: &[FileEntry],
     is_staged: bool,
     max_path: usize,
+    theme: &Theme,
 ) {
     let status = &app.git_status;
     let sel_path = selected_path_for(app, is_staged);
@@ -659,6 +671,7 @@ fn render_files(
             max_path,
             &status.collapsed_dirs,
             &sel_path,
+            theme,
         );
     } else {
         for file in files {
@@ -671,6 +684,7 @@ fn render_files(
                 max_path,
                 is_sel,
                 "  ",
+                theme,
             ));
         }
     }
@@ -685,6 +699,7 @@ fn walk_tree(
     max_path: usize,
     collapsed: &std::collections::HashSet<String>,
     selected_path: &Option<String>,
+    theme: &Theme,
 ) {
     let mut entries: Vec<(&String, &Node)> = tree.iter().collect();
     entries.sort_by(|a, b| {
@@ -702,7 +717,7 @@ fn walk_tree(
             Node::Dir { path, children } => {
                 let key = gtree::collapsed_key(is_staged, path);
                 let is_collapsed = collapsed.contains(&key);
-                rows.push(dir_row(name, path, is_staged, depth, is_collapsed));
+                rows.push(dir_row(name, path, is_staged, depth, is_collapsed, theme));
                 if !is_collapsed {
                     walk_tree(
                         rows,
@@ -712,6 +727,7 @@ fn walk_tree(
                         max_path,
                         collapsed,
                         selected_path,
+                        theme,
                     );
                 }
             }
@@ -727,21 +743,32 @@ fn walk_tree(
                     max_path,
                     is_sel,
                     &indent,
+                    theme,
                 ));
             }
         }
     }
 }
 
-fn dir_row(name: &str, path: &str, is_staged: bool, depth: usize, is_collapsed: bool) -> Row {
+fn dir_row(
+    name: &str,
+    path: &str,
+    is_staged: bool,
+    depth: usize,
+    is_collapsed: bool,
+    theme: &Theme,
+) -> Row {
     let arrow = if is_collapsed { "›" } else { "⌄" };
     Row::new(vec![
         RowSpan::plain("  ".repeat(depth)),
-        RowSpan::styled(format!("{} ", arrow), Style::default().fg(Color::DarkGray)),
+        RowSpan::styled(
+            format!("{} ", arrow),
+            Style::default().fg(theme.fg_secondary),
+        ),
         RowSpan::styled(
             format!("{}/", name),
             Style::default()
-                .fg(Color::Cyan)
+                .fg(theme.accent)
                 .add_modifier(Modifier::BOLD),
         ),
     ])
@@ -751,6 +778,7 @@ fn dir_row(name: &str, path: &str, is_staged: bool, depth: usize, is_collapsed: 
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn file_row(
     path: &str,
     display: &str,
@@ -759,6 +787,7 @@ fn file_row(
     max_path: usize,
     is_selected: bool,
     indent: &str,
+    theme: &Theme,
 ) -> Row {
     let status_color = match status {
         FileStatus::Modified => Color::Yellow,
@@ -785,14 +814,17 @@ fn file_row(
         display.to_string()
     };
 
-    let sel_bg = Color::Rgb(40, 60, 100);
-    let base_bg = if is_selected { Some(sel_bg) } else { None };
+    let base_bg = if is_selected {
+        Some(theme.selection_bg)
+    } else {
+        None
+    };
 
     let mut spans: Vec<RowSpan> = vec![
         RowSpan::styled(indent.to_string(), apply_bg(Style::default(), base_bg)),
         RowSpan::styled(
             display_path,
-            apply_bg(Style::default().fg(Color::White), base_bg),
+            apply_bg(Style::default().fg(theme.fg_primary), base_bg),
         ),
         RowSpan::styled(
             format!(" {} ", status_label),
@@ -843,6 +875,7 @@ fn apply_bg(style: Style, bg: Option<Color>) -> Style {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn section_header(
     collapsed: bool,
     label: &str,
@@ -851,6 +884,7 @@ fn section_header(
     toggle_cmd: &str,
     action: Option<(&str, &str, Color)>,
     width: u16,
+    theme: &Theme,
 ) -> Row {
     let arrow = if collapsed { "›" } else { "⌄" };
     let prefix = format!("{} ", arrow);
@@ -863,11 +897,11 @@ fn section_header(
     let padding = (width as usize).saturating_sub(used);
 
     let mut spans = vec![
-        RowSpan::styled(prefix, Style::default().fg(Color::White)),
+        RowSpan::styled(prefix, Style::default().fg(theme.fg_primary)),
         RowSpan::styled(
             label.to_string(),
             Style::default()
-                .fg(Color::White)
+                .fg(theme.fg_primary)
                 .add_modifier(Modifier::BOLD),
         ),
         RowSpan::styled(count_str, Style::default().fg(count_color)),

--- a/src/ui/highlight.rs
+++ b/src/ui/highlight.rs
@@ -10,9 +10,15 @@ pub type StyledToken = (Style, String);
 
 static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(two_face::syntax::extra_no_newlines);
 
-static THEME: LazyLock<Theme> = LazyLock::new(|| {
+static THEME_DARK: LazyLock<Theme> = LazyLock::new(|| {
     two_face::theme::extra()
         .get(EmbeddedThemeName::OneHalfDark)
+        .clone()
+});
+
+static THEME_LIGHT: LazyLock<Theme> = LazyLock::new(|| {
+    two_face::theme::extra()
+        .get(EmbeddedThemeName::OneHalfLight)
         .clone()
 });
 
@@ -54,9 +60,10 @@ fn resolve_syntax(path: &str, lines: &[String]) -> Option<&'static SyntaxReferen
     None
 }
 
-pub fn highlight_file(path: &str, lines: &[String]) -> Option<Vec<Vec<StyledToken>>> {
+pub fn highlight_file(path: &str, lines: &[String], dark: bool) -> Option<Vec<Vec<StyledToken>>> {
     let syntax = resolve_syntax(path, lines)?;
-    let mut h = HighlightLines::new(syntax, &THEME);
+    let theme: &Theme = if dark { &THEME_DARK } else { &THEME_LIGHT };
+    let mut h = HighlightLines::new(syntax, theme);
 
     let mut out = Vec::with_capacity(lines.len());
     for line in lines {
@@ -93,7 +100,7 @@ mod tests {
     #[test]
     fn highlight_rust_line() {
         let lines = vec!["fn main() { let x = \"hi\"; }".to_string()];
-        let out = highlight_file("foo.rs", &lines).expect("rust must highlight");
+        let out = highlight_file("foo.rs", &lines, true).expect("rust must highlight");
         println!("tokens: {:#?}", out);
         assert_eq!(out.len(), 1);
         assert!(
@@ -114,7 +121,7 @@ mod tests {
         let mut missing = vec![];
         for ext in exts {
             let path = format!("foo.{}", ext);
-            if highlight_file(&path, &["hello".to_string()]).is_none() {
+            if highlight_file(&path, &["hello".to_string()], true).is_none() {
                 missing.push(ext);
             }
         }
@@ -130,7 +137,7 @@ mod tests {
             "Rakefile",
             "CMakeLists.txt",
         ] {
-            let result = highlight_file(name, &["x = y".to_string()]);
+            let result = highlight_file(name, &["x = y".to_string()], true);
             assert!(result.is_some(), "{} should resolve a syntax", name);
         }
     }
@@ -140,13 +147,14 @@ mod tests {
         let result = highlight_file(
             "no_extension_file",
             &["#!/usr/bin/env python".to_string(), "print(1)".to_string()],
+            true,
         );
         assert!(result.is_some(), "shebang should resolve python");
     }
 
     #[test]
     fn highlight_empty_lines_returns_empty_vec() {
-        let result = highlight_file("foo.rs", &[]);
+        let result = highlight_file("foo.rs", &[], true);
         // A known syntax with zero lines should return Some([])
         assert!(
             matches!(result, Some(ref v) if v.is_empty()),
@@ -156,13 +164,13 @@ mod tests {
 
     #[test]
     fn highlight_unknown_extension_returns_none() {
-        assert!(highlight_file("foo.xyz", &["hello".to_string()]).is_none());
+        assert!(highlight_file("foo.xyz", &["hello".to_string()], true).is_none());
     }
 
     #[test]
     fn highlight_returns_same_line_count() {
         let lines: Vec<String> = (0..10).map(|i| format!("let x{} = {};", i, i)).collect();
-        let result = highlight_file("foo.rs", &lines).expect("rust must highlight");
+        let result = highlight_file("foo.rs", &lines, true).expect("rust must highlight");
         assert_eq!(result.len(), lines.len());
     }
 
@@ -170,7 +178,7 @@ mod tests {
     fn highlight_many_lines_all_returned() {
         // highlight_file has no line-count limit — all lines are processed
         let lines: Vec<String> = (0..100).map(|i| format!("let x{i} = {i};")).collect();
-        let result = highlight_file("foo.rs", &lines).expect("rust must highlight");
+        let result = highlight_file("foo.rs", &lines, true).expect("rust must highlight");
         assert_eq!(result.len(), 100);
     }
 
@@ -178,8 +186,19 @@ mod tests {
     fn highlight_toml_file_recognized() {
         let lines = vec!["[package]".to_string(), "name = \"reef\"".to_string()];
         assert!(
-            highlight_file("Cargo.toml", &lines).is_some(),
+            highlight_file("Cargo.toml", &lines, true).is_some(),
             "toml should be recognized"
         );
+    }
+
+    #[test]
+    fn highlight_light_theme_smoke() {
+        // Light theme uses OneHalfLight; token colors come from a different
+        // palette but structure must match (same line count, multiple tokens
+        // for a non-trivial rust line).
+        let lines = vec!["fn main() { let x = \"hi\"; }".to_string()];
+        let out = highlight_file("foo.rs", &lines, false).expect("light theme must highlight");
+        assert_eq!(out.len(), 1);
+        assert!(out[0].len() > 1);
     }
 }

--- a/src/ui/hover.rs
+++ b/src/ui/hover.rs
@@ -1,14 +1,13 @@
 //! Shared mouse-hover row tinting for the three inline git panels.
 //!
-//! The subtle `Rgb(40, 40, 50)` wash is applied only to spans that don't
-//! already carry a background — so selection highlights (`Rgb(40, 60, 100)`)
-//! and banner buttons keep their identity under the cursor.
+//! The subtle hover wash is applied only to spans that don't already carry a
+//! background — so selection highlights and banner buttons keep their identity
+//! under the cursor. Callers pass the theme's `hover_bg` explicitly so this
+//! module stays free of a back-dependency on `ui::theme`.
 
 use crate::app::App;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
-
-const HOVER_BG: Color = Color::Rgb(40, 40, 50);
 
 /// True when the mouse is over row `y` within `area`.
 pub fn is_hover(app: &App, area: Rect, y: u16) -> bool {
@@ -22,9 +21,9 @@ pub fn is_hover(app: &App, area: Rect, y: u16) -> bool {
 /// Return `style` with the hover bg applied, but only when the span doesn't
 /// already have its own bg — that way selection / button chrome keeps its
 /// specific color.
-pub fn apply(style: Style, hover: bool) -> Style {
+pub fn apply(style: Style, hover: bool, hover_bg: Color) -> Style {
     if hover && style.bg.is_none() {
-        style.bg(HOVER_BG)
+        style.bg(hover_bg)
     } else {
         style
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -8,6 +8,7 @@ pub mod highlight;
 pub mod hover;
 pub mod mouse;
 pub mod text;
+pub mod theme;
 pub mod toast;
 
 use crate::app::{App, Tab};
@@ -59,7 +60,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
     match app.active_tab {
         Tab::Git => {
             if app.repo.is_none() {
-                render_no_repo(f, body_layout[0]);
+                render_no_repo(f, app, body_layout[0]);
             } else {
                 render_git_sidebar(f, app, body_layout[0]);
                 render_git_editor(f, app, body_layout[1]);
@@ -78,15 +79,16 @@ pub fn render(f: &mut Frame, app: &mut App) {
     render_status_bar(f, app, main_layout[3]);
 
     if app.show_help {
-        render_help(f, size);
+        render_help(f, app, size);
     }
 }
 
 /// Full-width message shown in the Git tab when not inside a git repository.
-fn render_no_repo(f: &mut Frame, area: Rect) {
+fn render_no_repo(f: &mut Frame, app: &App, area: Rect) {
+    let th = app.theme;
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::DarkGray));
+        .border_style(Style::default().fg(th.border));
     let msg = Paragraph::new(Text::from(vec![
         Line::from(""),
         Line::from(Span::styled(
@@ -98,7 +100,7 @@ fn render_no_repo(f: &mut Frame, area: Rect) {
         Line::from(""),
         Line::from(Span::styled(
             "Run `git init` to initialise one, or open reef inside a git repo.",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(th.fg_secondary),
         )),
     ]))
     .alignment(ratatui::layout::Alignment::Center)
@@ -110,7 +112,7 @@ fn render_no_repo(f: &mut Frame, area: Rect) {
 fn render_git_sidebar(f: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .borders(Borders::RIGHT)
-        .border_style(Style::default().fg(Color::DarkGray));
+        .border_style(Style::default().fg(app.theme.border));
     let inner = block.inner(area);
     f.render_widget(block, area);
 
@@ -133,7 +135,7 @@ fn render_git_editor(f: &mut Frame, app: &mut App, area: Rect) {
 fn render_graph_sidebar(f: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .borders(Borders::RIGHT)
-        .border_style(Style::default().fg(Color::DarkGray));
+        .border_style(Style::default().fg(app.theme.border));
     let inner = block.inner(area);
     f.render_widget(block, area);
 
@@ -160,7 +162,8 @@ fn render_graph_editor(f: &mut Frame, app: &mut App, area: Rect) {
 }
 
 fn render_tab_bar(f: &mut Frame, app: &mut App, area: Rect) {
-    let bg = Color::Rgb(30, 30, 40);
+    let th = app.theme;
+    let bg = th.chrome_bg;
     let tabs = Tab::ALL;
 
     let mut spans: Vec<Span> = Vec::new();
@@ -171,11 +174,11 @@ fn render_tab_bar(f: &mut Frame, app: &mut App, area: Rect) {
         let is_active = app.active_tab == *tab;
         let style = if is_active {
             Style::default()
-                .fg(Color::White)
-                .bg(Color::Rgb(60, 60, 80))
+                .fg(th.chrome_active_fg)
+                .bg(th.chrome_active_bg)
                 .add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(Color::DarkGray).bg(bg)
+            Style::default().fg(th.chrome_muted_fg).bg(bg)
         };
         let span = Span::styled(label, style);
         // Hit-registry uses terminal columns (display width), not bytes — tab
@@ -192,7 +195,7 @@ fn render_tab_bar(f: &mut Frame, app: &mut App, area: Rect) {
         if i < tabs.len() - 1 {
             spans.push(Span::styled(
                 "│",
-                Style::default().fg(Color::DarkGray).bg(bg),
+                Style::default().fg(th.chrome_muted_fg).bg(bg),
             ));
             x += 1;
         }
@@ -205,13 +208,14 @@ fn render_tab_bar(f: &mut Frame, app: &mut App, area: Rect) {
     spans.push(Span::styled(" ".repeat(pad), Style::default().bg(bg)));
     spans.push(Span::styled(
         keys_hint,
-        Style::default().fg(Color::DarkGray).bg(bg),
+        Style::default().fg(th.chrome_muted_fg).bg(bg),
     ));
 
     f.render_widget(Line::from(spans), area);
 }
 
 fn render_title_bar(f: &mut Frame, app: &App, area: Rect) {
+    let th = app.theme;
     let repo_name = app
         .repo
         .as_ref()
@@ -227,16 +231,16 @@ fn render_title_bar(f: &mut Frame, app: &App, area: Rect) {
         Span::styled(
             " reef ",
             Style::default()
-                .fg(Color::Black)
-                .bg(Color::Blue)
+                .fg(th.badge_fg)
+                .bg(th.badge_bg)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(" ", Style::default().bg(Color::Rgb(30, 30, 40))),
+        Span::styled(" ", Style::default().bg(th.chrome_bg)),
         Span::styled(
             &repo_name,
             Style::default()
-                .fg(Color::White)
-                .bg(Color::Rgb(30, 30, 40))
+                .fg(th.chrome_fg)
+                .bg(th.chrome_bg)
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
@@ -245,7 +249,7 @@ fn render_title_bar(f: &mut Frame, app: &App, area: Rect) {
             } else {
                 format!("  ⎇ {}", branch)
             },
-            Style::default().fg(Color::Cyan).bg(Color::Rgb(30, 30, 40)),
+            Style::default().fg(th.accent).bg(th.chrome_bg),
         ),
         Span::styled(
             " ".repeat(
@@ -253,13 +257,14 @@ fn render_title_bar(f: &mut Frame, app: &App, area: Rect) {
                     .saturating_sub(repo_name.len() as u16 + branch.len() as u16 + 10)
                     as usize,
             ),
-            Style::default().bg(Color::Rgb(30, 30, 40)),
+            Style::default().bg(th.chrome_bg),
         ),
     ]);
     f.render_widget(title, area);
 }
 
 fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
+    let th = app.theme;
     if app.select_mode {
         let hint = Line::from(vec![
             Span::styled(
@@ -271,9 +276,7 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
             ),
             Span::styled(
                 "  拖拽鼠标选择文字，按 v 退出选择模式",
-                Style::default()
-                    .fg(Color::Yellow)
-                    .bg(Color::Rgb(30, 30, 40)),
+                Style::default().fg(Color::Yellow).bg(th.chrome_bg),
             ),
         ]);
         f.render_widget(hint, area);
@@ -294,25 +297,21 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
     };
 
     let status = Line::from(vec![
-        Span::styled(
-            notif,
-            Style::default().fg(notif_color).bg(Color::Rgb(30, 30, 40)),
-        ),
+        Span::styled(notif, Style::default().fg(notif_color).bg(th.chrome_bg)),
         Span::styled(
             " ".repeat(area.width.saturating_sub(60) as usize),
-            Style::default().bg(Color::Rgb(30, 30, 40)),
+            Style::default().bg(th.chrome_bg),
         ),
         Span::styled(
             " q:退出 Tab:切换 s:暂存 u:取消 r:刷新 h:帮助 ",
-            Style::default()
-                .fg(Color::DarkGray)
-                .bg(Color::Rgb(30, 30, 40)),
+            Style::default().fg(th.chrome_muted_fg).bg(th.chrome_bg),
         ),
     ]);
     f.render_widget(status, area);
 }
 
-fn render_help(f: &mut Frame, screen: Rect) {
+fn render_help(f: &mut Frame, app: &App, screen: Rect) {
+    let th = app.theme;
     let core_entries: &[(&str, &str)] = &[
         ("q / Ctrl+C", "退出"),
         ("Tab", "切换顶部标签页（Files ↔ Git ↔ Graph）"),
@@ -347,11 +346,11 @@ fn render_help(f: &mut Frame, screen: Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Blue))
+        .border_style(Style::default().fg(th.accent))
         .title(Span::styled(
             " 快捷键帮助 ",
             Style::default()
-                .fg(Color::White)
+                .fg(th.fg_primary)
                 .add_modifier(Modifier::BOLD),
         ))
         .padding(Padding::new(1, 1, 0, 0));
@@ -373,7 +372,7 @@ fn render_help(f: &mut Frame, screen: Rect) {
                     .fg(Color::Yellow)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(*desc, Style::default().fg(Color::White)),
+            Span::styled(*desc, Style::default().fg(th.fg_primary)),
         ]);
         f.render_widget(line, Rect::new(inner.x, row_y, inner.width, 1));
         row_y += 1;

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,0 +1,170 @@
+//! Color theme for reef's UI chrome and diff surfaces.
+//!
+//! `Theme` is a flat struct of `ratatui::Color` fields addressed by role
+//! (`chrome_bg`, `selection_bg`, `added_bg`, …), not by UI component. Every
+//! panel grabs `let th = app.theme;` once at the top of its render fn and
+//! looks up colors by role. Two presets (`dark`, `light`) match our hardcoded
+//! dark values byte-for-byte and a GitHub-Light-derived light palette.
+//!
+//! `resolve()` decides which preset to use on startup:
+//!   1. `prefs.ui.theme` — `"dark" | "light" | "auto"` (default `"auto"`).
+//!   2. Under `"auto"`, if stdin or stdout isn't a TTY (CI, piped, snapshot
+//!      tests), fall back to `dark()` so builds stay deterministic.
+//!   3. Otherwise probe the terminal via `terminal-colorsaurus` (OSC 11).
+//!      Must run BEFORE `enable_raw_mode()` in `main.rs` — otherwise the
+//!      terminal's reply fragments leak onto the TUI.
+
+use ratatui::style::Color;
+use std::io::IsTerminal;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy)]
+pub struct Theme {
+    pub is_dark: bool,
+
+    // Chrome — title bar, tab bar, status bar, help popup.
+    pub chrome_bg: Color,
+    pub chrome_fg: Color,
+    pub chrome_muted_fg: Color,
+    pub chrome_active_bg: Color,
+    pub chrome_active_fg: Color,
+
+    // Panel borders and separators.
+    pub border: Color,
+
+    // Selection / hover row backgrounds.
+    pub selection_bg: Color,
+    pub hover_bg: Color,
+
+    // Diff line highlights.
+    pub added_bg: Color,
+    pub removed_bg: Color,
+    pub added_accent: Color,
+    pub removed_accent: Color,
+
+    // Conflict / error banner background (distinct from `removed_bg` so a
+    // banner stays visible when stacked over a diff).
+    pub error_bg: Color,
+
+    // Generic text.
+    pub fg_primary: Color,
+    pub fg_secondary: Color,
+
+    // Blue/cyan highlights (branch name, hunk headers, accent links).
+    pub accent: Color,
+
+    // "reef" title badge.
+    pub badge_fg: Color,
+    pub badge_bg: Color,
+}
+
+impl Theme {
+    /// Dark preset — byte-identical to reef's pre-theme hardcoded colors so
+    /// existing users see zero visual change.
+    pub const fn dark() -> Self {
+        Self {
+            is_dark: true,
+            chrome_bg: Color::Rgb(30, 30, 40),
+            chrome_fg: Color::White,
+            chrome_muted_fg: Color::DarkGray,
+            chrome_active_bg: Color::Rgb(60, 60, 80),
+            chrome_active_fg: Color::White,
+            border: Color::DarkGray,
+            selection_bg: Color::Rgb(40, 60, 100),
+            hover_bg: Color::Rgb(40, 40, 50),
+            added_bg: Color::Rgb(0, 40, 0),
+            removed_bg: Color::Rgb(60, 0, 0),
+            added_accent: Color::Green,
+            removed_accent: Color::Red,
+            error_bg: Color::Rgb(60, 0, 0),
+            fg_primary: Color::White,
+            fg_secondary: Color::DarkGray,
+            accent: Color::Cyan,
+            badge_fg: Color::Black,
+            badge_bg: Color::Blue,
+        }
+    }
+
+    /// Light preset — grounded in GitHub Light so diff reds/greens preserve
+    /// syntect OneHalfLight legibility.
+    pub const fn light() -> Self {
+        Self {
+            is_dark: false,
+            chrome_bg: Color::Rgb(246, 248, 250),
+            chrome_fg: Color::Rgb(36, 41, 47),
+            chrome_muted_fg: Color::Rgb(101, 109, 118),
+            chrome_active_bg: Color::Rgb(221, 244, 255),
+            chrome_active_fg: Color::Rgb(9, 105, 218),
+            border: Color::Rgb(208, 215, 222),
+            selection_bg: Color::Rgb(221, 244, 255),
+            hover_bg: Color::Rgb(234, 238, 242),
+            added_bg: Color::Rgb(230, 255, 237),
+            removed_bg: Color::Rgb(255, 235, 233),
+            added_accent: Color::Rgb(26, 127, 55),
+            removed_accent: Color::Rgb(207, 34, 46),
+            error_bg: Color::Rgb(255, 235, 233),
+            fg_primary: Color::Rgb(36, 41, 47),
+            fg_secondary: Color::Rgb(101, 109, 118),
+            accent: Color::Rgb(9, 105, 218),
+            badge_fg: Color::Rgb(255, 255, 255),
+            badge_bg: Color::Rgb(9, 105, 218),
+        }
+    }
+
+    /// Pref override + terminal-background detection. Runs once in `main.rs`
+    /// before raw mode is enabled.
+    pub fn resolve() -> Self {
+        match crate::prefs::get("ui.theme").as_deref() {
+            Some("dark") => return Self::dark(),
+            Some("light") => return Self::light(),
+            _ => {}
+        }
+
+        if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+            return Self::dark();
+        }
+
+        // `QueryOptions` is marked `#[non_exhaustive]` so we can't struct-init
+        // it directly — start from `default()` and override only what we need.
+        let mut opts = terminal_colorsaurus::QueryOptions::default();
+        opts.timeout = Duration::from_millis(100);
+        match terminal_colorsaurus::theme_mode(opts) {
+            Ok(terminal_colorsaurus::ThemeMode::Light) => Self::light(),
+            _ => Self::dark(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dark_is_dark_light_is_not() {
+        assert!(Theme::dark().is_dark);
+        assert!(!Theme::light().is_dark);
+    }
+
+    #[test]
+    fn dark_and_light_differ_on_chrome() {
+        let d = Theme::dark();
+        let l = Theme::light();
+        assert_ne!(d.chrome_bg, l.chrome_bg);
+        assert_ne!(d.chrome_fg, l.chrome_fg);
+        assert_ne!(d.added_bg, l.added_bg);
+        assert_ne!(d.removed_bg, l.removed_bg);
+        assert_ne!(d.selection_bg, l.selection_bg);
+        assert_ne!(d.hover_bg, l.hover_bg);
+    }
+
+    #[test]
+    fn dark_preserves_legacy_hardcodes() {
+        // Guard against accidental drift from the pre-theme dark look.
+        let d = Theme::dark();
+        assert_eq!(d.chrome_bg, Color::Rgb(30, 30, 40));
+        assert_eq!(d.selection_bg, Color::Rgb(40, 60, 100));
+        assert_eq!(d.hover_bg, Color::Rgb(40, 40, 50));
+        assert_eq!(d.added_bg, Color::Rgb(0, 40, 0));
+        assert_eq!(d.removed_bg, Color::Rgb(60, 0, 0));
+    }
+}

--- a/tests/app_error_paths.rs
+++ b/tests/app_error_paths.rs
@@ -1,8 +1,9 @@
-//! `App::new()` error-path tests: verify graceful degradation when the
+//! `App::new(Theme::dark())` error-path tests: verify graceful degradation when the
 //! environment is missing pieces — most importantly when the cwd is not
 //! inside a git repo, so `GitRepo::open()` returns `None`.
 
 use reef::app::App;
+use reef::ui::theme::Theme;
 use std::sync::Mutex;
 use tempfile::TempDir;
 
@@ -33,7 +34,7 @@ fn app_new_outside_git_repo_does_not_panic() {
     // Deliberately NOT initialized as a git repo
     let _g = CwdGuard::enter(tmp.path());
 
-    let app = App::new();
+    let app = App::new(Theme::dark());
     assert!(app.repo.is_none(), "no repo outside a git dir");
     assert!(app.staged_files.is_empty());
     assert!(app.unstaged_files.is_empty());
@@ -45,21 +46,21 @@ fn app_new_refresh_status_is_noop_without_repo() {
     let tmp = TempDir::new().unwrap();
     let _g = CwdGuard::enter(tmp.path());
 
-    let mut app = App::new();
+    let mut app = App::new(Theme::dark());
     app.refresh_status(); // must not panic when repo is None
     assert!(app.staged_files.is_empty());
 }
 
 #[test]
 fn app_tick_without_fs_watcher_is_safe() {
-    // `App::new()` starts an fs_watcher thread per workdir; tick() drains
+    // `App::new(Theme::dark())` starts an fs_watcher thread per workdir; tick() drains
     // its channel and refreshes caches. Outside a git repo the watcher may
     // still spin up for the tempdir — tick must stay a no-op regardless.
     let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let tmp = TempDir::new().unwrap();
     let _g = CwdGuard::enter(tmp.path());
 
-    let mut app = App::new();
+    let mut app = App::new(Theme::dark());
     app.tick();
     app.tick();
 }

--- a/tests/snapshots/ui_snapshots__with_staged_and_unstaged_light.snap
+++ b/tests/snapshots/ui_snapshots__with_staged_and_unstaged_light.snap
@@ -1,0 +1,25 @@
+---
+source: tests/ui_snapshots.rs
+assertion_line: 124
+expression: output
+---
+ reef  [TMPDIR]  ⎇ master
+ 📁  Files │ ⎇ Git │ ⑂ Graph                                1:Files 2:Git 3:Graph
+ 视 图 : 列 表             │
+                       │
+ ⌄ 更 改   2    暂 存 全 部  │
+   new.txt U + ↺       │
+   tracked.txt M + ↺   │
+                       │
+                       │
+                       │
+                       │                 选 择 一 个 文 件 查 看  diff
+                       │
+                       │
+                       │
+                       │
+                       │
+                       │
+                       │
+                       │
+                     q:退 出  Tab:切 换  s:暂 存  u:取 消  r:刷 新  h:帮 助

--- a/tests/ui_snapshots.rs
+++ b/tests/ui_snapshots.rs
@@ -11,6 +11,7 @@ use ratatui::backend::TestBackend;
 use ratatui::buffer::Buffer;
 use reef::app::App;
 use reef::ui;
+use reef::ui::theme::Theme;
 use std::sync::Mutex;
 use test_support::{HomeGuard, commit_file, tempdir_repo, write_file};
 
@@ -77,7 +78,7 @@ fn snapshot_empty_repo() {
     let _h = HomeGuard::enter(tmp.path());
     let _g = CwdGuard::enter(tmp.path());
 
-    let mut app = App::new();
+    let mut app = App::new(Theme::dark());
     let output = render_app(&mut app, 80, 20);
     with_filters(|| insta::assert_snapshot!("empty_repo", output));
 }
@@ -92,10 +93,33 @@ fn snapshot_with_staged_and_unstaged() {
     let _h = HomeGuard::enter(tmp.path());
     let _g = CwdGuard::enter(tmp.path());
 
-    let mut app = App::new();
+    let mut app = App::new(Theme::dark());
     // Switch to Git tab to show staged/unstaged sections
     app.active_tab = reef::app::Tab::Git;
     app.refresh_status();
     let output = render_app(&mut app, 80, 20);
     with_filters(|| insta::assert_snapshot!("with_staged_and_unstaged", output));
+}
+
+#[test]
+fn snapshot_with_staged_and_unstaged_light_theme() {
+    // Locks in the light-theme wiring: a dark-vs-light snapshot diff must exist
+    // somewhere, otherwise the Theme plumbing could silently regress to dark.
+    // Text content should match the dark snapshot; only style bytes differ, but
+    // TestBackend's `Cell::symbol()` drops styles, so the plain-text dump here
+    // intentionally asserts "same content, same layout" — not color fidelity.
+    // Color fidelity is verified by the unit tests in `src/ui/theme.rs`.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, raw) = tempdir_repo();
+    commit_file(&raw, "tracked.txt", "v1\n", "init");
+    write_file(&raw, "tracked.txt", "v2\n");
+    write_file(&raw, "new.txt", "new\n");
+    let _h = HomeGuard::enter(tmp.path());
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::light());
+    app.active_tab = reef::app::Tab::Git;
+    app.refresh_status();
+    let output = render_app(&mut app, 80, 20);
+    with_filters(|| insta::assert_snapshot!("with_staged_and_unstaged_light", output));
 }


### PR DESCRIPTION
## Summary

- Adds a `Theme` struct (`dark()` / `light()` presets) threaded through every UI surface. Dark preset is byte-identical to the pre-theme hardcoded colors, so existing users see zero visual change.
- Auto-detects the terminal background via OSC 11 (`terminal-colorsaurus`) on startup, probed **before** `enable_raw_mode` in `main.rs` so the terminal's reply doesn't fragment onto the TUI.
- New `ui.theme = dark | light | auto` pref (default `auto`) overrides the probe; non-TTY (CI, piped, snapshot tests) fall back to `dark`.
- Syntect now carries dual `OneHalfDark` / `OneHalfLight` `LazyLock`s; `highlight_file` picks one via `app.theme.is_dark`.
- Light palette grounded in GitHub Light (pale green / red diff backgrounds, `Rgb(9, 105, 218)` accent) so syntect's `OneHalfLight` tokens stay legible against the diff chrome.
- No runtime toggle in the TUI — theme is fixed per session. Swap at startup via pref if auto-detect guesses wrong.

Fixes #4.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 128 / 128 pass (added a light-theme snapshot test + Theme unit tests + a light-theme `highlight_file` smoke test)
- [ ] Manual dark terminal: visually confirm tab bar, title bar, status bar, diff panel look byte-identical to before
- [ ] Manual light terminal (Terminal.app / iTerm2 light profile): confirm chrome/diff bgs readable, no invisible text
- [ ] Pref override: `echo 'ui.theme=light' >> ~/.config/reef/prefs` on a dark terminal renders light
- [ ] Non-TTY fallback: `echo q | reef` doesn't hang on OSC probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)