### PR TITLE
fix(ui): stop snapping tree scroll back to the opened file (#10)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -132,6 +132,11 @@ pub struct App {
     pub file_tree: FileTree,
     pub preview_content: Option<PreviewContent>,
     pub tree_scroll: usize,
+    /// The `file_tree.selected` value we observed on the previous render.
+    /// Used by the Files-tab tree panel to distinguish "selection just changed
+    /// (scroll the viewport to keep it visible)" from "user scrolled the
+    /// viewport themselves (leave it alone)".
+    pub last_rendered_tree_selected: Option<usize>,
     pub preview_scroll: usize,
     pub preview_h_scroll: usize,
 
@@ -228,6 +233,7 @@ impl App {
             file_tree,
             preview_content: None,
             tree_scroll: 0,
+            last_rendered_tree_selected: None,
             preview_scroll: 0,
             preview_h_scroll: 0,
             split_percent: 30,

--- a/src/ui/file_tree_panel.rs
+++ b/src/ui/file_tree_panel.rs
@@ -33,18 +33,25 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
         return;
     }
 
-    // Clamp scroll
+    // Clamp scroll to valid range
     let max_scroll = entries.len().saturating_sub(padded.height as usize);
     app.tree_scroll = app.tree_scroll.min(max_scroll);
 
-    // Ensure selected is visible
-    if app.file_tree.selected < app.tree_scroll {
-        app.tree_scroll = app.file_tree.selected;
-    } else if app.file_tree.selected >= app.tree_scroll + padded.height as usize {
-        app.tree_scroll = app
-            .file_tree
-            .selected
-            .saturating_sub(padded.height as usize - 1);
+    // Keep the selection visible, but only when the selection actually moved
+    // since the last render. Running this every frame meant mouse-wheel scroll
+    // (which only changes tree_scroll, not selected) got snapped back to the
+    // opened file on the next tick — so the scroll appeared locked. See #10.
+    let selection_changed = app.last_rendered_tree_selected != Some(app.file_tree.selected);
+    if selection_changed {
+        if app.file_tree.selected < app.tree_scroll {
+            app.tree_scroll = app.file_tree.selected;
+        } else if app.file_tree.selected >= app.tree_scroll + padded.height as usize {
+            app.tree_scroll = app
+                .file_tree
+                .selected
+                .saturating_sub(padded.height as usize - 1);
+        }
+        app.last_rendered_tree_selected = Some(app.file_tree.selected);
     }
 
     let scroll = app.tree_scroll;


### PR DESCRIPTION
Closes #10.

## Summary
Opening a file in the Files tab was locking the tree-panel scroll to that file: the mouse wheel appeared to have no effect, you couldn't browse up or down the file list after opening something.

The root cause is `src/ui/file_tree_panel.rs:render` — it re-runs the "keep the selection visible" block every single frame. Mouse-wheel scroll only changes `app.tree_scroll` (not `file_tree.selected`), so the next render saw the selection below/above the viewport and yanked `tree_scroll` back to the selected row. Net effect: the viewport snaps back each tick.

## Change
Track the selection index from the previous render (`last_rendered_tree_selected: Option<usize>`). Only run the "follow selected into view" block when the selection actually moved. The unconditional `tree_scroll.min(max_scroll)` clamp is kept, so mouse scroll still can't overrun the list.

- Keyboard `j`/`k`/`PageUp`/`PageDown` → `file_tree.selected` changes → selection-changed branch runs → viewport follows (unchanged behavior).
- Mouse wheel on the tree → only `tree_scroll` changes → selection-changed branch is skipped → viewport scrolls freely (fixes #10).

## Files
- `src/app.rs`: one new field `last_rendered_tree_selected: Option<usize>`, initialized to `None`.
- `src/ui/file_tree_panel.rs`: wrap the keep-selected-visible block in `if selection_changed { ... }` and update `last_rendered_tree_selected` inside it.

+22 / −9.

## Test plan
- [x] Builds (CI will confirm; no new deps).
- [ ] Manual: open Files tab, click a deep-in-the-list file, then scroll up with the mouse wheel on the tree panel — the list should actually scroll now and stay scrolled until you use `j`/`k` again.
- [ ] Regression: `j`/`k` navigation should still keep the cursor on-screen. Selection jumps (e.g. navigating into a previously-scrolled-out-of-view entry) should still scroll the viewport to bring it back.

Rebased onto the latest `main` (post-#11 vim-search merge); no conflicts — my diff sits cleanly alongside the new `overlay_match_highlight` block.