### PR TITLE
feat(i18n): auto-detect system locale, add English translations

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -22,10 +22,11 @@ impl Tab {
     pub const ALL: &'static [Tab] = &[Tab::Files, Tab::Git, Tab::Graph];
 
     pub fn label(self) -> &'static str {
+        use crate::i18n::{Msg, t};
         match self {
-            Tab::Files => " 📁 Files ",
-            Tab::Git => " ⎇ Git ",
-            Tab::Graph => " ⑂ Graph ",
+            Tab::Files => t(Msg::TabFiles),
+            Tab::Git => t(Msg::TabGit),
+            Tab::Graph => t(Msg::TabGraph),
         }
     }
 }
@@ -614,16 +615,18 @@ impl App {
                 self.push_rx = None;
                 match result {
                     Ok(()) => {
+                        use crate::i18n::{Msg, t};
                         self.git_status.push_error = None;
                         self.toasts.push(Toast::info(if force {
-                            "强制推送成功"
+                            t(Msg::ForcePushSuccess)
                         } else {
-                            "推送成功"
+                            t(Msg::PushSuccess)
                         }));
                     }
                     Err(e) => {
                         self.git_status.push_error = Some(e.clone());
-                        self.toasts.push(Toast::error(format!("推送失败: {e}")));
+                        self.toasts
+                            .push(Toast::error(crate::i18n::push_failed_toast(&e)));
                     }
                 }
                 // Push advances remote-tracking refs — invalidate the graph
@@ -640,7 +643,8 @@ impl App {
                 // itself always sends). Recover so the user can retry.
                 self.push_in_flight = false;
                 self.push_rx = None;
-                self.toasts.push(Toast::error("推送线程异常退出，请重试"));
+                self.toasts
+                    .push(Toast::error(crate::i18n::t(crate::i18n::Msg::PushThreadCrashed)));
             }
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -643,8 +643,9 @@ impl App {
                 // itself always sends). Recover so the user can retry.
                 self.push_in_flight = false;
                 self.push_rx = None;
-                self.toasts
-                    .push(Toast::error(crate::i18n::t(crate::i18n::Msg::PushThreadCrashed)));
+                self.toasts.push(Toast::error(crate::i18n::t(
+                    crate::i18n::Msg::PushThreadCrashed,
+                )));
             }
         }
     }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -1,0 +1,409 @@
