### PR TITLE
fix(ui): stop snapping graph scroll back to the selected commit

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -75,6 +75,12 @@ pub struct GitGraphState {
     pub selected_idx: usize,
     pub selected_commit: Option<String>,
     pub scroll: usize,
+    /// `selected_idx` observed on the previous render. Used to distinguish
+    /// selection-change follow (bring the selected commit into view) from
+    /// user-initiated scroll (leave the viewport alone). Mirrors #13's fix
+    /// for the Files tab — without this, mouse-wheel scroll snapped back to
+    /// the selected commit on the next tick.
+    pub last_rendered_selected: Option<usize>,
 }
 
 /// State for the inline commit-detail editor panel (Tab::Graph right side).

--- a/src/ui/git_graph_panel.rs
+++ b/src/ui/git_graph_panel.rs
@@ -34,18 +34,26 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
     let max_subject = (area.width as usize).saturating_sub(if show_meta { 40 } else { 14 });
     let head_oid = app.repo.as_ref().and_then(|r| r.head_oid());
 
-    // Clamp scroll and auto-scroll to keep the selected row in view.
+    // Clamp scroll to a valid range. Auto-scroll into view only when the
+    // selection actually moved since the last render — running this every
+    // frame meant mouse-wheel scroll (which only changes `scroll`, not
+    // `selected_idx`) got snapped back to the selected commit on the next
+    // tick. Graph-tab equivalent of #10 / follow-up to #13.
     let total = app.git_graph.rows.len();
     let height = area.height as usize;
-    let sel = app.git_graph.selected_idx;
-    let mut scroll = app.git_graph.scroll;
-    if sel < scroll {
-        scroll = sel;
-    } else if sel >= scroll + height && height > 0 {
-        scroll = sel + 1 - height;
-    }
     let max_scroll = total.saturating_sub(height);
-    scroll = scroll.min(max_scroll);
+    let mut scroll = app.git_graph.scroll.min(max_scroll);
+
+    let sel = app.git_graph.selected_idx;
+    if app.git_graph.last_rendered_selected != Some(sel) {
+        if sel < scroll {
+            scroll = sel;
+        } else if sel >= scroll + height && height > 0 {
+            scroll = sel + 1 - height;
+        }
+        scroll = scroll.min(max_scroll);
+        app.git_graph.last_rendered_selected = Some(sel);
+    }
     app.git_graph.scroll = scroll;
 
     let rows: Vec<&GraphRow> = app.git_graph.rows.iter().collect();


### PR DESCRIPTION
Follow-up to #13 for the Graph tab.

## Summary
- The commit-list panel (`src/ui/git_graph_panel.rs:render`) had the same every-frame "keep the selection visible" block that #13 just removed from the file tree. Mouse-wheel scroll only moves `git_graph.scroll`, not `selected_idx`, so the next render snapped the viewport back to the selected commit — same symptom as #10, different panel.
- Mirror #13: record the previously-rendered `selected_idx` on `GitGraphState.last_rendered_selected`, and only re-enter the follow branch when it actually changed. `max_scroll` clamp stays unconditional so the list still can't be scrolled past its end.

## Files
- `src/app.rs` — new `last_rendered_selected: Option<usize>` on `GitGraphState` (defaults to `None` via the existing `#[derive(Default)]`, so the first render still follows — matches #13's initial-frame behavior).
- `src/ui/git_graph_panel.rs` — wrap the auto-follow in `if last_rendered_selected != Some(sel)` and update the snapshot inside.

+22 / −8.

## Test plan
- [x] `cargo build` green.
- [x] `cargo test` — unrelated `workdir_write_triggers_event` fs-watcher timing failure only; graph/scroll tests pass.
- [ ] Manual: Graph tab → select a commit mid-list → mouse-wheel up and down → viewport scrolls freely and stays where you put it.
- [ ] Regression: `j`/`k` still drags the viewport along when the selected commit would fall off-screen.
- [ ] Regression: Files tab behavior unchanged (that's #13's field, not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)