### PR TITLE
feat: quick-open palette with fuzzy file search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,6 +1824,7 @@ dependencies = [
  "ignore",
  "insta",
  "notify",
+ "nucleo-matcher",
  "proptest",
  "ratatui",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ syntect       = { version = "5.2", default-features = false, features = ["defaul
 two-face      = { version = "0.5", default-features = false, features = ["syntect-fancy"] }
 notify        = "6"
 ignore        = "0.4"
+nucleo-matcher = "0.3"
 serde_json    = { workspace = true }
 terminal-colorsaurus = "1.0.3"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -194,6 +194,17 @@ pub struct App {
     /// In-panel vim-style search (`/`, `?`, `n`, `N`). See `crate::search`.
     pub search: crate::search::SearchState,
 
+    /// VSCode-style quick-open palette. While `active`, input is routed
+    /// exclusively to `crate::quick_open::handle_key` (see input.rs).
+    pub quick_open: crate::quick_open::QuickOpenState,
+
+    /// Timestamp of the most recent bare-Space keystroke in the global
+    /// keymap. `Some(t)` means a Space leader is primed and waiting for a
+    /// follow-up key within `input::LEADER_TIMEOUT`. The palette-side
+    /// leader has its own slot inside `QuickOpenState` — separate so they
+    /// can't interfere across mode transitions.
+    pub space_leader_at: Option<std::time::Instant>,
+
     /// Last-rendered content height (in rows) for each right-side panel.
     /// Search jumps read these to center the match in view. Written by the
     /// panel's render fn every frame; defaults to 0 until the first render.
@@ -281,6 +292,8 @@ impl App {
             pending_edit: None,
             theme,
             search: crate::search::SearchState::default(),
+            quick_open: crate::quick_open::QuickOpenState::from_prefs(),
+            space_leader_at: None,
             last_preview_view_h: 0,
             last_diff_view_h: 0,
             last_commit_detail_view_h: 0,
@@ -694,6 +707,13 @@ impl App {
                 }
                 let _ = crate::ui::commit_detail_panel::handle_command(self, &command, &args);
             }
+            // Quick-open palette clicks are dispatched inline by
+            // `quick_open::handle_mouse` (single-click select, double-click
+            // accept) rather than routed through `handle_action`, because
+            // the double-click distinction needs `last_click` timing that's
+            // only available at the input layer. This arm is unreachable
+            // under normal flow but keeps the match exhaustive.
+            ClickAction::QuickOpenSelect(_) => {}
         }
     }
 
@@ -775,6 +795,10 @@ impl App {
             self.refresh_file_tree();
             self.load_preview();
             self.load_diff();
+            // Mark the quick-open index stale so the next palette open picks up
+            // the new/deleted files. Rebuilding immediately on every fs
+            // event would be wasteful for a palette the user may not open.
+            crate::quick_open::mark_stale(&mut self.quick_open);
         }
 
         self.drain_push_result();

--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -132,6 +132,24 @@ impl FileTree {
         self.entries.get(self.selected)
     }
 
+    /// Expand every ancestor directory of `rel` and move `selected` to the
+    /// row that displays `rel` in the flattened tree. Used by the quick-open
+    /// palette on accept, so the chosen file is visible and the preview
+    /// panel shows it immediately. Silently no-ops if the file isn't in the
+    /// tree after rebuild (e.g. deleted between index and accept).
+    pub fn reveal(&mut self, rel: &Path) {
+        for ancestor in rel.ancestors().skip(1) {
+            if ancestor.as_os_str().is_empty() {
+                break;
+            }
+            self.expanded.insert(ancestor.to_path_buf());
+        }
+        self.rebuild();
+        if let Some(idx) = self.entries.iter().position(|e| e.path == rel) {
+            self.selected = idx;
+        }
+    }
+
     /// Merge git status from the host's file lists.
     pub fn refresh_git_statuses(
         &mut self,

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -137,6 +137,7 @@ pub enum Msg {
     HelpRefresh,
     HelpSelectMode,
     HelpShowHelp,
+    HelpQuickOpen,
     HelpAnyKey,
 }
 
@@ -221,6 +222,7 @@ fn t_zh(m: Msg) -> &'static str {
         HelpRefresh => "刷新",
         HelpSelectMode => "文字选择模式",
         HelpShowHelp => "显示 / 关闭此帮助",
+        HelpQuickOpen => "打开 / 关闭快速打开浮层（全局模糊搜索）",
         HelpAnyKey => "关闭帮助",
     }
 }
@@ -299,6 +301,7 @@ fn t_en(m: Msg) -> &'static str {
         HelpRefresh => "Refresh",
         HelpSelectMode => "Text selection mode",
         HelpShowHelp => "Show / close this help",
+        HelpQuickOpen => "Toggle quick-open palette (global fuzzy search)",
         HelpAnyKey => "Close help",
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -9,6 +9,7 @@
 //! just add indirection.
 
 use crate::app::{App, Panel, Tab};
+use crate::quick_open;
 use crate::search;
 use crate::ui;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
@@ -18,14 +19,117 @@ use std::time::{Duration, Instant};
 
 pub const DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(400);
 
+/// How long a primed Space leader stays valid before being discarded. Long
+/// enough for a deliberate "Space, p" chord on a keyboard, short enough
+/// that a forgotten leader doesn't steal the next unrelated keypress.
+pub const LEADER_TIMEOUT: Duration = Duration::from_millis(800);
+
+/// One-keystroke verdict for the Space-leader chord.
+///
+/// The chord lives in two places (global toggle and palette-side close), so
+/// the decision is pulled out of both call sites into a pure function that
+/// both drive off the same state machine.
+#[derive(Debug, PartialEq, Eq)]
+pub enum LeaderVerdict {
+    /// Arm the leader now — caller writes `Some(Instant::now())` into its
+    /// state slot and returns without further dispatch.
+    Arm,
+    /// Fire the chord — caller triggers the target action (open / close)
+    /// and clears the leader slot.
+    Fire,
+    /// Leader was armed but this keystroke isn't the chord target. Caller
+    /// clears the leader slot and falls through to normal key dispatch so
+    /// the key still does whatever it would have done without the leader.
+    Consume,
+    /// No leader interaction; dispatch the key normally.
+    None,
+}
+
+/// Pure leader-decision state machine. Returns what the caller should do
+/// about `key` given whether arming is permitted in this context
+/// (`allow_arm`) and whether a leader is already pending (`leader_at`).
+///
+/// Rules in one paragraph: when nothing is armed, a bare Space with
+/// `allow_arm` asks to arm. When a leader is armed and `key` is a bare `p`
+/// or `P` within `timeout`, fire. When a leader is armed and the user
+/// presses Space again with `allow_arm`, re-arm (double-Space is more
+/// usefully "reset the chord" than "lose it"). Any other key with a primed
+/// leader consumes the leader — the user changed their mind.
+pub fn leader_decision(
+    key: &KeyEvent,
+    allow_arm: bool,
+    leader_at: Option<Instant>,
+    now: Instant,
+    timeout: Duration,
+) -> LeaderVerdict {
+    let is_bare_space = key.code == KeyCode::Char(' ') && key.modifiers.is_empty();
+    let is_bare_p =
+        matches!(key.code, KeyCode::Char('p') | KeyCode::Char('P')) && key.modifiers.is_empty();
+
+    // Fresh-arm path: no leader pending, space pressed, context allows.
+    if allow_arm && leader_at.is_none() && is_bare_space {
+        return LeaderVerdict::Arm;
+    }
+
+    // A leader is pending — resolve it.
+    if let Some(t) = leader_at {
+        let within = now.duration_since(t) < timeout;
+        if within && is_bare_p {
+            return LeaderVerdict::Fire;
+        }
+        // Re-arm on a second Space so the user can stutter their leader.
+        if allow_arm && is_bare_space {
+            return LeaderVerdict::Arm;
+        }
+        return LeaderVerdict::Consume;
+    }
+
+    LeaderVerdict::None
+}
+
 // ─── Keyboard ────────────────────────────────────────────────────────────────
 
 pub fn handle_key(key: KeyEvent, app: &mut App) {
+    // Quick-open palette has the highest priority — while active it fully
+    // owns input (character append, cursor, Enter/Esc, Space-P close).
+    if app.quick_open.active {
+        quick_open::handle_key(key, app);
+        return;
+    }
+
     // Search mode has priority over everything else — the prompt fully owns
     // input (character append, Backspace, Enter/Esc) while active.
     if app.search.active {
         search::handle_key_in_search_mode(key, app);
         return;
+    }
+
+    // Space-leader chord: bare Space primes, bare P opens the quick-open
+    // palette. Bare Space has no other meaning globally, so the chord
+    // doesn't collide with any existing binding. Context: we're already
+    // past the quick_open / search gates, so the leader is only in play
+    // during normal tab navigation.
+    match leader_decision(
+        &key,
+        /* allow_arm */ true,
+        app.space_leader_at,
+        Instant::now(),
+        LEADER_TIMEOUT,
+    ) {
+        LeaderVerdict::Arm => {
+            app.space_leader_at = Some(Instant::now());
+            return;
+        }
+        LeaderVerdict::Fire => {
+            app.space_leader_at = None;
+            quick_open::begin(app);
+            return;
+        }
+        LeaderVerdict::Consume => {
+            app.space_leader_at = None;
+            // Fall through — the current key still gets its normal meaning.
+        }
+        LeaderVerdict::None => {}
     }
 
     // Global keys (work on all tabs)
@@ -337,6 +441,15 @@ fn handle_key_files(key: KeyEvent, app: &mut App) {
 // ─── Mouse ───────────────────────────────────────────────────────────────────
 
 pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Terminal<B>) {
+    // Quick-open palette, like the keyboard path, fully owns mouse input
+    // while active: the overlay shouldn't let clicks leak to the hidden
+    // panels behind it, and scroll wheels inside the popup should move the
+    // candidate selection — not scroll the underlying diff.
+    if app.quick_open.active {
+        quick_open::handle_mouse(mouse, app);
+        return;
+    }
+
     match mouse.kind {
         MouseEventKind::Down(MouseButton::Left) => {
             let now = Instant::now();
@@ -494,4 +607,115 @@ fn apply_horizontal_scroll(app: &mut App, column: u16, total_width: u16, delta: 
     } else {
         target.saturating_add(delta as usize)
     };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod leader_tests {
+    use super::*;
+    use crossterm::event::KeyEventKind;
+
+    fn ke(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            state: crossterm::event::KeyEventState::empty(),
+        }
+    }
+
+    fn space() -> KeyEvent {
+        ke(KeyCode::Char(' '), KeyModifiers::empty())
+    }
+
+    fn lower_p() -> KeyEvent {
+        ke(KeyCode::Char('p'), KeyModifiers::empty())
+    }
+
+    fn upper_p() -> KeyEvent {
+        ke(KeyCode::Char('P'), KeyModifiers::empty())
+    }
+
+    #[test]
+    fn space_with_no_leader_arms() {
+        let now = Instant::now();
+        let v = leader_decision(&space(), true, None, now, LEADER_TIMEOUT);
+        assert_eq!(v, LeaderVerdict::Arm);
+    }
+
+    #[test]
+    fn space_when_arm_not_allowed_does_not_arm() {
+        // Palette has non-empty query → bare Space is a literal char.
+        let now = Instant::now();
+        let v = leader_decision(&space(), false, None, now, LEADER_TIMEOUT);
+        assert_eq!(v, LeaderVerdict::None);
+    }
+
+    #[test]
+    fn p_after_arm_within_window_fires() {
+        let now = Instant::now();
+        let v = leader_decision(&lower_p(), true, Some(now), now, LEADER_TIMEOUT);
+        assert_eq!(v, LeaderVerdict::Fire);
+    }
+
+    #[test]
+    fn uppercase_p_after_arm_also_fires() {
+        // Accept both cases so CapsLock or Shift doesn't defeat the chord.
+        let now = Instant::now();
+        let v = leader_decision(&upper_p(), true, Some(now), now, LEADER_TIMEOUT);
+        assert_eq!(v, LeaderVerdict::Fire);
+    }
+
+    #[test]
+    fn p_after_window_expired_consumes() {
+        let armed = Instant::now();
+        let now = armed + LEADER_TIMEOUT + Duration::from_millis(50);
+        let v = leader_decision(&lower_p(), true, Some(armed), now, LEADER_TIMEOUT);
+        assert_eq!(v, LeaderVerdict::Consume);
+    }
+
+    #[test]
+    fn p_with_ctrl_does_not_fire_even_when_armed() {
+        // Ctrl+P is bound to "prev candidate" inside the palette; the
+        // chord must not accidentally swallow it.
+        let now = Instant::now();
+        let ctrl_p = ke(KeyCode::Char('p'), KeyModifiers::CONTROL);
+        let v = leader_decision(&ctrl_p, true, Some(now), now, LEADER_TIMEOUT);
+        assert_eq!(v, LeaderVerdict::Consume);
+    }
+
+    #[test]
+    fn second_space_rearms_the_leader() {
+        // Double-Space is more usefully "reset the chord" than "lose it"
+        // — otherwise Space+Space+P wouldn't open the palette.
+        let first = Instant::now();
+        let second = first + Duration::from_millis(100);
+        let v = leader_decision(&space(), true, Some(first), second, LEADER_TIMEOUT);
+        assert_eq!(v, LeaderVerdict::Arm);
+    }
+
+    #[test]
+    fn non_chord_key_after_arm_consumes() {
+        let now = Instant::now();
+        let j = ke(KeyCode::Char('j'), KeyModifiers::empty());
+        let v = leader_decision(&j, true, Some(now), now, LEADER_TIMEOUT);
+        assert_eq!(v, LeaderVerdict::Consume);
+    }
+
+    #[test]
+    fn no_leader_and_non_space_is_passthrough() {
+        let now = Instant::now();
+        let j = ke(KeyCode::Char('j'), KeyModifiers::empty());
+        let v = leader_decision(&j, true, None, now, LEADER_TIMEOUT);
+        assert_eq!(v, LeaderVerdict::None);
+    }
+
+    #[test]
+    fn shift_space_does_not_arm() {
+        let now = Instant::now();
+        let shift_space = ke(KeyCode::Char(' '), KeyModifiers::SHIFT);
+        let v = leader_decision(&shift_space, true, None, now, LEADER_TIMEOUT);
+        assert_eq!(v, LeaderVerdict::None);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,6 @@ pub mod git;
 pub mod i18n;
 pub mod input;
 pub mod prefs;
+pub mod quick_open;
 pub mod search;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     // so the terminal's native text-selection works. Kept inline
                     // because it's the only input that needs to poke the terminal
                     // backend mid-loop.
-                    if key.code == KeyCode::Char('v') && key.modifiers.is_empty() {
+                    //
+                    // When the quick-open palette is active it owns every key
+                    // unconditionally — 'v' must land as a literal in the query
+                    // and 'any key' must not dismiss help/palette — so route to
+                    // handle_key first and let it delegate to quick_open.
+                    if app.quick_open.active {
+                        input::handle_key(key, &mut app);
+                    } else if key.code == KeyCode::Char('v') && key.modifiers.is_empty() {
                         app.select_mode = !app.select_mode;
                         if app.select_mode {
                             execute!(terminal.backend_mut(), DisableMouseCapture)?;

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -13,6 +13,10 @@
 //!                                                Read once in `main.rs` before raw-mode
 //!                                                entry; `auto` probes the terminal's
 //!                                                background via OSC 11.
+//!   - `quickopen.mru`                          — Quick-open palette MRU; tab-separated
+//!                                                workdir-relative paths, newest-first,
+//!                                                capped at 50 entries. Written on every
+//!                                                accept, read once in `App::new`.
 //!
 //! Writers must go through `set()` (not raw `std::fs::write`) so that
 //! updating one key doesn't erase all the others.

--- a/src/quick_open.rs
+++ b/src/quick_open.rs
@@ -1,0 +1,819 @@
+//! VSCode-style quick-open palette (bound to Space-P): fuzzy search every
+//! file in the workdir (honouring `.gitignore`) and jump to it in the Files
+//! tab preview.
+//!
+//! The state machine mirrors `search.rs`'s "active prompt owns input" pattern:
+//! while `active` is true, `input::handle_key` delegates all key events here
+//! and the overlay renders on top of the normal UI. Unlike `search.rs` this
+//! never mutates backing panel scroll/selection until the user confirms with
+//! Enter — so Esc cleanly drops back to exactly what was on screen.
+//!
+//! Index & MRU:
+//! - Index is (re)built lazily on `begin()` when `index_stale` is set. A fresh
+//!   `ignore::WalkBuilder` walk pulls every non-`.git` file under the workdir,
+//!   respecting every ignore layer (`.gitignore`, `.git/info/exclude`,
+//!   global), then caches the UTF-32 encoding nucleo needs so typing stays
+//!   hot on large repos.
+//! - MRU is an ordered dedup of recently accepted paths, capped at 50 and
+//!   persisted via the same flat-kv prefs file the rest of the app uses. We
+//!   sanitise `\t` / `\n` in paths on write to keep the file parseable; those
+//!   characters in real-world paths are exotic enough to be worth the edge.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use ignore::WalkBuilder;
+use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
+use nucleo_matcher::{Config, Matcher, Utf32String};
+use ratatui::layout::Rect;
+use std::collections::{HashSet, VecDeque};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use crate::app::{App, Tab};
+use crate::input::DOUBLE_CLICK_WINDOW;
+use crate::prefs;
+use crate::ui::mouse::ClickAction;
+
+const MRU_MAX: usize = 50;
+const MRU_PREF_KEY: &str = "quickopen.mru";
+const MRU_SEP: char = '\t';
+
+/// One file that can be matched. `display` is the workdir-relative path as it
+/// appears in the UI; `utf32` is the same string pre-encoded to the form
+/// nucleo consumes, so filter() doesn't re-encode every keystroke.
+pub struct Candidate {
+    pub rel_path: PathBuf,
+    pub display: String,
+    utf32: Utf32String,
+}
+
+/// A single filtered hit. `indices` are character positions in
+/// `index[idx].display` that matched — fed to the renderer for highlighting.
+#[derive(Clone)]
+pub struct MatchEntry {
+    pub idx: usize,
+    pub score: u32,
+    pub indices: Vec<u32>,
+}
+
+pub struct QuickOpenState {
+    pub active: bool,
+    pub query: String,
+    /// Byte offset into `query`. Always on a char boundary.
+    pub cursor: usize,
+    pub selected: usize,
+    pub scroll: usize,
+    pub index: Vec<Candidate>,
+    /// fs-watcher flips this on; `begin()` rebuilds and clears it. Avoids
+    /// re-walking the tree on every unrelated fs event.
+    pub index_stale: bool,
+    pub matches: Vec<MatchEntry>,
+    pub mru: VecDeque<PathBuf>,
+    /// Last-rendered list viewport height in rows; used by PageUp/PageDown
+    /// to pick a step size. Mirrors `last_preview_view_h` etc. in `App`.
+    pub last_view_h: u16,
+    /// Last-rendered popup bounds. Read by the mouse dispatcher to decide
+    /// whether a click landed inside the palette (stays in palette mode) or
+    /// outside (dismisses). `None` means the popup hasn't been rendered yet —
+    /// any click in that window is treated as "inside" so the first click
+    /// after opening never accidentally dismisses.
+    pub last_popup_area: Option<Rect>,
+
+    /// Timestamp of the most recent bare-Space keystroke inside the palette.
+    /// Drives the in-palette half of the Space-P chord so the user can
+    /// toggle the palette closed without reaching for Esc. Only armed when
+    /// `query.is_empty()` so that Space becomes a literal char once the
+    /// user is actually searching for something with a space in it.
+    pub space_leader_at: Option<Instant>,
+}
+
+impl Default for QuickOpenState {
+    fn default() -> Self {
+        Self {
+            active: false,
+            query: String::new(),
+            cursor: 0,
+            selected: 0,
+            scroll: 0,
+            index: Vec::new(),
+            index_stale: true,
+            matches: Vec::new(),
+            mru: VecDeque::new(),
+            last_view_h: 0,
+            last_popup_area: None,
+            space_leader_at: None,
+        }
+    }
+}
+
+impl QuickOpenState {
+    /// Build state from persisted prefs (loads the MRU). Index stays empty
+    /// and stale — it'll be walked on the first `begin()` call so startup
+    /// time isn't spent on an index the user may never open.
+    pub fn from_prefs() -> Self {
+        Self {
+            mru: load_mru_from_prefs(),
+            ..Self::default()
+        }
+    }
+}
+
+// ─── Entry points ────────────────────────────────────────────────────────────
+
+/// Open the palette. Rebuilds the index if stale (first open, or fs-watcher
+/// saw changes since the last build). Preserves `query` across close/reopen
+/// so the user can Esc to peek at something and come back.
+pub fn begin(app: &mut App) {
+    let root = app.file_tree.root.clone();
+    if app.quick_open.index_stale || app.quick_open.index.is_empty() {
+        app.quick_open.index = rebuild_index(&root);
+        app.quick_open.index_stale = false;
+    }
+    app.quick_open.active = true;
+    app.quick_open.selected = 0;
+    app.quick_open.scroll = 0;
+    // Position cursor at end so the first keystroke continues (not splits)
+    // the existing query.
+    app.quick_open.cursor = app.quick_open.query.len();
+    // Start with a clean leader slot — a stale timestamp from a previous
+    // session would make the first Space-after-open surprisingly close the
+    // palette.
+    app.quick_open.space_leader_at = None;
+    filter(&mut app.quick_open);
+}
+
+/// Commit the current selection: update MRU, close the palette, and jump
+/// the Files tab to the chosen file with a fresh preview loaded.
+pub fn accept(app: &mut App) {
+    let Some(m) = app.quick_open.matches.get(app.quick_open.selected) else {
+        app.quick_open.active = false;
+        return;
+    };
+    let Some(cand) = app.quick_open.index.get(m.idx) else {
+        app.quick_open.active = false;
+        return;
+    };
+    let rel = cand.rel_path.clone();
+
+    // MRU: move-to-front with dedup, cap at MRU_MAX.
+    app.quick_open.mru.retain(|p| p != &rel);
+    app.quick_open.mru.push_front(rel.clone());
+    while app.quick_open.mru.len() > MRU_MAX {
+        app.quick_open.mru.pop_back();
+    }
+    save_mru_to_prefs(&app.quick_open.mru);
+
+    app.quick_open.active = false;
+    app.active_tab = Tab::Files;
+    app.file_tree.reveal(&rel);
+    app.load_preview();
+}
+
+/// Dispatch one key while the palette is active. The caller (input.rs)
+/// guarantees exclusivity — no other handler sees these keys.
+///
+/// Binding map:
+/// - `Esc`                                 close palette (keeps query for re-open)
+/// - `Ctrl+C`                              close + quit app
+/// - `Enter`                               accept selected
+/// - `Backspace`                           delete char
+/// - `Alt+Backspace` / `Ctrl+Backspace` / `Ctrl+W`  delete previous word
+/// - `Ctrl+U`                              clear the whole query
+/// - `Up` / `Ctrl+P` / `Ctrl+K`            previous candidate
+/// - `Down` / `Ctrl+N` / `Ctrl+J`          next candidate
+/// - `PageUp` / `PageDown`                 page by viewport height
+/// - `Left` / `Right` / `Home` / `End`     edit-cursor movement
+///
+/// Historic note: an earlier revision made `Ctrl+P` close the palette
+/// (toggle-on, toggle-off). That conflicted with users' expectation that
+/// `Ctrl+P` navigates inside the palette (VSCode / readline / vim parity),
+/// so `Ctrl+P` now only means "previous candidate" — Esc is the sole
+/// keyboard close.
+pub fn handle_key(key: KeyEvent, app: &mut App) {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
+
+    // Space-leader close: mirrors the global open chord. Only armed while
+    // `query.is_empty()` so once the user starts typing a path that might
+    // legitimately contain a space (or a `p`), the chord shuts off and
+    // characters go straight into the query.
+    match crate::input::leader_decision(
+        &key,
+        /* allow_arm */ app.quick_open.query.is_empty(),
+        app.quick_open.space_leader_at,
+        Instant::now(),
+        crate::input::LEADER_TIMEOUT,
+    ) {
+        crate::input::LeaderVerdict::Arm => {
+            app.quick_open.space_leader_at = Some(Instant::now());
+            return;
+        }
+        crate::input::LeaderVerdict::Fire => {
+            app.quick_open.space_leader_at = None;
+            app.quick_open.active = false;
+            return;
+        }
+        crate::input::LeaderVerdict::Consume => {
+            app.quick_open.space_leader_at = None;
+            // Fall through — the current key still runs below.
+        }
+        crate::input::LeaderVerdict::None => {}
+    }
+
+    match key.code {
+        KeyCode::Esc => {
+            app.quick_open.active = false;
+        }
+        KeyCode::Char('c') if ctrl => {
+            app.quick_open.active = false;
+            app.should_quit = true;
+        }
+        KeyCode::Enter => accept(app),
+
+        // ── Deletion ─────────────────────────────────────────────
+        // Alt+Backspace (macOS Option+Backspace) and Ctrl+Backspace
+        // (Windows/Linux) both ask for "delete previous word". Crossterm
+        // only surfaces these modifiers when the terminal uses a kitty /
+        // fixterms-style protocol; older terminals collapse Alt+Backspace
+        // onto plain Backspace, so Ctrl+W stays as the reliable fallback.
+        KeyCode::Backspace if alt || ctrl => {
+            delete_word_backward(&mut app.quick_open);
+            filter(&mut app.quick_open);
+        }
+        KeyCode::Char('w') if ctrl => {
+            delete_word_backward(&mut app.quick_open);
+            filter(&mut app.quick_open);
+        }
+        KeyCode::Char('u') if ctrl => {
+            clear_query(&mut app.quick_open);
+            filter(&mut app.quick_open);
+        }
+        KeyCode::Backspace => {
+            backspace(&mut app.quick_open);
+            filter(&mut app.quick_open);
+        }
+
+        // ── List navigation ──────────────────────────────────────
+        KeyCode::Up => move_selection(&mut app.quick_open, -1),
+        KeyCode::Char('p') if ctrl => move_selection(&mut app.quick_open, -1),
+        KeyCode::Char('k') if ctrl => move_selection(&mut app.quick_open, -1),
+        KeyCode::Down => move_selection(&mut app.quick_open, 1),
+        KeyCode::Char('n') if ctrl => move_selection(&mut app.quick_open, 1),
+        KeyCode::Char('j') if ctrl => move_selection(&mut app.quick_open, 1),
+        KeyCode::PageUp => {
+            let step = app.quick_open.last_view_h.max(1) as i32;
+            move_selection(&mut app.quick_open, -step);
+        }
+        KeyCode::PageDown => {
+            let step = app.quick_open.last_view_h.max(1) as i32;
+            move_selection(&mut app.quick_open, step);
+        }
+
+        // ── Edit-cursor movement ─────────────────────────────────
+        KeyCode::Left => move_cursor(&mut app.quick_open, -1),
+        KeyCode::Right => move_cursor(&mut app.quick_open, 1),
+        KeyCode::Home => {
+            app.quick_open.cursor = 0;
+        }
+        KeyCode::End => {
+            app.quick_open.cursor = app.quick_open.query.len();
+        }
+
+        // Any other Ctrl-combo is a no-op; we don't want Ctrl+A etc.
+        // landing as a literal 'a' in the query.
+        KeyCode::Char(c) if !ctrl => {
+            insert_char(&mut app.quick_open, c);
+            filter(&mut app.quick_open);
+        }
+        _ => {}
+    }
+}
+
+/// Dispatch one mouse event while the palette is active. The caller
+/// (input.rs) routes all events here instead of the normal mouse pipeline,
+/// so the underlying panels can't receive clicks through the overlay.
+///
+/// Semantics:
+/// - Left click outside the popup area → close palette
+/// - Left click on a row → select that candidate
+/// - Double left-click on a row → select + accept (open file)
+/// - Scroll wheel inside popup → move selection (3 rows per tick)
+/// - Everything else (drag, right-click, move) → ignored
+pub fn handle_mouse(mouse: MouseEvent, app: &mut App) {
+    let popup = match app.quick_open.last_popup_area {
+        Some(r) => r,
+        // No popup rendered yet — swallow the event without side-effects so
+        // a spurious click during the first tick can't dismiss the palette.
+        None => return,
+    };
+    let inside = mouse.column >= popup.x
+        && mouse.column < popup.x + popup.width
+        && mouse.row >= popup.y
+        && mouse.row < popup.y + popup.height;
+
+    match mouse.kind {
+        MouseEventKind::Down(MouseButton::Left) => {
+            if !inside {
+                // Click-away dismisses the palette, just like clicking
+                // outside a dropdown in a GUI. Keeps the pre-palette state
+                // intact (filter doesn't touch scroll/selection elsewhere).
+                app.quick_open.active = false;
+                app.last_click = None;
+                return;
+            }
+
+            let now = Instant::now();
+            let is_double = matches!(
+                app.last_click,
+                Some((t, c, r))
+                    if c == mouse.column
+                        && r == mouse.row
+                        && now.duration_since(t) < DOUBLE_CLICK_WINDOW
+            );
+
+            // hit_test walks the registry in reverse registration order, and
+            // the palette registers its rows AFTER the underlying panels, so
+            // the palette's zones always win on overlap — meaning a click on
+            // the popup never leaks through to a TreeClick / GitCommand
+            // behind it.
+            if let Some(ClickAction::QuickOpenSelect(idx)) =
+                app.hit_registry.hit_test(mouse.column, mouse.row)
+            {
+                app.quick_open.selected = idx;
+                if is_double {
+                    accept(app);
+                    app.last_click = None;
+                    return;
+                }
+            }
+
+            // Track click for the next frame's double-click check.
+            app.last_click = if is_double {
+                None
+            } else {
+                Some((now, mouse.column, mouse.row))
+            };
+        }
+        MouseEventKind::ScrollUp if inside => {
+            move_selection(&mut app.quick_open, -3);
+        }
+        MouseEventKind::ScrollDown if inside => {
+            move_selection(&mut app.quick_open, 3);
+        }
+        _ => {}
+    }
+}
+
+// ─── Filtering ───────────────────────────────────────────────────────────────
+
+/// Recompute `matches` from the current `query` and `index`. When `query` is
+/// empty we surface MRU first (alive paths only) and then the rest of the
+/// index in alphabetical order, so an empty palette is still useful. When
+/// `query` is non-empty we delegate to nucleo and sort by score desc, with
+/// shorter paths as a tiebreaker (keeps basename hits above deep-path hits).
+pub fn filter(state: &mut QuickOpenState) {
+    state.matches.clear();
+
+    if state.query.is_empty() {
+        let mut seen: HashSet<usize> = HashSet::new();
+        for path in &state.mru {
+            if let Some(idx) = state.index.iter().position(|c| &c.rel_path == path) {
+                state.matches.push(MatchEntry {
+                    idx,
+                    score: 0,
+                    indices: Vec::new(),
+                });
+                seen.insert(idx);
+            }
+        }
+        for idx in 0..state.index.len() {
+            if !seen.contains(&idx) {
+                state.matches.push(MatchEntry {
+                    idx,
+                    score: 0,
+                    indices: Vec::new(),
+                });
+            }
+        }
+    } else {
+        let mut matcher = Matcher::new(Config::DEFAULT);
+        let pattern = Pattern::parse(&state.query, CaseMatching::Smart, Normalization::Smart);
+        for (idx, cand) in state.index.iter().enumerate() {
+            let mut indices: Vec<u32> = Vec::new();
+            if let Some(score) = pattern.indices(cand.utf32.slice(..), &mut matcher, &mut indices) {
+                state.matches.push(MatchEntry {
+                    idx,
+                    score,
+                    indices,
+                });
+            }
+        }
+        // Primary: score desc. Tiebreak: shorter path (basename hits beat
+        // deep-path hits with the same score). Secondary tiebreak:
+        // lexicographic so the order is stable.
+        state.matches.sort_by(|a, b| {
+            b.score.cmp(&a.score).then_with(|| {
+                let la = state.index[a.idx].display.len();
+                let lb = state.index[b.idx].display.len();
+                la.cmp(&lb)
+                    .then_with(|| state.index[a.idx].display.cmp(&state.index[b.idx].display))
+            })
+        });
+    }
+
+    // Query change resets the viewport so the top match is visible.
+    state.selected = 0;
+    state.scroll = 0;
+}
+
+/// Mark the index as stale. Called from `App::tick` when fs-watcher fires —
+/// cheaper than re-walking the tree on every event, and if the user never
+/// opens the palette we never pay the walk cost at all.
+pub fn mark_stale(state: &mut QuickOpenState) {
+    state.index_stale = true;
+}
+
+// ─── Index construction ──────────────────────────────────────────────────────
+
+fn rebuild_index(root: &Path) -> Vec<Candidate> {
+    let mut out: Vec<Candidate> = Vec::new();
+
+    // `hidden(false)` so dotfiles (`.gitignore`, `.vimrc`, …) surface, which
+    // matches VSCode's Ctrl+P. We still need to prune `.git` itself — that's
+    // version-control metadata, not source you'd ever want to open through
+    // this palette. `filter_entry` prunes the whole subtree at the matching
+    // directory, so the walker never descends into it.
+    let walker = WalkBuilder::new(root)
+        .hidden(false)
+        .filter_entry(|dent| {
+            let name = dent.file_name();
+            name != ".git"
+        })
+        .build();
+
+    for result in walker {
+        let Ok(entry) = result else { continue };
+        let is_file = entry.file_type().map(|ft| ft.is_file()).unwrap_or(false);
+        if !is_file {
+            continue;
+        }
+        let Ok(rel) = entry.path().strip_prefix(root) else {
+            continue;
+        };
+        let display = rel.to_string_lossy().to_string();
+        if display.is_empty() {
+            continue;
+        }
+        let utf32 = Utf32String::from(display.as_str());
+        out.push(Candidate {
+            rel_path: rel.to_path_buf(),
+            display,
+            utf32,
+        });
+    }
+
+    out.sort_by(|a, b| a.display.cmp(&b.display));
+    out
+}
+
+// ─── MRU persistence ─────────────────────────────────────────────────────────
+
+fn load_mru_from_prefs() -> VecDeque<PathBuf> {
+    let Some(raw) = prefs::get(MRU_PREF_KEY) else {
+        return VecDeque::new();
+    };
+    raw.split(MRU_SEP)
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .collect()
+}
+
+fn save_mru_to_prefs(mru: &VecDeque<PathBuf>) {
+    // The prefs file uses `key=value\n` lines split via `split_once('=')` and
+    // per-line trim, so values mustn't contain `\n`, and we use `\t` as our
+    // in-value separator. Either character in a real path is pathological,
+    // but we replace them defensively so one weird path can't corrupt the
+    // whole prefs file.
+    let joined: String = mru
+        .iter()
+        .map(|p| p.to_string_lossy().replace(['\t', '\n'], " "))
+        .collect::<Vec<_>>()
+        .join(&MRU_SEP.to_string());
+    prefs::set(MRU_PREF_KEY, &joined);
+}
+
+// ─── Input helpers ───────────────────────────────────────────────────────────
+
+fn insert_char(state: &mut QuickOpenState, c: char) {
+    state.query.insert(state.cursor, c);
+    state.cursor += c.len_utf8();
+}
+
+fn backspace(state: &mut QuickOpenState) {
+    if state.cursor == 0 {
+        return;
+    }
+    let prev = prev_char_boundary(&state.query, state.cursor);
+    state.query.replace_range(prev..state.cursor, "");
+    state.cursor = prev;
+}
+
+/// Delete the word immediately before the cursor. A "word" here is a run of
+/// alphanumeric chars (plus `_`); any trailing non-word chars (whitespace,
+/// `/`, `.`, `-`) are swept up first so deleting `"src/ui/|"` once lands on
+/// `"src/"` — matching how readline / Alt+Backspace behave in most editors.
+/// No-op at the start of the query.
+fn delete_word_backward(state: &mut QuickOpenState) {
+    if state.cursor == 0 {
+        return;
+    }
+    // Walk backwards char-by-char, not byte-by-byte — the query can contain
+    // CJK, emoji, etc. once a user pastes a non-ASCII path component.
+    let chars: Vec<(usize, char)> = state.query[..state.cursor].char_indices().collect();
+    let mut i = chars.len();
+
+    // Phase 1: sweep trailing non-word chars. Without this `"src/ui/|"`
+    // would delete nothing visible on the first press (cursor sits on `/`).
+    while i > 0 && !is_word_char(chars[i - 1].1) {
+        i -= 1;
+    }
+    // Phase 2: swallow the word.
+    while i > 0 && is_word_char(chars[i - 1].1) {
+        i -= 1;
+    }
+
+    let start = chars.get(i).map(|&(b, _)| b).unwrap_or(0);
+    state.query.replace_range(start..state.cursor, "");
+    state.cursor = start;
+}
+
+fn is_word_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+/// Wipe the whole query and reset the cursor. Bound to Ctrl+U — readline's
+/// "kill to beginning" collapses to "clear everything" in a single-line
+/// input, which is the more useful operation for a palette.
+fn clear_query(state: &mut QuickOpenState) {
+    state.query.clear();
+    state.cursor = 0;
+}
+
+fn move_cursor(state: &mut QuickOpenState, delta: i32) {
+    if delta < 0 {
+        if state.cursor == 0 {
+            return;
+        }
+        state.cursor = prev_char_boundary(&state.query, state.cursor);
+    } else {
+        if state.cursor >= state.query.len() {
+            return;
+        }
+        state.cursor = next_char_boundary(&state.query, state.cursor);
+    }
+}
+
+fn move_selection(state: &mut QuickOpenState, delta: i32) {
+    if state.matches.is_empty() {
+        state.selected = 0;
+        return;
+    }
+    let last = state.matches.len() - 1;
+    let cur = state.selected as i32;
+    let next = (cur + delta).clamp(0, last as i32) as usize;
+    state.selected = next;
+}
+
+fn prev_char_boundary(s: &str, offset: usize) -> usize {
+    s[..offset]
+        .char_indices()
+        .last()
+        .map(|(i, _)| i)
+        .unwrap_or(0)
+}
+
+fn next_char_boundary(s: &str, offset: usize) -> usize {
+    s[offset..]
+        .chars()
+        .next()
+        .map(|c| offset + c.len_utf8())
+        .unwrap_or(offset)
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_state(paths: &[&str]) -> QuickOpenState {
+        let index = paths
+            .iter()
+            .map(|p| Candidate {
+                rel_path: PathBuf::from(p),
+                display: p.to_string(),
+                utf32: Utf32String::from(*p),
+            })
+            .collect();
+        QuickOpenState {
+            index,
+            index_stale: false,
+            ..QuickOpenState::default()
+        }
+    }
+
+    #[test]
+    fn empty_query_lists_all_with_mru_first() {
+        let mut s = mk_state(&["a/x.rs", "b/y.rs", "c/z.rs"]);
+        s.mru.push_back(PathBuf::from("c/z.rs"));
+        s.mru.push_back(PathBuf::from("a/x.rs"));
+        filter(&mut s);
+        assert_eq!(s.matches.len(), 3);
+        // MRU order first, then the rest
+        assert_eq!(s.index[s.matches[0].idx].display, "c/z.rs");
+        assert_eq!(s.index[s.matches[1].idx].display, "a/x.rs");
+        assert_eq!(s.index[s.matches[2].idx].display, "b/y.rs");
+    }
+
+    #[test]
+    fn empty_query_skips_mru_entries_that_no_longer_exist() {
+        let mut s = mk_state(&["a/x.rs", "b/y.rs"]);
+        s.mru.push_back(PathBuf::from("ghost.rs"));
+        s.mru.push_back(PathBuf::from("a/x.rs"));
+        filter(&mut s);
+        assert_eq!(s.matches.len(), 2);
+        assert_eq!(s.index[s.matches[0].idx].display, "a/x.rs");
+        assert_eq!(s.index[s.matches[1].idx].display, "b/y.rs");
+    }
+
+    #[test]
+    fn subsequence_match_hits_camelcase() {
+        let mut s = mk_state(&["src/ui/file_tree_panel.rs", "src/app.rs", "README.md"]);
+        s.query = "uiftp".to_string();
+        s.cursor = s.query.len();
+        filter(&mut s);
+        assert!(!s.matches.is_empty());
+        // The file_tree_panel path must rank first — it's the only one
+        // containing the subsequence.
+        assert_eq!(
+            s.index[s.matches[0].idx].display,
+            "src/ui/file_tree_panel.rs"
+        );
+    }
+
+    #[test]
+    fn shorter_path_wins_on_score_tie() {
+        let mut s = mk_state(&["deep/nested/foo.rs", "foo.rs"]);
+        s.query = "foo".to_string();
+        s.cursor = s.query.len();
+        filter(&mut s);
+        assert_eq!(s.index[s.matches[0].idx].display, "foo.rs");
+    }
+
+    #[test]
+    fn non_match_is_excluded_when_query_nonempty() {
+        let mut s = mk_state(&["alpha.rs", "beta.rs"]);
+        s.query = "zzz".to_string();
+        s.cursor = s.query.len();
+        filter(&mut s);
+        assert!(s.matches.is_empty());
+    }
+
+    #[test]
+    fn insert_and_backspace_roundtrip() {
+        let mut s = QuickOpenState::default();
+        insert_char(&mut s, 'h');
+        insert_char(&mut s, 'i');
+        assert_eq!(s.query, "hi");
+        assert_eq!(s.cursor, 2);
+        backspace(&mut s);
+        assert_eq!(s.query, "h");
+        assert_eq!(s.cursor, 1);
+    }
+
+    #[test]
+    fn backspace_at_start_is_noop() {
+        let mut s = QuickOpenState::default();
+        backspace(&mut s);
+        assert_eq!(s.query, "");
+        assert_eq!(s.cursor, 0);
+    }
+
+    #[test]
+    fn cursor_moves_respect_char_boundaries() {
+        let mut s = QuickOpenState::default();
+        s.query = "a你b".to_string();
+        s.cursor = s.query.len();
+        // back over 'b' (1 byte)
+        move_cursor(&mut s, -1);
+        assert_eq!(s.cursor, 4);
+        // back over '你' (3 bytes)
+        move_cursor(&mut s, -1);
+        assert_eq!(s.cursor, 1);
+        // forward over '你'
+        move_cursor(&mut s, 1);
+        assert_eq!(s.cursor, 4);
+    }
+
+    #[test]
+    fn move_selection_clamps() {
+        let mut s = mk_state(&["a.rs", "b.rs", "c.rs"]);
+        filter(&mut s);
+        move_selection(&mut s, 10);
+        assert_eq!(s.selected, 2);
+        move_selection(&mut s, -99);
+        assert_eq!(s.selected, 0);
+    }
+
+    #[test]
+    fn delete_word_backward_at_start_is_noop() {
+        let mut s = QuickOpenState::default();
+        delete_word_backward(&mut s);
+        assert_eq!(s.query, "");
+        assert_eq!(s.cursor, 0);
+    }
+
+    fn state_with(query: &str, cursor: usize) -> QuickOpenState {
+        QuickOpenState {
+            query: query.to_string(),
+            cursor,
+            ..QuickOpenState::default()
+        }
+    }
+
+    #[test]
+    fn delete_word_backward_consumes_one_word() {
+        let mut s = state_with("hello world", "hello world".len());
+        delete_word_backward(&mut s);
+        assert_eq!(s.query, "hello ");
+        assert_eq!(s.cursor, 6);
+    }
+
+    #[test]
+    fn delete_word_backward_sweeps_trailing_separators() {
+        // Path-like query: cursor sits after the trailing '/'. One press
+        // must kill the '/' AND the 'ui' word it delimits.
+        let mut s = state_with("src/ui/", "src/ui/".len());
+        delete_word_backward(&mut s);
+        assert_eq!(s.query, "src/");
+        assert_eq!(s.cursor, 4);
+    }
+
+    #[test]
+    fn delete_word_backward_handles_cjk() {
+        let mut s = state_with("测试 文件", "测试 文件".len());
+        delete_word_backward(&mut s);
+        assert_eq!(s.query, "测试 ");
+        // cursor lands at the byte position after the space
+        assert_eq!(s.cursor, "测试 ".len());
+    }
+
+    #[test]
+    fn delete_word_backward_respects_midquery_cursor() {
+        // Cursor in the middle of the string: only the word to the left of
+        // the cursor should vanish; text after the cursor is preserved.
+        let mut s = state_with("foo bar baz", 7); // right after "bar"
+        delete_word_backward(&mut s);
+        assert_eq!(s.query, "foo  baz");
+        assert_eq!(s.cursor, 4);
+    }
+
+    #[test]
+    fn clear_query_wipes_all() {
+        let mut s = state_with("anything", 4);
+        clear_query(&mut s);
+        assert_eq!(s.query, "");
+        assert_eq!(s.cursor, 0);
+    }
+
+    #[test]
+    fn rebuild_index_respects_gitignore_and_prunes_dotgit() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path();
+        // Seed files: a tracked source file, a dotfile (should surface), a
+        // gitignored build artefact (should be excluded), and a fake .git
+        // entry (must never appear).
+        std::fs::write(root.join("src.rs"), "fn main() {}").unwrap();
+        std::fs::write(root.join(".gitignore"), "target/\n").unwrap();
+        std::fs::create_dir(root.join("target")).unwrap();
+        std::fs::write(root.join("target/build.o"), "binary").unwrap();
+        std::fs::create_dir(root.join(".git")).unwrap();
+        std::fs::write(root.join(".git/HEAD"), "ref: refs/heads/main").unwrap();
+
+        let index = rebuild_index(root);
+        let displays: Vec<&str> = index.iter().map(|c| c.display.as_str()).collect();
+
+        assert!(displays.contains(&"src.rs"), "tracked source must appear");
+        assert!(
+            displays.contains(&".gitignore"),
+            "dotfiles must appear — hidden(false)"
+        );
+        assert!(
+            !displays.iter().any(|d| d.starts_with("target/")),
+            "gitignored target/ must be excluded"
+        );
+        assert!(
+            !displays.iter().any(|d| d.starts_with(".git/")),
+            ".git/ must never appear in the palette"
+        );
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,6 +7,7 @@ pub mod git_status_panel;
 pub mod highlight;
 pub mod hover;
 pub mod mouse;
+pub mod quick_open_panel;
 pub mod text;
 pub mod theme;
 pub mod toast;
@@ -81,6 +82,13 @@ pub fn render(f: &mut Frame, app: &mut App) {
 
     if app.show_help {
         render_help(f, app, size);
+    }
+
+    // Render last so the palette overlays help if both are somehow active
+    // (shouldn't happen in practice — opening one dismisses the other via
+    // input-priority — but the ordering here is a belt-and-braces guard).
+    if app.quick_open.active {
+        quick_open_panel::render(f, app, size);
     }
 }
 
@@ -430,6 +438,7 @@ fn render_help(f: &mut Frame, app: &App, screen: Rect) {
         ("r", t(Msg::HelpRefresh)),
         ("v", t(Msg::HelpSelectMode)),
         ("h", t(Msg::HelpShowHelp)),
+        ("Space p", t(Msg::HelpQuickOpen)),
         (t(Msg::HelpKeyAnyKey), t(Msg::HelpAnyKey)),
     ];
 

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -15,6 +15,12 @@ pub enum ClickAction {
     StartDragSplit,
     SwitchTab(Tab),
     TreeClick(usize),
+    /// Click on a row in the quick-open palette. The `usize` indexes
+    /// into `QuickOpenState.matches`. Double-click semantics (select +
+    /// accept) live in `input::handle_mouse` rather than here — the palette
+    /// owns mouse when active, so we don't round-trip through
+    /// `App::handle_action` for it.
+    QuickOpenSelect(usize),
     /// Invoke an inline Git panel command (`git.stage`, `git.selectCommit`, …).
     /// `dbl_command`/`dbl_args`, if present, are fired on double-click instead.
     GitCommand {

--- a/src/ui/quick_open_panel.rs
+++ b/src/ui/quick_open_panel.rs
@@ -1,0 +1,292 @@
+//! Quick-open palette overlay (bound to Space-P; see `crate::quick_open`).
+//!
+//! Rendered on top of the normal UI when `app.quick_open.active` is true.
+//! Three regions inside the popup: a single-row input line, a list of
+//! matches, and a right-aligned counter footer. The only state this panel
+//! writes back to `App` is `quick_open.last_view_h` (used by PageUp/PageDown
+//! step sizing) and `quick_open.scroll` (kept in sync with `selected`); the
+//! matching itself lives in `crate::quick_open`.
+//!
+//! Highlight strategy: nucleo reports `indices` as character positions in
+//! the full display path. We render the path as "basename + dir" — basename
+//! first, parent dir dimmed to the right — so indices need mapping to the
+//! correct segment. `build_row_line` does that mapping char-by-char so a
+//! query like "uiftp" lights up 'u', 'i', 'f', 't', 'p' across both the
+//! directory and basename columns.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Padding};
+use std::collections::HashSet;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::app::App;
+use crate::quick_open::{Candidate, MatchEntry};
+use crate::ui::mouse::ClickAction;
+use crate::ui::theme::Theme;
+
+pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
+    let th = app.theme;
+
+    let popup_w = 82u16.min(screen.width.saturating_sub(4).max(20));
+    let popup_h = 24u16.min(screen.height.saturating_sub(4).max(8));
+    let x = screen.x + screen.width.saturating_sub(popup_w) / 2;
+    let y = screen.y + screen.height.saturating_sub(popup_h) / 2;
+    let area = Rect::new(x, y, popup_w, popup_h);
+
+    // Stash bounds so `quick_open::handle_mouse` can decide "inside popup
+    // vs. click-away dismiss". Overwritten every frame so it stays in sync
+    // with terminal resizes.
+    app.quick_open.last_popup_area = Some(area);
+
+    f.render_widget(Clear, area);
+
+    let recent = app.quick_open.query.is_empty() && !app.quick_open.mru.is_empty();
+    let title = if recent {
+        " Quick Open · recent "
+    } else {
+        " Quick Open "
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(th.accent))
+        .title(Span::styled(
+            title,
+            Style::default()
+                .fg(th.fg_primary)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .padding(Padding::new(1, 1, 0, 0));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    if inner.height < 3 {
+        return;
+    }
+
+    let input_y = inner.y;
+    let sep_y = inner.y + 1;
+    let list_y = inner.y + 2;
+    // Reserve the last row for the footer when there's room; otherwise let
+    // the list use every available row. This mirrors how `render_help`
+    // degrades on tiny screens.
+    let has_footer = inner.height >= 5;
+    let list_h = if has_footer {
+        inner.height.saturating_sub(3)
+    } else {
+        inner.height.saturating_sub(2)
+    };
+    let footer_y = inner.y + inner.height.saturating_sub(1);
+
+    app.quick_open.last_view_h = list_h;
+
+    // ── Input row ──────────────────────────────────────────────────────
+    let prompt_spans = vec![
+        Span::styled(
+            "> ",
+            Style::default().fg(th.accent).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            app.quick_open.query.clone(),
+            Style::default().fg(th.fg_primary),
+        ),
+    ];
+    f.render_widget(
+        Line::from(prompt_spans),
+        Rect::new(inner.x, input_y, inner.width, 1),
+    );
+    // Blinking cursor — same trick `render_search_prompt` uses. Using
+    // UnicodeWidthStr so cursor lands between CJK/wide chars correctly.
+    let cursor_w = UnicodeWidthStr::width(&app.quick_open.query[..app.quick_open.cursor]) as u16;
+    let cursor_x = inner.x + 2 + cursor_w.min(inner.width.saturating_sub(3));
+    f.set_cursor_position((cursor_x, input_y));
+
+    // ── Separator row ──────────────────────────────────────────────────
+    f.render_widget(
+        Line::from(Span::styled(
+            "─".repeat(inner.width as usize),
+            Style::default().fg(th.border),
+        )),
+        Rect::new(inner.x, sep_y, inner.width, 1),
+    );
+
+    // ── List ───────────────────────────────────────────────────────────
+    if app.quick_open.matches.is_empty() {
+        let msg = if app.quick_open.query.is_empty() {
+            "Type to search files…"
+        } else {
+            "No matching files"
+        };
+        f.render_widget(
+            Line::from(Span::styled(
+                msg,
+                Style::default()
+                    .fg(th.fg_secondary)
+                    .add_modifier(Modifier::ITALIC),
+            )),
+            Rect::new(inner.x, list_y, inner.width, 1),
+        );
+    } else {
+        // Keep the selection in view. Same pattern as file_tree_panel — only
+        // adjust scroll when selection moved outside the window, so the user
+        // can scroll independently (Future: wire mouse wheel on popup).
+        let sel = app.quick_open.selected;
+        if sel < app.quick_open.scroll {
+            app.quick_open.scroll = sel;
+        } else if list_h > 0 && sel >= app.quick_open.scroll + list_h as usize {
+            app.quick_open.scroll = sel + 1 - list_h as usize;
+        }
+        let scroll = app.quick_open.scroll;
+
+        for row in 0..list_h as usize {
+            let match_idx = scroll + row;
+            let Some(m) = app.quick_open.matches.get(match_idx) else {
+                break;
+            };
+            let Some(cand) = app.quick_open.index.get(m.idx) else {
+                continue;
+            };
+            let is_sel = match_idx == sel;
+            let y = list_y + row as u16;
+            let line = build_row_line(cand, m, is_sel, inner.width, &th);
+            f.render_widget(line, Rect::new(inner.x, y, inner.width, 1));
+            // Register the row as a click zone. Registered after the
+            // underlying panels drew theirs, so `hit_test` (which scans
+            // in reverse) picks up the palette zone first on overlap.
+            app.hit_registry.register_row(
+                inner.x,
+                y,
+                inner.width,
+                ClickAction::QuickOpenSelect(match_idx),
+            );
+        }
+    }
+
+    // ── Footer (N/M counter) ───────────────────────────────────────────
+    if has_footer {
+        let cur = if app.quick_open.matches.is_empty() {
+            0
+        } else {
+            app.quick_open.selected + 1
+        };
+        let text = format!("{} / {}", cur, app.quick_open.matches.len());
+        let w = UnicodeWidthStr::width(text.as_str()) as u16;
+        let fx = inner.x + inner.width.saturating_sub(w);
+        f.render_widget(
+            Line::from(Span::styled(text, Style::default().fg(th.fg_secondary))),
+            Rect::new(fx, footer_y, w, 1),
+        );
+    }
+}
+
+/// Render one result row. Layout:
+/// `<bg> basename   dir/ <fill> `
+/// — basename bold, dir dim, matched chars in `indices` in accent color.
+/// The whole row gets `selection_bg` when selected.
+fn build_row_line(
+    cand: &Candidate,
+    m: &MatchEntry,
+    is_sel: bool,
+    width: u16,
+    th: &Theme,
+) -> Line<'static> {
+    let bg = if is_sel {
+        th.selection_bg
+    } else {
+        Color::Reset
+    };
+
+    let display = &cand.display;
+    // Byte offset where basename starts; also acts as "dir byte length".
+    let basename_start_byte = display.rfind('/').map(|i| i + 1).unwrap_or(0);
+    let basename = &display[basename_start_byte..];
+    let dir = &display[..basename_start_byte];
+    // Char count of the dir prefix; `indices` are char offsets into the
+    // full display so we need a char boundary, not the byte one.
+    let basename_start_char = display[..basename_start_byte].chars().count();
+
+    let basename_hl: HashSet<usize> = m
+        .indices
+        .iter()
+        .filter_map(|&i| {
+            let i = i as usize;
+            if i >= basename_start_char {
+                Some(i - basename_start_char)
+            } else {
+                None
+            }
+        })
+        .collect();
+    let dir_hl: HashSet<usize> = m
+        .indices
+        .iter()
+        .filter_map(|&i| {
+            let i = i as usize;
+            if i < basename_start_char {
+                Some(i)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let basename_base = Style::default()
+        .fg(th.fg_primary)
+        .bg(bg)
+        .add_modifier(Modifier::BOLD);
+    let dir_base = Style::default().fg(th.fg_secondary).bg(bg);
+    let hl_bg = if is_sel {
+        th.search_current
+    } else {
+        th.search_match
+    };
+    let hl = Style::default()
+        .fg(th.fg_primary)
+        .bg(hl_bg)
+        .add_modifier(Modifier::BOLD);
+
+    let mut spans: Vec<Span<'static>> = Vec::new();
+
+    // Leading single-space so the selection bar doesn't hug the border.
+    spans.push(Span::styled(" ".to_string(), Style::default().bg(bg)));
+
+    // Basename, char-by-char so we can apply per-char highlight style.
+    let mut basename_w: usize = 0;
+    for (ci, c) in basename.chars().enumerate() {
+        let style = if basename_hl.contains(&ci) {
+            hl
+        } else {
+            basename_base
+        };
+        spans.push(Span::styled(c.to_string(), style));
+        basename_w += UnicodeWidthChar::width(c).unwrap_or(0);
+    }
+
+    // Pad basename column to ~40 cols (or narrower on small screens) so the
+    // dir column visually aligns across rows.
+    let name_col: usize = (width as usize).saturating_sub(10).clamp(10, 40);
+    let used = 1 + basename_w;
+    let pad = name_col.saturating_sub(used) + 2; // +2: always have a gap
+    spans.push(Span::styled(" ".repeat(pad), Style::default().bg(bg)));
+
+    // Dir, char-by-char for matching char highlight.
+    let mut dir_w: usize = 0;
+    for (ci, c) in dir.chars().enumerate() {
+        let style = if dir_hl.contains(&ci) { hl } else { dir_base };
+        spans.push(Span::styled(c.to_string(), style));
+        dir_w += UnicodeWidthChar::width(c).unwrap_or(0);
+    }
+
+    // Trailing fill so the selection bg reaches the right edge.
+    let used_total = used + pad + dir_w;
+    let fill = (width as usize).saturating_sub(used_total);
+    if fill > 0 {
+        spans.push(Span::styled(" ".repeat(fill), Style::default().bg(bg)));
+    }
+
+    Line::from(spans)
+}


### PR DESCRIPTION
## Summary

- Adds a VSCode-style quick-open overlay bound to `Space p`. Fuzzy file matching via `nucleo-matcher`, `.gitignore`-aware walk via `ignore::WalkBuilder`, matched chars highlighted on a basename-first row layout.
- Persists a move-to-front MRU of opened paths in `~/.config/reef/prefs` (`quickopen.mru`), capped at 50; surfaced first on empty-query opens.
- On Enter, switches to the Files tab, expands ancestors via a new `FileTree::reveal`, and loads the preview — no external `$EDITOR` round-trip.

## UX

- **Open / toggle close**: `Space p` chord (global when closed; also closes when palette is open with an empty query). Implemented as a pure `leader_decision` fn reused by both sides.
- **Input editing**: `Backspace`, `Alt+Backspace` / `Ctrl+Backspace` / `Ctrl+W` (delete word — sweeps trailing `/ . -` etc. first), `Ctrl+U` (clear).
- **Navigation**: `Up`/`Down`, `Ctrl+N`/`Ctrl+P`, `Ctrl+J`/`Ctrl+K`, `PageUp`/`PageDown`, `Home`/`End`/`Left`/`Right` for the input cursor.
- **Mouse**: single-click selects, double-click accepts, scroll wheel moves selection; clicking outside the popup dismisses. Clicks through the overlay are blocked from leaking to underlying panels.
- **Accept**: `Enter` commits; `Esc` / `Ctrl+C` cancel.

## Architecture notes

- New module `src/quick_open.rs` holds state, fuzzy filter, MRU, and handlers. Rendering is a new `src/ui/quick_open_panel.rs`, mirroring reef's per-panel file split.
- `App.quick_open` + `App.space_leader_at` added; palette also owns its own `space_leader_at` so cross-mode transitions can't leak leader state.
- `ClickAction::QuickOpenSelect(usize)` added; palette rows registered via `hit_registry` after the underlying panels so `hit_test`'s reverse scan picks the overlay first.
- Help popup gets a `Space p` entry; `src/prefs.rs` doc header calls out the new `quickopen.mru` key.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets` clean
- [x] `cargo test --lib` green (141 tests — +26 new across quick_open, leader_decision)
  - filter: MRU ordering / ghost-path skip / subsequence CamelCase hit / short-path-wins tiebreak
  - input edit: insert + backspace, CJK cursor boundaries, word-delete (path sep sweep, CJK, mid-cursor), clear-all
  - index walk: `.gitignore` respected, `.git/` pruned, dotfiles surface
  - leader: arm / fire / expired / re-arm on double-Space / Shift+Space ignored / Ctrl+P not swallowed
- [x] `cargo build --release` clean
- [ ] Manual smoke: press `Space p`, fuzzy-search a file, Enter opens preview; re-press `Space p` on empty query closes; click outside dismisses; double-click accepts
- [ ] Manual: MRU persists across restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)