+//! Minimal two-language (en / zh) i18n for the TUI.
+//!
+//! Detection order: `ui.lang` pref → `REEF_LANG` env → `LC_ALL` →
+//! `LC_MESSAGES` → `LANG`. A locale starting with `zh` selects Chinese;
+//! anything else (empty, POSIX, en_*, fr_*, …) falls back to English.
+
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Lang {
+    En,
+    Zh,
+}
+
+static LANG: OnceLock<Lang> = OnceLock::new();
+
+pub fn lang() -> Lang {
+    *LANG.get_or_init(detect)
+}
+
+fn detect() -> Lang {
+    if let Some(v) = crate::prefs::get("ui.lang") {
+        match v.trim().to_ascii_lowercase().as_str() {
+            "zh" | "zh-cn" | "zh_cn" | "zh-hans" => return Lang::Zh,
+            "en" | "en-us" | "en_us" => return Lang::En,
+            _ => {}
+        }
+    }
+    for var in ["REEF_LANG", "LC_ALL", "LC_MESSAGES", "LANG"] {
+        let Ok(raw) = std::env::var(var) else {
+            continue;
+        };
+        let s = raw.trim();
+        if s.is_empty() {
+            continue;
+        }
+        if s.to_ascii_lowercase().starts_with("zh") {
+            return Lang::Zh;
+        }
+        return Lang::En;
+    }
+    Lang::En
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Msg {
+    // Tab labels + tab bar hint
+    TabFiles,
+    TabGit,
+    TabGraph,
+    TabBarHint,
+
+    // Chrome
+    StatusBarHint,
+    SelectModeHint,
+    HelpTitle,
+
+    // No-repo panel
+    NoRepoTitle,
+    NoRepoHint,
+
+    // Search
+    SearchNoMatch,
+
+    // Toasts
+    PushSuccess,
+    ForcePushSuccess,
+    PushThreadCrashed,
+
+    // Git status panel
+    PushingHint,
+    PushFailedPrefix,
+    DismissClose,
+    ForcePushPrompt,
+    ForcePushWarning,
+    PushToRemote,
+    ConfirmForcePush,
+    ConfirmPush,
+    Cancel,
+    YEscHint,
+    DiscardPromptPrefix,
+    DiscardPromptSuffix,
+    ConfirmDiscard,
+    ViewModeTree,
+    ViewModeList,
+    StagedChanges,
+    Changes,
+    StageAll,
+    UnstageAll,
+    NoFiles,
+
+    // Diff panel
+    DiffEmpty,
+    PreviewEmpty,
+    LayoutUnified,
+    LayoutSideBySide,
+    ModeCompact,
+    ModeFullFile,
+
+    // Commit detail panel
+    CommitDetailEmpty,
+    AuthorLabel,
+    DateLabel,
+    RefsLabel,
+    CommitLabel,
+    ChangedFiles,
+    ViewTree,
+    ViewList,
+
+    // Graph panel
+    NoCommits,
+
+    // File tree
+    EmptyDir,
+
+    // Help popup — key column
+    HelpKeyAnyKey,
+    HelpKeyMouseHScroll,
+    // Help popup — descriptions
+    HelpQuit,
+    HelpSwitchTab,
+    HelpSwitchPanel,
+    HelpJumpTab,
+    HelpNavUp,
+    HelpNavDown,
+    HelpPageUp,
+    HelpPageDown,
+    HelpHScroll,
+    HelpHScrollFast,
+    HelpHomeEnd,
+    HelpMouseHScroll,
+    HelpStageUnstage,
+    HelpDiscard,
+    HelpDiffLayout,
+    HelpDiffMode,
+    HelpToggleView,
+    HelpRefresh,
+    HelpSelectMode,
+    HelpShowHelp,
+    HelpAnyKey,
+}
+
+pub fn t(m: Msg) -> &'static str {
+    match lang() {
+        Lang::Zh => t_zh(m),
+        Lang::En => t_en(m),
+    }
+}
+
+fn t_zh(m: Msg) -> &'static str {
+    use Msg::*;
+    match m {
+        TabFiles => " 📁 文件 ",
+        TabGit => " ⎇ Git ",
+        TabGraph => " ⑂ 图表 ",
+        TabBarHint => " 1:文件 2:Git 3:图表",
+        StatusBarHint => " q:退出 Tab:切换 s:暂存 u:取消 r:刷新 h:帮助 ",
+        SelectModeHint => "  拖拽鼠标选择文字，按 v 退出选择模式",
+        HelpTitle => " 快捷键帮助 ",
+        NoRepoTitle => "不在 git 仓库中",
+        NoRepoHint => "运行 `git init` 初始化，或在 git 仓库里打开 reef。",
+        SearchNoMatch => "无匹配 ",
+        PushSuccess => "推送成功",
+        ForcePushSuccess => "强制推送成功",
+        PushThreadCrashed => "推送线程异常退出，请重试",
+        PushingHint => "  ⋯ 推送中…",
+        PushFailedPrefix => "  ✖ 推送失败: ",
+        DismissClose => "  [关闭]",
+        ForcePushPrompt => "  ⚠ 强制推送？",
+        ForcePushWarning => "（会覆盖远端，使用 --force-with-lease）",
+        PushToRemote => "  推送到远端？",
+        ConfirmForcePush => " 确认强制推送 ",
+        ConfirmPush => " 确认推送 ",
+        Cancel => " 取消 ",
+        YEscHint => "(y / Esc)",
+        DiscardPromptPrefix => "  ⚠ 还原 ",
+        DiscardPromptSuffix => "？（不可撤销）",
+        ConfirmDiscard => " 确认还原 ",
+        ViewModeTree => "视图: 树形",
+        ViewModeList => "视图: 列表",
+        StagedChanges => "暂存的更改",
+        Changes => "更改",
+        StageAll => "暂存全部",
+        UnstageAll => "取消全部",
+        NoFiles => "  无文件",
+        DiffEmpty => "选择一个文件查看 diff",
+        PreviewEmpty => "选择一个文件预览内容",
+        LayoutUnified => "上下",
+        LayoutSideBySide => "左右",
+        ModeCompact => "局部",
+        ModeFullFile => "全量",
+        CommitDetailEmpty => "  选择一个 commit 查看详情",
+        AuthorLabel => "作者: ",
+        DateLabel => "日期: ",
+        RefsLabel => "引用: ",
+        CommitLabel => "commit ",
+        ChangedFiles => "变更文件",
+        ViewTree => "树形",
+        ViewList => "列表",
+        NoCommits => "  无 commit",
+        EmptyDir => "(空)",
+        HelpKeyAnyKey => "任意键",
+        HelpKeyMouseHScroll => "Shift+滚轮 / 触控板横划",
+        HelpQuit => "退出",
+        HelpSwitchTab => "切换顶部标签页（文件 ↔ Git ↔ 图表）",
+        HelpSwitchPanel => "切换焦点面板（侧边栏 ↔ 编辑区）",
+        HelpJumpTab => "跳转到第 N 个标签页",
+        HelpNavUp => "向上导航 / 向上滚动",
+        HelpNavDown => "向下导航 / 向下滚动",
+        HelpPageUp => "快速向上翻页",
+        HelpPageDown => "快速向下翻页",
+        HelpHScroll => "横向滚动（Diff/预览 面板聚焦时）",
+        HelpHScrollFast => "横向快速滚动（10 列）",
+        HelpHomeEnd => "回到行首 / 跳到行尾",
+        HelpMouseHScroll => "鼠标横向滚动",
+        HelpStageUnstage => "暂存 / 取消暂存（Git tab）",
+        HelpDiscard => "还原工作树文件（Git tab）",
+        HelpDiffLayout => "切换 Diff 布局（上下 ↔ 左右）",
+        HelpDiffMode => "切换 Diff 模式（局部 ↔ 全量）",
+        HelpToggleView => "切换列表 / 树形视图",
+        HelpRefresh => "刷新",
+        HelpSelectMode => "文字选择模式",
+        HelpShowHelp => "显示 / 关闭此帮助",
+        HelpAnyKey => "关闭帮助",
+    }
+}
+
+fn t_en(m: Msg) -> &'static str {
+    use Msg::*;
+    match m {
+        TabFiles => " 📁 Files ",
+        TabGit => " ⎇ Git ",
+        TabGraph => " ⑂ Graph ",
+        TabBarHint => " 1:Files 2:Git 3:Graph",
+        StatusBarHint => " q:quit Tab:switch s:stage u:unstage r:refresh h:help ",
+        SelectModeHint => "  Drag to select text, press v to exit select mode",
+        HelpTitle => " Keybindings ",
+        NoRepoTitle => "Not a git repository",
+        NoRepoHint => "Run `git init` to initialise one, or open reef inside a git repo.",
+        SearchNoMatch => "no match ",
+        PushSuccess => "Push succeeded",
+        ForcePushSuccess => "Force push succeeded",
+        PushThreadCrashed => "Push worker crashed, please retry",
+        PushingHint => "  ⋯ Pushing…",
+        PushFailedPrefix => "  ✖ Push failed: ",
+        DismissClose => "  [dismiss]",
+        ForcePushPrompt => "  ⚠ Force push?",
+        ForcePushWarning => "(overwrites remote, uses --force-with-lease)",
+        PushToRemote => "  Push to remote?",
+        ConfirmForcePush => " Confirm force push ",
+        ConfirmPush => " Confirm push ",
+        Cancel => " Cancel ",
+        YEscHint => "(y / Esc)",
+        DiscardPromptPrefix => "  ⚠ Discard ",
+        DiscardPromptSuffix => "? (irreversible)",
+        ConfirmDiscard => " Confirm discard ",
+        ViewModeTree => "View: tree",
+        ViewModeList => "View: list",
+        StagedChanges => "Staged changes",
+        Changes => "Changes",
+        StageAll => "Stage all",
+        UnstageAll => "Unstage all",
+        NoFiles => "  (no files)",
+        DiffEmpty => "Select a file to view diff",
+        PreviewEmpty => "Select a file to preview",
+        LayoutUnified => "unified",
+        LayoutSideBySide => "split",
+        ModeCompact => "compact",
+        ModeFullFile => "full",
+        CommitDetailEmpty => "  Select a commit to view details",
+        AuthorLabel => "Author: ",
+        DateLabel => "Date:   ",
+        RefsLabel => "Refs:   ",
+        CommitLabel => "commit ",
+        ChangedFiles => "Changed files",
+        ViewTree => "tree",
+        ViewList => "list",
+        NoCommits => "  (no commits)",
+        EmptyDir => "(empty)",
+        HelpKeyAnyKey => "any key",
+        HelpKeyMouseHScroll => "Shift+Wheel / trackpad",
+        HelpQuit => "Quit",
+        HelpSwitchTab => "Cycle top tabs (Files ↔ Git ↔ Graph)",
+        HelpSwitchPanel => "Switch focused panel (sidebar ↔ editor)",
+        HelpJumpTab => "Jump to the Nth tab",
+        HelpNavUp => "Navigate up / scroll up",
+        HelpNavDown => "Navigate down / scroll down",
+        HelpPageUp => "Page up",
+        HelpPageDown => "Page down",
+        HelpHScroll => "Horizontal scroll (when Diff/Preview focused)",
+        HelpHScrollFast => "Horizontal fast scroll (10 cols)",
+        HelpHomeEnd => "Jump to line start / end",
+        HelpMouseHScroll => "Mouse horizontal scroll",
+        HelpStageUnstage => "Stage / unstage (Git tab)",
+        HelpDiscard => "Discard workdir file (Git tab)",
+        HelpDiffLayout => "Toggle diff layout (unified ↔ split)",
+        HelpDiffMode => "Toggle diff mode (compact ↔ full)",
+        HelpToggleView => "Toggle list / tree view",
+        HelpRefresh => "Refresh",
+        HelpSelectMode => "Text selection mode",
+        HelpShowHelp => "Show / close this help",
+        HelpAnyKey => "Close help",
+    }
+}
+
+// ─── Parameterised strings ────────────────────────────────────────────────────
+
+pub fn edit_open_failed(e: &str) -> String {
+    match lang() {
+        Lang::Zh => format!("打开编辑器失败: {e}"),
+        Lang::En => format!("Failed to open editor: {e}"),
+    }
+}
+
+pub fn push_failed_toast(e: &str) -> String {
+    match lang() {
+        Lang::Zh => format!("推送失败: {e}"),
+        Lang::En => format!("Push failed: {e}"),
+    }
+}
+
+pub fn push_n_commits_prompt(ahead: usize) -> String {
+    match lang() {
+        Lang::Zh => format!("  推送 {ahead} 个提交到远端？"),
+        Lang::En => format!("  Push {ahead} commits to remote?"),
+    }
+}
+
+pub fn push_button(ahead: usize) -> String {
+    match lang() {
+        Lang::Zh => format!(" ↑ 推送 ({ahead}) "),
+        Lang::En => format!(" ↑ Push ({ahead}) "),
+    }
+}
+
+pub fn behind_remote(behind: usize) -> String {
+    match lang() {
+        Lang::Zh => format!("  ↓ 落后远端 {behind} 次提交 — 请先 fetch/pull"),
+        Lang::En => format!("  ↓ Behind remote by {behind} — fetch/pull first"),
+    }
+}
+
+pub fn diverged_force_push(ahead: usize, behind: usize) -> String {
+    match lang() {
+        Lang::Zh => format!(" ⚠ 已分叉 ↑{ahead} ↓{behind} — 强制推送 "),
+        Lang::En => format!(" ⚠ Diverged ↑{ahead} ↓{behind} — force push "),
+    }
+}
+
+pub fn changed_files_header(n: usize) -> String {
+    format!("{} ({})", t(Msg::ChangedFiles), n)
+}
+
+/// Trailing "  [label]  t 切换" / "  [label]  t toggle" hint on the commit
+/// files header.
+pub fn view_toggle_hint(view_label: &str) -> String {
+    match lang() {
+        Lang::Zh => format!("  [{view_label}]  t 切换"),
+        Lang::En => format!("  [{view_label}]  t toggle"),
+    }
+}
+
+/// Trailing "  [layout][mode]  m/f 切换" / "  [layout][mode]  m/f toggle" hint.
+pub fn diff_mode_hint(layout_label: &str, mode_label: &str) -> String {
+    match lang() {
+        Lang::Zh => format!("  [{layout_label}][{mode_label}]  m/f 切换"),
+        Lang::En => format!("  [{layout_label}][{mode_label}]  m/f toggle"),
+    }
+}
+
+/// Counter + wrap message for active search. `wrap` is `Some(WrapMsg::Top)` /
+/// `Some(WrapMsg::Bottom)` / `None`. Caller passes the raw state.
+pub fn search_counter(i: usize, n: usize, wrap: Option<crate::search::WrapMsg>) -> String {
+    use crate::search::WrapMsg;
+    match (wrap, lang()) {
+        (Some(WrapMsg::Bottom), Lang::Zh) => format!("{}/{}  ↻ 回到顶部 ", i + 1, n),
+        (Some(WrapMsg::Bottom), Lang::En) => format!("{}/{}  ↻ top ", i + 1, n),
+        (Some(WrapMsg::Top), Lang::Zh) => format!("{}/{}  ↻ 回到底部 ", i + 1, n),
+        (Some(WrapMsg::Top), Lang::En) => format!("{}/{}  ↻ bottom ", i + 1, n),
+        _ => format!("{}/{} ", i + 1, n),
+    }
+}
+
+pub fn search_dormant_with_counter(prefix: char, query: &str, i: usize, n: usize) -> String {
+    match lang() {
+        Lang::Zh => format!(" {prefix}{query}  {}/{}  n/N 切换 ", i + 1, n),
+        Lang::En => format!(" {prefix}{query}  {}/{}  n/N ", i + 1, n),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn t_returns_translation_for_both_langs() {
+        // Smoke test: every Msg variant should return non-empty for both
+        // languages (catches accidentally-dropped match arms).
+        for m in [
+            Msg::TabFiles,
+            Msg::PushSuccess,
+            Msg::HelpQuit,
+            Msg::DiffEmpty,
+        ] {
+            assert!(!t_zh(m).is_empty());
+            assert!(!t_en(m).is_empty());
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod editor;
 pub mod file_tree;
 pub mod fs_watcher;
 pub mod git;
+pub mod i18n;
 pub mod input;
 pub mod prefs;
 pub mod search;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use crossterm::{
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use reef::app::App;
+use reef::i18n;
 use reef::ui::theme::Theme;
 use reef::ui::toast::Toast;
 use reef::{editor, input, ui};
@@ -114,7 +115,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mouse_was_on = !app.select_mode;
             if let Err(e) = editor::launch(&mut terminal, &path, mouse_was_on) {
                 app.toasts
-                    .push(Toast::error(format!("打开编辑器失败: {e}")));
+                    .push(Toast::error(i18n::edit_open_failed(&e.to_string())));
             }
             // Pick up on-disk changes immediately rather than waiting for
             // the fs-watcher debounce.

--- a/src/ui/commit_detail_panel.rs
+++ b/src/ui/commit_detail_panel.rs
@@ -4,6 +4,7 @@
 use crate::app::{App, DiffLayout, DiffMode};
 use crate::git::tree::{self as gtree, Node};
 use crate::git::{DiffContent, FileEntry, FileStatus, LineTag};
+use crate::i18n::{Msg, t};
 use crate::search::SearchTarget;
 use crate::ui::git_graph_panel;
 use crate::ui::mouse::ClickAction;
@@ -269,7 +270,7 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
 
     let Some(detail) = &cd.detail else {
         rows.push(Row::new(vec![RowSpan::styled(
-            "  选择一个 commit 查看详情",
+            t(Msg::CommitDetailEmpty),
             Style::default().fg(theme.fg_secondary),
         )]));
         return rows;
@@ -280,7 +281,7 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
     let max_path = (width as usize).saturating_sub(6);
 
     rows.push(Row::new(vec![
-        RowSpan::styled("commit ", Style::default().fg(theme.fg_secondary)),
+        RowSpan::styled(t(Msg::CommitLabel), Style::default().fg(theme.fg_secondary)),
         RowSpan::styled(
             info.oid.clone(),
             Style::default()
@@ -289,14 +290,14 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
         ),
     ]));
     rows.push(Row::new(vec![
-        RowSpan::styled("Author: ", Style::default().fg(theme.fg_secondary)),
+        RowSpan::styled(t(Msg::AuthorLabel), Style::default().fg(theme.fg_secondary)),
         RowSpan::styled(
             format!("{} <{}>", info.author_name, info.author_email),
             Style::default().fg(theme.fg_primary),
         ),
     ]));
     rows.push(Row::new(vec![
-        RowSpan::styled("Date:   ", Style::default().fg(theme.fg_secondary)),
+        RowSpan::styled(t(Msg::DateLabel), Style::default().fg(theme.fg_secondary)),
         RowSpan::styled(
             format_timestamp(info.time),
             Style::default().fg(theme.fg_primary),
@@ -305,7 +306,7 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
 
     if let Some(labels) = app.git_graph.ref_map.get(&info.oid) {
         let mut spans: Vec<RowSpan> = vec![RowSpan::styled(
-            "Refs:   ",
+            t(Msg::RefsLabel),
             Style::default().fg(theme.fg_secondary),
         )];
         for label in labels {
@@ -329,19 +330,19 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
     rows.push(Row::blank());
 
     let view_label = if cd.files_tree_mode {
-        "树形"
+        t(Msg::ViewTree)
     } else {
-        "列表"
+        t(Msg::ViewList)
     };
     rows.push(Row::new(vec![
         RowSpan::styled(
-            format!("Changed files ({})", detail.files.len()),
+            crate::i18n::changed_files_header(detail.files.len()),
             Style::default()
                 .fg(Color::Green)
                 .add_modifier(Modifier::BOLD),
         ),
         RowSpan::styled(
-            format!("  [{}]  t 切换", view_label),
+            crate::i18n::view_toggle_hint(view_label),
             Style::default().fg(theme.fg_secondary),
         )
         .on_click("git.toggleCommitFilesView", Value::Null),
@@ -487,14 +488,14 @@ fn diff_header_row(
     theme: &Theme,
 ) -> Row {
     let layout_label = match layout {
-        DiffLayout::Unified => "上下",
-        DiffLayout::SideBySide => "左右",
+        DiffLayout::Unified => t(Msg::LayoutUnified),
+        DiffLayout::SideBySide => t(Msg::LayoutSideBySide),
     };
     let mode_label = match mode {
-        DiffMode::Compact => "局部",
-        DiffMode::FullFile => "全量",
+        DiffMode::Compact => t(Msg::ModeCompact),
+        DiffMode::FullFile => t(Msg::ModeFullFile),
     };
-    let tag_str = format!("  [{}][{}]  m/f 切换", layout_label, mode_label);
+    let tag_str = crate::i18n::diff_mode_hint(layout_label, mode_label);
     let tag_w = UnicodeWidthStr::width(tag_str.as_str());
     let path_max = (width as usize).saturating_sub(tag_w);
     let path_display = truncate_to_display_width(path, path_max).to_string();

--- a/src/ui/diff_panel.rs
+++ b/src/ui/diff_panel.rs
@@ -1,5 +1,6 @@
 use crate::app::{App, DiffLayout};
 use crate::git::{DiffContent, DiffHunk, LineTag};
+use crate::i18n::{Msg, t};
 use crate::search::SearchTarget;
 use crate::ui::text::{clip_spans, overlay_match_highlight, skip_n_columns, truncate_to_width};
 use crate::ui::theme::Theme;
@@ -35,7 +36,7 @@ fn render_empty(f: &mut Frame, app: &App, area: Rect) {
         return;
     }
     let msg = Line::from(Span::styled(
-        "选择一个文件查看 diff",
+        t(Msg::DiffEmpty),
         Style::default().fg(app.theme.fg_secondary),
     ));
     let y = area.y + area.height / 2;
@@ -464,15 +465,15 @@ fn render_file_header(
 
     let th = app.theme;
     let layout_label = match app.diff_layout {
-        DiffLayout::Unified => "上下",
-        DiffLayout::SideBySide => "左右",
+        DiffLayout::Unified => t(Msg::LayoutUnified),
+        DiffLayout::SideBySide => t(Msg::LayoutSideBySide),
     };
     let mode_label = match app.diff_mode {
-        crate::app::DiffMode::Compact => "局部",
-        crate::app::DiffMode::FullFile => "全量",
+        crate::app::DiffMode::Compact => t(Msg::ModeCompact),
+        crate::app::DiffMode::FullFile => t(Msg::ModeFullFile),
     };
 
-    let tag_str = format!("  [{}][{}]  m/f 切换", layout_label, mode_label);
+    let tag_str = crate::i18n::diff_mode_hint(layout_label, mode_label);
     let tag_len = UnicodeWidthStr::width(tag_str.as_str()) as u16;
     let path_max = area.width.saturating_sub(tag_len) as usize;
     let path_display = truncate_to_width(&diff.file_path, path_max);

--- a/src/ui/file_preview_panel.rs
+++ b/src/ui/file_preview_panel.rs
@@ -1,5 +1,6 @@
 use crate::app::App;
 use crate::file_tree::PreviewContent;
+use crate::i18n::{Msg, t};
 use crate::search::SearchTarget;
 use crate::ui::text::{clip_spans, overlay_match_highlight};
 use ratatui::Frame;
@@ -36,7 +37,7 @@ fn render_empty(f: &mut Frame, app: &App, area: Rect) {
         return;
     }
     let msg = Line::from(Span::styled(
-        "选择一个文件预览内容",
+        t(Msg::PreviewEmpty),
         Style::default().fg(app.theme.fg_secondary),
     ));
     let y = area.y + area.height / 2;

--- a/src/ui/file_tree_panel.rs
+++ b/src/ui/file_tree_panel.rs
@@ -1,4 +1,5 @@
 use crate::app::App;
+use crate::i18n::{Msg, t};
 use crate::search::SearchTarget;
 use crate::ui::mouse::ClickAction;
 use crate::ui::text::overlay_match_highlight;
@@ -26,7 +27,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
     let entries = &app.file_tree.entries;
     if entries.is_empty() {
         let msg = Line::from(Span::styled(
-            "(empty)",
+            t(Msg::EmptyDir),
             Style::default().fg(th.fg_secondary),
         ));
         f.render_widget(msg, Rect::new(padded.x, padded.y, padded.width, 1));

--- a/src/ui/git_graph_panel.rs
+++ b/src/ui/git_graph_panel.rs
@@ -4,6 +4,7 @@
 use crate::app::App;
 use crate::git::RefLabel;
 use crate::git::graph::{GraphRow, LaneCell};
+use crate::i18n::{Msg, t};
 use crate::search::SearchTarget;
 use crate::ui::mouse::ClickAction;
 use crate::ui::text::overlay_match_highlight;
@@ -23,7 +24,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
 
     if app.git_graph.rows.is_empty() {
         let line = Line::from(Span::styled(
-            "  无 commit",
+            t(Msg::NoCommits),
             Style::default().fg(app.theme.fg_secondary),
         ));
         f.render_widget(line, area);

--- a/src/ui/git_status_panel.rs
+++ b/src/ui/git_status_panel.rs
@@ -480,7 +480,10 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
                     Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
                 ),
                 RowSpan::styled(msg, Style::default().fg(theme.fg_primary)),
-                RowSpan::styled(t(Msg::DismissClose), Style::default().fg(theme.fg_secondary)),
+                RowSpan::styled(
+                    t(Msg::DismissClose),
+                    Style::default().fg(theme.fg_secondary),
+                ),
             ])
             .on_click("git.dismissPushError", Value::Null),
         );
@@ -505,10 +508,7 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
                         .fg(Color::Yellow)
                         .add_modifier(Modifier::BOLD),
                 ),
-                RowSpan::styled(
-                    t(Msg::ForcePushWarning),
-                    Style::default().fg(Color::Yellow),
-                ),
+                RowSpan::styled(t(Msg::ForcePushWarning), Style::default().fg(Color::Yellow)),
             ]));
         } else {
             let msg = if ahead > 0 {
@@ -591,7 +591,10 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
                     .fg(Color::White)
                     .add_modifier(Modifier::BOLD),
             ),
-            RowSpan::styled(t(Msg::DiscardPromptSuffix), Style::default().fg(Color::Yellow)),
+            RowSpan::styled(
+                t(Msg::DiscardPromptSuffix),
+                Style::default().fg(Color::Yellow),
+            ),
         ]));
         rows.push(Row::new(vec![
             RowSpan::plain("  "),

--- a/src/ui/git_status_panel.rs
+++ b/src/ui/git_status_panel.rs
@@ -9,6 +9,7 @@
 use crate::app::{App, Panel, SelectedFile};
 use crate::git::tree::{self as gtree, Node};
 use crate::git::{FileEntry, FileStatus};
+use crate::i18n::{Msg, t};
 use crate::search::SearchTarget;
 use crate::ui::mouse::ClickAction;
 use crate::ui::text::overlay_match_highlight;
@@ -460,7 +461,7 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
     // Non-interactive: user just waits for tick() to drain the result.
     if app.push_in_flight {
         rows.push(Row::new(vec![RowSpan::styled(
-            "  ⋯ 推送中…",
+            t(Msg::PushingHint),
             Style::default()
                 .fg(Color::Yellow)
                 .add_modifier(Modifier::BOLD),
@@ -475,11 +476,11 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
         rows.push(
             Row::new(vec![
                 RowSpan::styled(
-                    "  ✖ 推送失败: ",
+                    t(Msg::PushFailedPrefix),
                     Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
                 ),
                 RowSpan::styled(msg, Style::default().fg(theme.fg_primary)),
-                RowSpan::styled("  [关闭]", Style::default().fg(theme.fg_secondary)),
+                RowSpan::styled(t(Msg::DismissClose), Style::default().fg(theme.fg_secondary)),
             ])
             .on_click("git.dismissPushError", Value::Null),
         );
@@ -499,21 +500,21 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
         if force {
             rows.push(Row::new(vec![
                 RowSpan::styled(
-                    "  ⚠ 强制推送？",
+                    t(Msg::ForcePushPrompt),
                     Style::default()
                         .fg(Color::Yellow)
                         .add_modifier(Modifier::BOLD),
                 ),
                 RowSpan::styled(
-                    "（会覆盖远端，使用 --force-with-lease）",
+                    t(Msg::ForcePushWarning),
                     Style::default().fg(Color::Yellow),
                 ),
             ]));
         } else {
             let msg = if ahead > 0 {
-                format!("  推送 {ahead} 个提交到远端？")
+                crate::i18n::push_n_commits_prompt(ahead)
             } else {
-                "  推送到远端？".to_string()
+                t(Msg::PushToRemote).to_string()
             };
             rows.push(Row::new(vec![RowSpan::styled(
                 msg,
@@ -524,9 +525,9 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
         }
 
         let (confirm_label, confirm_bg, confirm_cmd) = if force {
-            (" 确认强制推送 ", Color::Red, "git.forcePushConfirm")
+            (t(Msg::ConfirmForcePush), Color::Red, "git.forcePushConfirm")
         } else {
-            (" 确认推送 ", Color::Green, "git.pushConfirm")
+            (t(Msg::ConfirmPush), Color::Green, "git.pushConfirm")
         };
         let cancel_cmd = if force {
             "git.forcePushCancel"
@@ -545,14 +546,14 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
             .on_click(confirm_cmd, Value::Null),
             RowSpan::plain("  "),
             RowSpan::styled(
-                " 取消 ",
+                t(Msg::Cancel),
                 Style::default()
                     .fg(theme.chrome_fg)
                     .bg(theme.chrome_muted_fg),
             )
             .on_click(cancel_cmd, Value::Null),
             RowSpan::plain("  "),
-            RowSpan::styled("(y / Esc)", Style::default().fg(theme.fg_secondary)),
+            RowSpan::styled(t(Msg::YEscHint), Style::default().fg(theme.fg_secondary)),
         ]));
         rows.push(Row::blank());
     }
@@ -579,7 +580,7 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
         truncate_in_place(&mut display, max_path);
         rows.push(Row::new(vec![
             RowSpan::styled(
-                "  ⚠ 还原 ",
+                t(Msg::DiscardPromptPrefix),
                 Style::default()
                     .fg(Color::Yellow)
                     .add_modifier(Modifier::BOLD),
@@ -590,12 +591,12 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
                     .fg(Color::White)
                     .add_modifier(Modifier::BOLD),
             ),
-            RowSpan::styled("？（不可撤销）", Style::default().fg(Color::Yellow)),
+            RowSpan::styled(t(Msg::DiscardPromptSuffix), Style::default().fg(Color::Yellow)),
         ]));
         rows.push(Row::new(vec![
             RowSpan::plain("  "),
             RowSpan::styled(
-                " 确认还原 ",
+                t(Msg::ConfirmDiscard),
                 Style::default()
                     .fg(Color::Black)
                     .bg(Color::Red)
@@ -604,21 +605,21 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
             .on_click("git.discardConfirm", Value::Null),
             RowSpan::plain("  "),
             RowSpan::styled(
-                " 取消 ",
+                t(Msg::Cancel),
                 Style::default().fg(Color::White).bg(Color::DarkGray),
             )
             .on_click("git.discardCancel", Value::Null),
             RowSpan::plain("  "),
-            RowSpan::styled("(y / Esc)", Style::default().fg(Color::DarkGray)),
+            RowSpan::styled(t(Msg::YEscHint), Style::default().fg(Color::DarkGray)),
         ]));
         rows.push(Row::blank());
     }
 
     // View mode toggle
     let mode_label = if status.tree_mode {
-        "视图: 树形"
+        t(Msg::ViewModeTree)
     } else {
-        "视图: 列表"
+        t(Msg::ViewModeList)
     };
     rows.push(
         Row::new(vec![RowSpan::styled(
@@ -633,11 +634,11 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
     if !app.staged_files.is_empty() {
         rows.push(section_header(
             app.staged_collapsed,
-            "暂存的更改",
+            t(Msg::StagedChanges),
             app.staged_files.len(),
             Color::Green,
             "git.toggleStaged",
-            Some(("取消全部", "git.unstageAll", Color::Red)),
+            Some((t(Msg::UnstageAll), "git.unstageAll", Color::Red)),
             width,
             theme,
         ));
@@ -651,11 +652,11 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
     let unstaged_button = if app.unstaged_files.is_empty() {
         None
     } else {
-        Some(("暂存全部", "git.stageAll", Color::Green))
+        Some((t(Msg::StageAll), "git.stageAll", Color::Green))
     };
     rows.push(section_header(
         app.unstaged_collapsed,
-        "更改",
+        t(Msg::Changes),
         app.unstaged_files.len(),
         Color::Blue,
         "git.toggleUnstaged",
@@ -675,7 +676,7 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
         );
         if app.unstaged_files.is_empty() {
             rows.push(Row::new(vec![RowSpan::styled(
-                "  无文件",
+                t(Msg::NoFiles),
                 Style::default().fg(theme.fg_secondary),
             )]));
         }
@@ -991,7 +992,7 @@ fn push_indicator_row(ahead: usize, behind: usize) -> Option<Row> {
         (a, 0) => Some(Row::new(vec![
             RowSpan::plain("  "),
             RowSpan {
-                text: format!(" ↑ 推送 ({a}) "),
+                text: crate::i18n::push_button(a),
                 style: Style::default()
                     .fg(Color::Black)
                     .bg(Color::Green)
@@ -1001,13 +1002,13 @@ fn push_indicator_row(ahead: usize, behind: usize) -> Option<Row> {
             },
         ])),
         (0, b) => Some(Row::new(vec![RowSpan::styled(
-            format!("  ↓ 落后远端 {b} 次提交 — 请先 fetch/pull"),
+            crate::i18n::behind_remote(b),
             Style::default().fg(Color::Yellow),
         )])),
         (a, b) => Some(Row::new(vec![
             RowSpan::plain("  "),
             RowSpan {
-                text: format!(" ⚠ 已分叉 ↑{a} ↓{b} — 强制推送 "),
+                text: crate::i18n::diverged_force_push(a, b),
                 style: Style::default()
                     .fg(Color::Black)
                     .bg(Color::Yellow)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -12,6 +12,7 @@ pub mod theme;
 pub mod toast;
 
 use crate::app::{App, Tab};
+use crate::i18n::{Msg, t};
 use crate::ui::mouse::ClickAction;
 use crate::ui::toast::ToastLevel;
 use ratatui::Frame;
@@ -92,14 +93,14 @@ fn render_no_repo(f: &mut Frame, app: &App, area: Rect) {
     let msg = Paragraph::new(Text::from(vec![
         Line::from(""),
         Line::from(Span::styled(
-            "Not a git repository",
+            t(Msg::NoRepoTitle),
             Style::default()
                 .fg(Color::Yellow)
                 .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
         Line::from(Span::styled(
-            "Run `git init` to initialise one, or open reef inside a git repo.",
+            t(Msg::NoRepoHint),
             Style::default().fg(th.fg_secondary),
         )),
     ]))
@@ -203,7 +204,7 @@ fn render_tab_bar(f: &mut Frame, app: &mut App, area: Rect) {
 
     // Fill rest of row
     let remaining = (area.width as usize).saturating_sub(x.saturating_sub(area.x) as usize);
-    let keys_hint = " 1:Files 2:Git 3:Graph";
+    let keys_hint = t(Msg::TabBarHint);
     let pad = remaining.saturating_sub(UnicodeWidthStr::width(keys_hint));
     spans.push(Span::styled(" ".repeat(pad), Style::default().bg(bg)));
     spans.push(Span::styled(
@@ -291,7 +292,7 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
                     .add_modifier(Modifier::BOLD),
             ),
             Span::styled(
-                "  拖拽鼠标选择文字，按 v 退出选择模式",
+                t(Msg::SelectModeHint),
                 Style::default().fg(Color::Yellow).bg(th.chrome_bg),
             ),
         ]);
@@ -319,7 +320,7 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
             Style::default().bg(th.chrome_bg),
         ),
         Span::styled(
-            " q:退出 Tab:切换 s:暂存 u:取消 r:刷新 h:帮助 ",
+            t(Msg::StatusBarHint),
             Style::default().fg(th.chrome_muted_fg).bg(th.chrome_bg),
         ),
     ]);
@@ -327,7 +328,6 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn render_search_prompt(f: &mut Frame, app: &App, area: Rect) {
-    use crate::search::WrapMsg;
     let th = app.theme;
     let prefix = if app.search.backwards { '?' } else { '/' };
     let query = app.search.query.as_str();
@@ -340,10 +340,8 @@ fn render_search_prompt(f: &mut Frame, app: &App, area: Rect) {
         query.is_empty(),
     ) {
         (0, _, _, true) => String::new(),
-        (0, _, _, false) => "no match ".to_string(),
-        (n, Some(i), Some(WrapMsg::Bottom), _) => format!("{}/{}  ↻ top ", i + 1, n),
-        (n, Some(i), Some(WrapMsg::Top), _) => format!("{}/{}  ↻ bottom ", i + 1, n),
-        (n, Some(i), _, _) => format!("{}/{} ", i + 1, n),
+        (0, _, _, false) => t(Msg::SearchNoMatch).to_string(),
+        (n, Some(i), wrap, _) => crate::i18n::search_counter(i, n, wrap),
         _ => String::new(),
     };
 
@@ -388,12 +386,11 @@ fn render_search_dormant(f: &mut Frame, app: &App, area: Rect) {
     let th = app.theme;
     let prefix = if app.search.backwards { '?' } else { '/' };
     let counter = match app.search.current {
-        Some(i) => format!(
-            " {}{}  {}/{}  n/N 切换 ",
+        Some(i) => crate::i18n::search_dormant_with_counter(
             prefix,
-            app.search.query,
-            i + 1,
-            app.search.matches.len()
+            &app.search.query,
+            i,
+            app.search.matches.len(),
         ),
         None => format!(" {}{} ", prefix, app.search.query),
     };
@@ -413,27 +410,27 @@ fn render_search_dormant(f: &mut Frame, app: &App, area: Rect) {
 fn render_help(f: &mut Frame, app: &App, screen: Rect) {
     let th = app.theme;
     let core_entries: &[(&str, &str)] = &[
-        ("q / Ctrl+C", "退出"),
-        ("Tab", "切换顶部标签页（Files ↔ Git ↔ Graph）"),
-        ("Shift+Tab", "切换焦点面板（侧边栏 ↔ 编辑区）"),
-        ("1 … 9", "跳转到第 N 个标签页"),
-        ("↑ / k", "向上导航 / 向上滚动"),
-        ("↓ / j", "向下导航 / 向下滚动"),
-        ("PageUp", "快速向上翻页"),
-        ("PageDown", "快速向下翻页"),
-        ("← / →", "横向滚动（Diff/预览 面板聚焦时）"),
-        ("Shift+← / Shift+→", "横向快速滚动（10 列）"),
-        ("Home / End", "回到行首 / 跳到行尾"),
-        ("Shift+滚轮 / 触控板横划", "鼠标横向滚动"),
-        ("s / u", "暂存 / 取消暂存（Git tab）"),
-        ("d → y", "还原工作树文件（Git tab）"),
-        ("m", "切换 Diff 布局（上下 ↔ 左右）"),
-        ("f", "切换 Diff 模式（局部 ↔ 全量）"),
-        ("t", "切换列表 / 树形视图"),
-        ("r", "刷新"),
-        ("v", "文字选择模式"),
-        ("h", "显示 / 关闭此帮助"),
-        ("任意键", "关闭帮助"),
+        ("q / Ctrl+C", t(Msg::HelpQuit)),
+        ("Tab", t(Msg::HelpSwitchTab)),
+        ("Shift+Tab", t(Msg::HelpSwitchPanel)),
+        ("1 … 9", t(Msg::HelpJumpTab)),
+        ("↑ / k", t(Msg::HelpNavUp)),
+        ("↓ / j", t(Msg::HelpNavDown)),
+        ("PageUp", t(Msg::HelpPageUp)),
+        ("PageDown", t(Msg::HelpPageDown)),
+        ("← / →", t(Msg::HelpHScroll)),
+        ("Shift+← / Shift+→", t(Msg::HelpHScrollFast)),
+        ("Home / End", t(Msg::HelpHomeEnd)),
+        (t(Msg::HelpKeyMouseHScroll), t(Msg::HelpMouseHScroll)),
+        ("s / u", t(Msg::HelpStageUnstage)),
+        ("d → y", t(Msg::HelpDiscard)),
+        ("m", t(Msg::HelpDiffLayout)),
+        ("f", t(Msg::HelpDiffMode)),
+        ("t", t(Msg::HelpToggleView)),
+        ("r", t(Msg::HelpRefresh)),
+        ("v", t(Msg::HelpSelectMode)),
+        ("h", t(Msg::HelpShowHelp)),
+        (t(Msg::HelpKeyAnyKey), t(Msg::HelpAnyKey)),
     ];
 
     let popup_w = 72u16;
@@ -448,7 +445,7 @@ fn render_help(f: &mut Frame, app: &App, screen: Rect) {
         .borders(Borders::ALL)
         .border_style(Style::default().fg(th.accent))
         .title(Span::styled(
-            " 快捷键帮助 ",
+            t(Msg::HelpTitle),
             Style::default()
                 .fg(th.fg_primary)
                 .add_modifier(Modifier::BOLD),

--- a/tests/snapshots/ui_snapshots__empty_repo.snap
+++ b/tests/snapshots/ui_snapshots__empty_repo.snap
@@ -1,5 +1,6 @@
 ---
-source: crates/reef-host/tests/ui_snapshots.rs
+source: tests/ui_snapshots.rs
+assertion_line: 86
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -12,7 +13,7 @@ expression: output
                        │
                        │
                        │
-                       │                  选 择 一 个 文 件 预 览 内 容
+                       │                  Select a file to preview
                        │
                        │
                        │
@@ -21,4 +22,4 @@ expression: output
                        │
                        │
                        │
-                     q:退 出  Tab:切 换  s:暂 存  u:取 消  r:刷 新  h:帮 助
+                     q:quit Tab:switch s:stage u:unstage r:refresh h:help

--- a/tests/snapshots/ui_snapshots__with_staged_and_unstaged.snap
+++ b/tests/snapshots/ui_snapshots__with_staged_and_unstaged.snap
@@ -1,19 +1,19 @@
 ---
-source: crates/reef-host/tests/ui_snapshots.rs
-assertion_line: 140
+source: tests/ui_snapshots.rs
+assertion_line: 105
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
  📁  Files │ ⎇ Git │ ⑂ Graph                                1:Files 2:Git 3:Graph
- 视 图 : 列 表             │
+ View: list            │
                        │
- ⌄ 更 改   2    暂 存 全 部  │
+ ⌄ Changes  2 Stage all│
    new.txt U + ↺       │
    tracked.txt M + ↺   │
                        │
                        │
                        │
-                       │                 选 择 一 个 文 件 查 看  diff
+                       │                 Select a file to view diff
                        │
                        │
                        │
@@ -22,4 +22,4 @@ expression: output
                        │
                        │
                        │
-                     q:退 出  Tab:切 换  s:暂 存  u:取 消  r:刷 新  h:帮 助
+                     q:quit Tab:switch s:stage u:unstage r:refresh h:help

--- a/tests/snapshots/ui_snapshots__with_staged_and_unstaged_light.snap
+++ b/tests/snapshots/ui_snapshots__with_staged_and_unstaged_light.snap
@@ -1,19 +1,19 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 124
+assertion_line: 128
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
  📁  Files │ ⎇ Git │ ⑂ Graph                                1:Files 2:Git 3:Graph
- 视 图 : 列 表             │
+ View: list            │
                        │
- ⌄ 更 改   2    暂 存 全 部  │
+ ⌄ Changes  2 Stage all│
    new.txt U + ↺       │
    tracked.txt M + ↺   │
                        │
                        │
                        │
-                       │                 选 择 一 个 文 件 查 看  diff
+                       │                 Select a file to view diff
                        │
                        │
                        │
@@ -22,4 +22,4 @@ expression: output
                        │
                        │
                        │
-                     q:退 出  Tab:切 换  s:暂 存  u:取 消  r:刷 新  h:帮 助
+                     q:quit Tab:switch s:stage u:unstage r:refresh h:help

--- a/tests/ui_snapshots.rs
+++ b/tests/ui_snapshots.rs
@@ -17,6 +17,18 @@ use test_support::{HomeGuard, commit_file, tempdir_repo, write_file};
 
 static CWD_LOCK: Mutex<()> = Mutex::new(());
 
+/// Pin the UI language so the snapshot is stable regardless of the test
+/// host's system locale. Called under `CWD_LOCK`; the first call seeds
+/// i18n's OnceLock cache for the process so all three snapshot tests
+/// render in the same language.
+fn force_en_lang() {
+    // SAFETY: test-only; `CWD_LOCK` serialises the three snapshot tests
+    // and no other test in this binary touches env vars.
+    unsafe {
+        std::env::set_var("REEF_LANG", "en");
+    }
+}
+
 struct CwdGuard {
     original: std::path::PathBuf,
 }
@@ -74,6 +86,7 @@ fn with_filters<F: FnOnce()>(body: F) {
 #[test]
 fn snapshot_empty_repo() {
     let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    force_en_lang();
     let (tmp, _raw) = tempdir_repo();
     // HOME must point outside the workdir — prefs creates `.config/reef`
     // and the file tree now shows dotfiles.
@@ -89,6 +102,7 @@ fn snapshot_empty_repo() {
 #[test]
 fn snapshot_with_staged_and_unstaged() {
     let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    force_en_lang();
     let (tmp, raw) = tempdir_repo();
     commit_file(&raw, "tracked.txt", "v1\n", "init");
     write_file(&raw, "tracked.txt", "v2\n"); // unstaged modification
@@ -114,6 +128,7 @@ fn snapshot_with_staged_and_unstaged_light_theme() {
     // intentionally asserts "same content, same layout" — not color fidelity.
     // Color fidelity is verified by the unit tests in `src/ui/theme.rs`.
     let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    force_en_lang();
     let (tmp, raw) = tempdir_repo();
     commit_file(&raw, "tracked.txt", "v1\n", "init");
     write_file(&raw, "tracked.txt", "v2\n");


### PR DESCRIPTION
## Summary

- Add lightweight `i18n` module (`src/i18n.rs`) with `Lang::{En, Zh}` and a `Msg` enum covering every user-facing string — tab labels, status/help/search chrome, push & discard banners, commit-detail metadata, diff/graph/preview empty states, etc.
- Auto-detect language from `ui.lang` pref → `REEF_LANG` env → `LC_ALL` → `LC_MESSAGES` → `LANG`. Locales starting with `zh` select Chinese; everything else falls back to English. Detection is cached once per process in `OnceLock`.
- Route every previously-hardcoded string through `i18n::t(Msg)` (static) or parameterised helpers like `push_failed_toast`, `push_n_commits_prompt`, `behind_remote`, `search_counter`, etc.
- Pin snapshot tests to `REEF_LANG=en` (set under the existing `CWD_LOCK`) so the rendered output is deterministic regardless of the test host's system locale. The three `.snap` files are updated to the English rendering.

## Behaviour

- Default: whatever the system locale says. Chinese speakers keep seeing the existing Chinese UI; everyone else now gets English instead of mixed Chinese/English.
- Override: `REEF_LANG=zh reef` / `REEF_LANG=en reef`, or a line like `ui.lang=zh` in `~/.config/reef/prefs`.

## Test plan

- [x] `cargo check`
- [x] `cargo test` (151 passed across 8 suites)
- [x] `cargo clippy --all-targets`
- [ ] Run `reef` with `REEF_LANG=zh` and confirm zh-CN strings match the previous UI
- [ ] Run `reef` with `REEF_LANG=en` and confirm the English rendering reads cleanly
- [ ] Run `reef` with no override on a non-zh locale and confirm English is picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)