### PR TITLE
perf: decouple rendering from heavy background work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 node_modules
 .claude
+.codex/
 npm/**/bin/reef
 npm/**/bin/reef.exe
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,14 +1,15 @@
-use crate::file_tree::{self, FileTree, PreviewContent};
+use crate::file_tree::{FileTree, PreviewContent};
 use crate::fs_watcher;
 use crate::git::graph::GraphRow;
 use crate::git::{CommitDetail, DiffContent, FileEntry, GitRepo, RefLabel};
+use crate::tasks::{AsyncState, TaskCoordinator, WorkerResult};
 use crate::ui::mouse::{ClickAction, HitTestRegistry};
 use crate::ui::theme::Theme;
 use crate::ui::toast::Toast;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::mpsc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Tab {
@@ -63,6 +64,7 @@ pub struct GitStatusState {
     /// ephemeral.
     pub push_error: Option<String>,
     pub scroll: usize,
+    pub ahead_behind: Option<(usize, usize)>,
 }
 
 /// State for the inline commit graph sidebar.
@@ -117,6 +119,8 @@ impl Default for CommitDetailState {
 
 pub struct App {
     pub repo: Option<GitRepo>,
+    pub workdir_name: String,
+    pub branch_name: String,
 
     // Tab
     pub active_tab: Tab,
@@ -211,6 +215,18 @@ pub struct App {
     pub last_preview_view_h: u16,
     pub last_diff_view_h: u16,
     pub last_commit_detail_view_h: u16,
+
+    // ── Background work state ──
+    pub tasks: TaskCoordinator,
+    pub file_tree_load: AsyncState,
+    pub preview_load: AsyncState,
+    pub git_status_load: AsyncState,
+    pub diff_load: AsyncState,
+    pub graph_load: AsyncState,
+    pub commit_detail_load: AsyncState,
+    pub commit_file_diff_load: AsyncState,
+    next_git_revalidate_at: Instant,
+    next_graph_revalidate_at: Instant,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -235,11 +251,26 @@ impl App {
             .as_ref()
             .and_then(|r| r.workdir_path())
             .unwrap_or_else(|| PathBuf::from("."));
+        let workdir_name = repo
+            .as_ref()
+            .map(|r| r.workdir_name())
+            .or_else(|| {
+                workdir
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(String::from)
+            })
+            .unwrap_or_else(|| "repo".to_string());
+        let branch_name = repo.as_ref().map(|r| r.branch_name()).unwrap_or_default();
         let file_tree = FileTree::new(&workdir);
         let fs_watcher_rx = Some(fs_watcher::spawn(workdir.clone()));
         let (saved_layout, saved_mode) = load_prefs();
+        let tasks = TaskCoordinator::new();
+        let now = Instant::now();
         let mut app = Self {
             repo,
+            workdir_name,
+            branch_name,
             active_tab: Tab::Files,
             active_panel: Panel::Files,
             staged_files: Vec::new(),
@@ -297,67 +328,64 @@ impl App {
             last_preview_view_h: 0,
             last_diff_view_h: 0,
             last_commit_detail_view_h: 0,
+            tasks,
+            file_tree_load: AsyncState::default(),
+            preview_load: AsyncState::default(),
+            git_status_load: AsyncState::default(),
+            diff_load: AsyncState::default(),
+            graph_load: AsyncState::default(),
+            commit_detail_load: AsyncState::default(),
+            commit_file_diff_load: AsyncState::default(),
+            next_git_revalidate_at: now + Duration::from_millis(800),
+            next_graph_revalidate_at: now + Duration::from_millis(1200),
         };
         app.refresh_status();
         app
     }
 
     pub fn refresh_status(&mut self) {
-        let Some(ref repo) = self.repo else {
+        if self.repo.is_none() {
             return;
         };
-        let (staged, unstaged) = repo.get_status();
-        self.staged_files = staged;
-        self.unstaged_files = unstaged;
-
-        self.file_tree
-            .refresh_git_statuses(&self.staged_files, &self.unstaged_files);
-
-        // Reconcile selection: check both lists so is_staged stays correct
-        // if the file has just moved between sections (e.g. an fs-watcher
-        // refresh after an external `git add`).
-        if let Some(ref mut sel) = self.selected_file {
-            let in_staged = self.staged_files.iter().any(|f| f.path == sel.path);
-            let in_unstaged = self.unstaged_files.iter().any(|f| f.path == sel.path);
-            if in_staged {
-                sel.is_staged = true;
-            } else if in_unstaged {
-                sel.is_staged = false;
-            } else {
-                self.selected_file = None;
-                self.diff_content = None;
-            }
-        }
+        let generation = self.git_status_load.begin();
+        self.tasks
+            .refresh_status(generation, self.file_tree.root.clone());
     }
 
     /// Rebuild the file tree from disk, applying git decorations when a repo is open.
     /// Safe to call on any workdir — `refresh_status` handles repo/no-repo internally.
     pub fn refresh_file_tree(&mut self) {
-        if self.repo.is_some() {
-            self.refresh_status();
-        } else {
-            self.file_tree.rebuild();
-        }
+        self.refresh_file_tree_with_target(self.file_tree.selected_path());
+    }
+
+    pub fn refresh_file_tree_with_target(&mut self, selected_path: Option<PathBuf>) {
+        let generation = self.file_tree_load.begin();
+        self.tasks.rebuild_tree(
+            generation,
+            self.file_tree.root.clone(),
+            self.file_tree.expanded_paths(),
+            self.file_tree.git_statuses(),
+            selected_path,
+            self.file_tree.selected,
+        );
     }
 
     pub fn load_preview(&mut self) {
         if let Some(entry) = self.file_tree.selected_entry() {
             if !entry.is_dir {
-                let new_content =
-                    file_tree::load_preview(&self.file_tree.root, &entry.path, self.theme.is_dark);
-                // Preserve scroll when reloading the same file (fs-watcher refresh);
-                // reset only when the selected path actually changed (navigation).
-                let same_file = matches!(
-                    (self.preview_content.as_ref(), new_content.as_ref()),
-                    (Some(old), Some(new)) if old.file_path == new.file_path
-                );
-                self.preview_content = new_content;
-                if !same_file {
-                    self.preview_scroll = 0;
-                    self.preview_h_scroll = 0;
-                }
+                self.load_preview_for_path(entry.path.clone());
             }
         }
+    }
+
+    pub fn load_preview_for_path(&mut self, rel_path: PathBuf) {
+        let generation = self.preview_load.begin();
+        self.tasks.load_preview(
+            generation,
+            self.file_tree.root.clone(),
+            rel_path,
+            self.theme.is_dark,
+        );
     }
 
     pub fn select_file(&mut self, path: &str, is_staged: bool) {
@@ -371,16 +399,26 @@ impl App {
     }
 
     pub fn load_diff(&mut self) {
-        let diff = if let (Some(repo), Some(sel)) = (&self.repo, &self.selected_file) {
-            let context = match self.diff_mode {
-                DiffMode::FullFile => 9999,
-                DiffMode::Compact => 3,
-            };
-            repo.get_diff(&sel.path, sel.is_staged, context)
-        } else {
-            None
+        let Some(sel) = self.selected_file.clone() else {
+            self.diff_content = None;
+            return;
         };
-        self.diff_content = diff;
+        if self.repo.is_none() {
+            self.diff_content = None;
+            return;
+        }
+        let context = match self.diff_mode {
+            DiffMode::FullFile => 9999,
+            DiffMode::Compact => 3,
+        };
+        let generation = self.diff_load.begin();
+        self.tasks.load_diff(
+            generation,
+            self.file_tree.root.clone(),
+            sel.path,
+            sel.is_staged,
+            context,
+        );
     }
 
     pub fn toggle_diff_layout(&mut self) {
@@ -498,48 +536,32 @@ impl App {
     /// Working-tree fs events do NOT invalidate the cache — see plan pitfall #2.
     pub fn refresh_graph(&mut self) {
         const GRAPH_COMMIT_LIMIT: usize = 500;
-        let Some(ref repo) = self.repo else {
+        if self.repo.is_none() {
             self.git_graph.rows.clear();
             self.git_graph.ref_map.clear();
             self.git_graph.cache_key = None;
             return;
         };
-
-        let head = repo.head_oid().unwrap_or_default();
-        let refs = repo.list_refs();
-        let refs_hash = hash_ref_map(&refs);
-        let key = (head, refs_hash);
-
-        if self.git_graph.cache_key.as_ref() == Some(&key) {
-            return;
-        }
-
-        let commits = repo.list_commits(GRAPH_COMMIT_LIMIT);
-        let rows = crate::git::graph::build_graph(&commits);
-
-        // Clamp selection if the graph got shorter (e.g. reset --hard).
-        if self.git_graph.selected_idx >= rows.len() {
-            self.git_graph.selected_idx = rows.len().saturating_sub(1);
-        }
-        self.git_graph.selected_commit = rows
-            .get(self.git_graph.selected_idx)
-            .map(|r| r.commit.oid.clone());
-
-        self.git_graph.rows = rows;
-        self.git_graph.ref_map = refs;
-        self.git_graph.cache_key = Some(key);
-
-        self.load_commit_detail();
+        let generation = self.graph_load.begin();
+        self.tasks
+            .refresh_graph(generation, self.file_tree.root.clone(), GRAPH_COMMIT_LIMIT);
     }
 
     /// (Re)load commit detail for the currently-selected commit. Clears detail
     /// and any previously-selected file diff whenever the target changes.
     pub fn load_commit_detail(&mut self) {
-        self.commit_detail.detail = match (&self.repo, &self.git_graph.selected_commit) {
-            (Some(repo), Some(oid)) => repo.get_commit(oid),
-            _ => None,
-        };
         self.commit_detail.file_diff = None;
+        let Some(oid) = self.git_graph.selected_commit.clone() else {
+            self.commit_detail.detail = None;
+            return;
+        };
+        if self.repo.is_none() {
+            self.commit_detail.detail = None;
+            return;
+        }
+        let generation = self.commit_detail_load.begin();
+        self.tasks
+            .load_commit_detail(generation, self.file_tree.root.clone(), oid);
     }
 
     /// Load the inline diff for a file inside the currently-selected commit.
@@ -548,12 +570,22 @@ impl App {
             DiffMode::Compact => 3,
             DiffMode::FullFile => 9999,
         };
-        self.commit_detail.file_diff = match (&self.repo, &self.git_graph.selected_commit) {
-            (Some(repo), Some(oid)) => repo
-                .get_commit_file_diff(oid, path, context)
-                .map(|d| (path.to_string(), d)),
-            _ => None,
+        let Some(oid) = self.git_graph.selected_commit.clone() else {
+            self.commit_detail.file_diff = None;
+            return;
         };
+        if self.repo.is_none() {
+            self.commit_detail.file_diff = None;
+            return;
+        }
+        let generation = self.commit_file_diff_load.begin();
+        self.tasks.load_commit_file_diff(
+            generation,
+            self.file_tree.root.clone(),
+            oid,
+            path.to_string(),
+            context,
+        );
     }
 
     /// Reload the currently-selected commit-file diff — used after toggling
@@ -642,10 +674,11 @@ impl App {
                             .push(Toast::error(crate::i18n::push_failed_toast(&e)));
                     }
                 }
-                // Push advances remote-tracking refs — invalidate the graph
-                // cache so Tab::Graph rebuilds on its next render.
+                // Push advances remote-tracking refs — mark git/graph data
+                // stale so the coordinator refreshes it off the render path.
                 self.git_graph.cache_key = None;
-                self.refresh_status();
+                self.git_status_load.mark_stale();
+                self.graph_load.mark_stale();
             }
             Err(TryRecvError::Empty) => {
                 // Worker still running. Check again next tick.
@@ -663,16 +696,212 @@ impl App {
         }
     }
 
+    fn drain_task_results(&mut self) {
+        use std::sync::mpsc::TryRecvError;
+        loop {
+            match self.tasks.try_recv() {
+                Ok(result) => self.apply_worker_result(result),
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => break,
+            }
+        }
+    }
+
+    fn apply_worker_result(&mut self, result: WorkerResult) {
+        match result {
+            WorkerResult::FileTree { generation, result } => match result {
+                Ok(payload) => {
+                    if self.file_tree_load.complete_ok(generation) {
+                        let before = self.file_tree.selected_path();
+                        self.file_tree
+                            .replace_entries(payload.entries, payload.selected_idx);
+                        self.file_tree
+                            .refresh_git_statuses(&self.staged_files, &self.unstaged_files);
+                        if before != self.file_tree.selected_path() {
+                            self.load_preview();
+                        }
+                    }
+                }
+                Err(error) => {
+                    self.file_tree_load.complete_err(generation, error);
+                }
+            },
+            WorkerResult::Preview { generation, result } => match result {
+                Ok(content) => {
+                    if self.preview_load.complete_ok(generation) {
+                        let same_file = matches!(
+                            (self.preview_content.as_ref(), content.as_ref()),
+                            (Some(old), Some(new)) if old.file_path == new.file_path
+                        );
+                        self.preview_content = content;
+                        if !same_file {
+                            self.preview_scroll = 0;
+                            self.preview_h_scroll = 0;
+                        }
+                    }
+                }
+                Err(error) => {
+                    self.preview_load.complete_err(generation, error);
+                }
+            },
+            WorkerResult::GitStatus { generation, result } => match result {
+                Ok(payload) => {
+                    if self.git_status_load.complete_ok(generation) {
+                        let before = self.selected_file.clone();
+                        self.staged_files = payload.staged;
+                        self.unstaged_files = payload.unstaged;
+                        self.git_status.ahead_behind = payload.ahead_behind;
+                        self.branch_name = payload.branch_name;
+
+                        self.file_tree
+                            .refresh_git_statuses(&self.staged_files, &self.unstaged_files);
+
+                        if let Some(ref mut sel) = self.selected_file {
+                            let in_staged = self.staged_files.iter().any(|f| f.path == sel.path);
+                            let in_unstaged =
+                                self.unstaged_files.iter().any(|f| f.path == sel.path);
+                            if in_staged {
+                                sel.is_staged = true;
+                            } else if in_unstaged {
+                                sel.is_staged = false;
+                            } else {
+                                self.selected_file = None;
+                                self.diff_content = None;
+                            }
+                        }
+                        if before != self.selected_file {
+                            self.load_diff();
+                        }
+                    }
+                }
+                Err(error) => {
+                    self.git_status_load.complete_err(generation, error);
+                }
+            },
+            WorkerResult::Diff { generation, result } => match result {
+                Ok(diff) => {
+                    if self.diff_load.complete_ok(generation) {
+                        self.diff_content = diff;
+                    }
+                }
+                Err(error) => {
+                    self.diff_load.complete_err(generation, error);
+                }
+            },
+            WorkerResult::Graph { generation, result } => match result {
+                Ok(payload) => {
+                    if self.graph_load.complete_ok(generation) {
+                        let previous_commit = self.git_graph.selected_commit.clone();
+                        self.git_graph.rows = payload.rows;
+                        self.git_graph.ref_map = payload.ref_map;
+                        self.git_graph.cache_key = Some(payload.cache_key);
+
+                        if let Some(ref oid) = previous_commit {
+                            if let Some(idx) = self
+                                .git_graph
+                                .rows
+                                .iter()
+                                .position(|r| r.commit.oid == *oid)
+                            {
+                                self.git_graph.selected_idx = idx;
+                            }
+                        }
+                        if self.git_graph.selected_idx >= self.git_graph.rows.len() {
+                            self.git_graph.selected_idx =
+                                self.git_graph.rows.len().saturating_sub(1);
+                        }
+                        self.git_graph.selected_commit = self
+                            .git_graph
+                            .rows
+                            .get(self.git_graph.selected_idx)
+                            .map(|r| r.commit.oid.clone());
+
+                        if self.git_graph.selected_commit != previous_commit
+                            || self.commit_detail.detail.is_none()
+                        {
+                            self.load_commit_detail();
+                        }
+                    }
+                }
+                Err(error) => {
+                    self.graph_load.complete_err(generation, error);
+                }
+            },
+            WorkerResult::CommitDetail { generation, result } => match result {
+                Ok(detail) => {
+                    if self.commit_detail_load.complete_ok(generation) {
+                        self.commit_detail.detail = detail;
+                    }
+                }
+                Err(error) => {
+                    self.commit_detail_load.complete_err(generation, error);
+                }
+            },
+            WorkerResult::CommitFileDiff { generation, result } => match result {
+                Ok(file_diff) => {
+                    if self.commit_file_diff_load.complete_ok(generation) {
+                        self.commit_detail.file_diff = file_diff;
+                    }
+                }
+                Err(error) => {
+                    self.commit_file_diff_load.complete_err(generation, error);
+                }
+            },
+        }
+    }
+
+    pub fn set_active_tab(&mut self, tab: Tab) {
+        if self.active_tab == tab {
+            return;
+        }
+        self.active_tab = tab;
+        match tab {
+            Tab::Git => self.git_status_load.mark_stale(),
+            Tab::Graph => self.graph_load.mark_stale(),
+            Tab::Files => {
+                if self.file_tree.entries.is_empty() {
+                    self.file_tree_load.mark_stale();
+                }
+            }
+        }
+    }
+
+    pub fn activity_message(&self) -> Option<String> {
+        fn from_state(label: &str, state: &AsyncState) -> Option<String> {
+            if state.loading {
+                Some(format!("{label} refreshing…"))
+            } else if let Some(error) = state.error.as_ref() {
+                Some(format!("{label} error: {error}"))
+            } else if state.stale {
+                Some(format!("{label} stale"))
+            } else {
+                None
+            }
+        }
+
+        match self.active_tab {
+            Tab::Files => from_state("files", &self.file_tree_load)
+                .or_else(|| from_state("preview", &self.preview_load)),
+            Tab::Git => from_state("git", &self.git_status_load)
+                .or_else(|| from_state("diff", &self.diff_load)),
+            Tab::Graph => from_state("graph", &self.graph_load)
+                .or_else(|| from_state("commit", &self.commit_detail_load))
+                .or_else(|| from_state("commit diff", &self.commit_file_diff_load)),
+        }
+    }
+
     pub fn handle_action(&mut self, action: ClickAction) {
         match action {
             ClickAction::SwitchTab(tab) => {
-                self.active_tab = tab;
+                self.set_active_tab(tab);
             }
             ClickAction::TreeClick(index) => {
                 self.file_tree.selected = index;
                 if let Some(entry) = self.file_tree.entries.get(index) {
                     if entry.is_dir {
                         self.file_tree.toggle_expand(index);
+                        let selected_path = self.file_tree.selected_path();
+                        self.refresh_file_tree_with_target(selected_path);
                     } else {
                         self.load_preview();
                     }
@@ -785,6 +1014,8 @@ impl App {
     /// HEAD or refs, so the commit graph stays valid (see plan pitfall #2).
     /// Push completion handles its own cache_key bust separately.
     pub fn tick(&mut self) {
+        self.drain_task_results();
+
         let mut fs_dirty = false;
         if let Some(rx) = self.fs_watcher_rx.as_ref() {
             while rx.try_recv().is_ok() {
@@ -792,9 +1023,10 @@ impl App {
             }
         }
         if fs_dirty {
-            self.refresh_file_tree();
-            self.load_preview();
-            self.load_diff();
+            self.file_tree_load.mark_stale();
+            self.preview_load.mark_stale();
+            self.diff_load.mark_stale();
+            self.git_status_load.mark_stale();
             // Mark the quick-open index stale so the next palette open picks up
             // the new/deleted files. Rebuilding immediately on every fs
             // event would be wasteful for a palette the user may not open.
@@ -802,6 +1034,54 @@ impl App {
         }
 
         self.drain_push_result();
+        self.kick_active_tab_work();
+        self.drain_task_results();
+    }
+
+    fn kick_active_tab_work(&mut self) {
+        let now = Instant::now();
+
+        if self.file_tree_load.should_request() {
+            self.refresh_file_tree();
+        }
+
+        match self.active_tab {
+            Tab::Files => {
+                if self.preview_load.should_request() {
+                    self.load_preview();
+                }
+            }
+            Tab::Git => {
+                let should_poll_git = self.repo.is_some() && now >= self.next_git_revalidate_at;
+                if self.git_status_load.should_request()
+                    || (should_poll_git && !self.git_status_load.loading)
+                {
+                    self.refresh_status();
+                    self.next_git_revalidate_at = now + Duration::from_secs(2);
+                }
+                if self.diff_load.should_request() {
+                    self.load_diff();
+                }
+            }
+            Tab::Graph => {
+                let should_poll_graph = self.repo.is_some() && now >= self.next_graph_revalidate_at;
+                if self.graph_load.should_request()
+                    || (self.repo.is_some()
+                        && self.git_graph.rows.is_empty()
+                        && !self.graph_load.loading)
+                    || (should_poll_graph && !self.graph_load.loading)
+                {
+                    self.refresh_graph();
+                    self.next_graph_revalidate_at = now + Duration::from_secs(5);
+                }
+                if self.commit_detail_load.should_request() {
+                    self.load_commit_detail();
+                }
+                if self.commit_file_diff_load.should_request() {
+                    self.reload_commit_file_diff();
+                }
+            }
+        }
     }
 }
 
@@ -822,35 +1102,6 @@ fn load_prefs() -> (DiffLayout, DiffMode) {
         _ => DiffMode::Compact,
     };
     (layout, mode)
-}
-
-/// Stable hash of the ref map — used as part of the graph cache key.
-fn hash_ref_map(map: &HashMap<String, Vec<RefLabel>>) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut entries: Vec<(&String, &Vec<RefLabel>)> = map.iter().collect();
-    entries.sort_by(|a, b| a.0.cmp(b.0));
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    for (oid, labels) in entries {
-        oid.hash(&mut hasher);
-        for label in labels {
-            match label {
-                RefLabel::Head => 0u8.hash(&mut hasher),
-                RefLabel::Branch(s) => {
-                    1u8.hash(&mut hasher);
-                    s.hash(&mut hasher);
-                }
-                RefLabel::RemoteBranch(s) => {
-                    2u8.hash(&mut hasher);
-                    s.hash(&mut hasher);
-                }
-                RefLabel::Tag(s) => {
-                    3u8.hash(&mut hasher);
-                    s.hash(&mut hasher);
-                }
-            }
-        }
-    }
-    hasher.finish()
 }
 
 fn save_prefs(layout: DiffLayout, mode: DiffMode) {

--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 /// A visible entry in the flattened file tree.
@@ -13,6 +13,7 @@ pub struct TreeEntry {
 }
 
 /// File preview content.
+#[derive(Debug)]
 pub struct PreviewContent {
     pub file_path: String,
     pub lines: Vec<String>,
@@ -26,7 +27,7 @@ pub struct FileTree {
     pub entries: Vec<TreeEntry>,
     pub selected: usize,
     expanded: HashSet<PathBuf>,
-    git_statuses: std::collections::HashMap<String, char>,
+    git_statuses: HashMap<String, char>,
 }
 
 impl FileTree {
@@ -36,7 +37,7 @@ impl FileTree {
             entries: Vec::new(),
             selected: 0,
             expanded: HashSet::new(),
-            git_statuses: std::collections::HashMap::new(),
+            git_statuses: HashMap::new(),
         };
         tree.rebuild();
         tree
@@ -44,62 +45,12 @@ impl FileTree {
 
     /// Regenerate the flat entries list from the filesystem.
     pub fn rebuild(&mut self) {
-        self.entries.clear();
-        self.walk_dir(&self.root.clone(), 0);
+        self.entries = build_entries(&self.root, &self.expanded, &self.git_statuses);
         // Clamp selection
         if !self.entries.is_empty() {
             self.selected = self.selected.min(self.entries.len() - 1);
         } else {
             self.selected = 0;
-        }
-    }
-
-    fn walk_dir(&mut self, dir: &Path, depth: usize) {
-        let mut children: Vec<(String, PathBuf, bool)> = Vec::new();
-
-        let entries = match std::fs::read_dir(dir) {
-            Ok(e) => e,
-            Err(_) => return,
-        };
-
-        for entry in entries.flatten() {
-            let name = entry.file_name().to_string_lossy().to_string();
-            if name == ".git" {
-                continue;
-            }
-            let path = entry.path();
-            let is_dir = path.is_dir();
-            children.push((name, path, is_dir));
-        }
-
-        // Sort: directories first, then files, alphabetically
-        children.sort_by(|a, b| match (a.2, b.2) {
-            (true, false) => std::cmp::Ordering::Less,
-            (false, true) => std::cmp::Ordering::Greater,
-            _ => a.0.to_lowercase().cmp(&b.0.to_lowercase()),
-        });
-
-        for (name, full_path, is_dir) in children {
-            let rel = full_path
-                .strip_prefix(&self.root)
-                .unwrap_or(&full_path)
-                .to_path_buf();
-            let rel_str = rel.to_string_lossy().to_string();
-            let is_expanded = is_dir && self.expanded.contains(&rel);
-            let git_status = self.git_statuses.get(&rel_str).copied();
-
-            self.entries.push(TreeEntry {
-                path: rel,
-                name,
-                depth,
-                is_dir,
-                is_expanded,
-                git_status,
-            });
-
-            if is_dir && is_expanded {
-                self.walk_dir(&full_path, depth + 1);
-            }
         }
     }
 
@@ -112,7 +63,6 @@ impl FileTree {
                 } else {
                     self.expanded.insert(path);
                 }
-                self.rebuild();
             }
         }
     }
@@ -132,6 +82,27 @@ impl FileTree {
         self.entries.get(self.selected)
     }
 
+    pub fn selected_path(&self) -> Option<PathBuf> {
+        self.selected_entry().map(|entry| entry.path.clone())
+    }
+
+    pub fn expanded_paths(&self) -> Vec<PathBuf> {
+        self.expanded.iter().cloned().collect()
+    }
+
+    pub fn git_statuses(&self) -> HashMap<String, char> {
+        self.git_statuses.clone()
+    }
+
+    pub fn replace_entries(&mut self, entries: Vec<TreeEntry>, selected_idx: usize) {
+        self.entries = entries;
+        if self.entries.is_empty() {
+            self.selected = 0;
+        } else {
+            self.selected = selected_idx.min(self.entries.len() - 1);
+        }
+    }
+
     /// Expand every ancestor directory of `rel` and move `selected` to the
     /// row that displays `rel` in the flattened tree. Used by the quick-open
     /// palette on accept, so the chosen file is visible and the preview
@@ -144,7 +115,6 @@ impl FileTree {
             }
             self.expanded.insert(ancestor.to_path_buf());
         }
-        self.rebuild();
         if let Some(idx) = self.entries.iter().position(|e| e.path == rel) {
             self.selected = idx;
         }
@@ -179,7 +149,79 @@ impl FileTree {
                 self.git_statuses.entry(a).or_insert('●');
             }
         }
-        self.rebuild();
+        self.apply_git_statuses_to_entries();
+    }
+
+    fn apply_git_statuses_to_entries(&mut self) {
+        for entry in &mut self.entries {
+            let rel = entry.path.to_string_lossy().to_string();
+            entry.git_status = self.git_statuses.get(&rel).copied();
+        }
+    }
+}
+
+pub fn build_entries(
+    root: &Path,
+    expanded: &HashSet<PathBuf>,
+    git_statuses: &HashMap<String, char>,
+) -> Vec<TreeEntry> {
+    let mut entries = Vec::new();
+    walk_dir(root, root, expanded, git_statuses, &mut entries, 0);
+    entries
+}
+
+fn walk_dir(
+    root: &Path,
+    dir: &Path,
+    expanded: &HashSet<PathBuf>,
+    git_statuses: &HashMap<String, char>,
+    out: &mut Vec<TreeEntry>,
+    depth: usize,
+) {
+    let mut children: Vec<(String, PathBuf, bool)> = Vec::new();
+
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name == ".git" {
+            continue;
+        }
+        let path = entry.path();
+        let is_dir = path.is_dir();
+        children.push((name, path, is_dir));
+    }
+
+    children.sort_by(|a, b| match (a.2, b.2) {
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        _ => a.0.to_lowercase().cmp(&b.0.to_lowercase()),
+    });
+
+    for (name, full_path, is_dir) in children {
+        let rel = full_path
+            .strip_prefix(root)
+            .unwrap_or(&full_path)
+            .to_path_buf();
+        let rel_str = rel.to_string_lossy().to_string();
+        let is_expanded = is_dir && expanded.contains(&rel);
+        let git_status = git_statuses.get(&rel_str).copied();
+
+        out.push(TreeEntry {
+            path: rel.clone(),
+            name,
+            depth,
+            is_dir,
+            is_expanded,
+            git_status,
+        });
+
+        if is_dir && is_expanded {
+            walk_dir(root, &full_path, expanded, git_statuses, out, depth + 1);
+        }
     }
 }
 
@@ -357,5 +399,22 @@ mod tests {
         // staged sets 'A'; unstaged uses or_insert so 'A' stays
         tree.refresh_git_statuses(&staged, &unstaged);
         assert_eq!(tree.git_statuses.get("a.rs").copied(), Some('A'));
+    }
+
+    #[test]
+    fn refresh_git_statuses_updates_visible_entries_without_rebuild() {
+        let mut src = dummy_entry("src");
+        src.is_dir = true;
+        let mut file = dummy_entry("main.rs");
+        file.path = PathBuf::from("src/main.rs");
+        file.depth = 1;
+        let mut tree = make_tree_with_entries(vec![src, file]);
+
+        let staged = vec![make_entry("src/main.rs", FileStatus::Modified)];
+        tree.refresh_git_statuses(&staged, &[]);
+
+        assert_eq!(tree.entries.len(), 2);
+        assert_eq!(tree.entries[0].git_status, Some('●'));
+        assert_eq!(tree.entries[1].git_status, Some('M'));
     }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -111,6 +111,11 @@ impl GitRepo {
         Ok(Self { repo })
     }
 
+    pub fn open_at(workdir: &Path) -> Result<Self, git2::Error> {
+        let repo = Repository::discover(workdir)?;
+        Ok(Self { repo })
+    }
+
     pub fn workdir_path(&self) -> Option<PathBuf> {
         self.repo.workdir().map(|p| p.to_path_buf())
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -148,14 +148,14 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
                 if app.active_tab != tab {
                     app.search.clear();
                 }
-                app.active_tab = tab;
+                app.set_active_tab(tab);
             }
             return;
         }
         KeyCode::Tab => {
             let tabs = Tab::ALL;
             let cur = tabs.iter().position(|&t| t == app.active_tab).unwrap_or(0);
-            app.active_tab = tabs[(cur + 1) % tabs.len()];
+            app.set_active_tab(tabs[(cur + 1) % tabs.len()]);
             app.search.clear();
             return;
         }
@@ -413,7 +413,7 @@ fn handle_key_files(key: KeyEvent, app: &mut App) {
             if let Some(entry) = app.file_tree.entries.get(idx) {
                 if entry.is_dir {
                     app.file_tree.toggle_expand(idx);
-                    app.load_preview();
+                    app.refresh_file_tree_with_target(app.file_tree.selected_path());
                 } else {
                     // File: hand off to the main loop, which owns the
                     // terminal and can suspend it around `$EDITOR`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,4 +12,5 @@ pub mod input;
 pub mod prefs;
 pub mod quick_open;
 pub mod search;
+pub mod tasks;
 pub mod ui;

--- a/src/quick_open.rs
+++ b/src/quick_open.rs
@@ -163,9 +163,10 @@ pub fn accept(app: &mut App) {
     save_mru_to_prefs(&app.quick_open.mru);
 
     app.quick_open.active = false;
-    app.active_tab = Tab::Files;
+    app.set_active_tab(Tab::Files);
     app.file_tree.reveal(&rel);
-    app.load_preview();
+    app.refresh_file_tree_with_target(Some(rel.clone()));
+    app.load_preview_for_path(rel);
 }
 
 /// Dispatch one key while the palette is active. The caller (input.rs)

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,0 +1,453 @@
+//! Background task coordinator.
+//!
+//! UI code should render cached snapshots only. Anything that can touch git,
+//! the filesystem, diff generation, or syntax highlighting is routed through
+//! these workers and merged back into `App` from `tick()`.
+
+use crate::file_tree::{self, PreviewContent, TreeEntry};
+use crate::git::graph::GraphRow;
+use crate::git::{CommitDetail, DiffContent, FileEntry, GitRepo, RefLabel};
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::thread;
+
+#[derive(Debug, Default)]
+pub struct AsyncState {
+    pub generation: u64,
+    pub loading: bool,
+    pub stale: bool,
+    pub error: Option<String>,
+}
+
+impl AsyncState {
+    pub fn mark_stale(&mut self) {
+        self.stale = true;
+    }
+
+    pub fn begin(&mut self) -> u64 {
+        self.generation = self.generation.wrapping_add(1).max(1);
+        self.loading = true;
+        self.stale = false;
+        self.error = None;
+        self.generation
+    }
+
+    pub fn complete_ok(&mut self, generation: u64) -> bool {
+        if generation != self.generation {
+            return false;
+        }
+        self.loading = false;
+        self.stale = false;
+        self.error = None;
+        true
+    }
+
+    pub fn complete_err(&mut self, generation: u64, error: String) -> bool {
+        if generation != self.generation {
+            return false;
+        }
+        self.loading = false;
+        self.stale = true;
+        self.error = Some(error);
+        true
+    }
+
+    pub fn should_request(&self) -> bool {
+        self.stale && !self.loading
+    }
+}
+
+#[derive(Debug)]
+pub struct GitStatusPayload {
+    pub staged: Vec<FileEntry>,
+    pub unstaged: Vec<FileEntry>,
+    pub ahead_behind: Option<(usize, usize)>,
+    pub branch_name: String,
+}
+
+#[derive(Debug)]
+pub struct FileTreePayload {
+    pub entries: Vec<TreeEntry>,
+    pub selected_idx: usize,
+}
+
+#[derive(Debug)]
+pub struct GraphPayload {
+    pub rows: Vec<GraphRow>,
+    pub ref_map: HashMap<String, Vec<RefLabel>>,
+    pub cache_key: (String, u64),
+}
+
+#[derive(Debug)]
+pub enum WorkerResult {
+    FileTree {
+        generation: u64,
+        result: Result<FileTreePayload, String>,
+    },
+    Preview {
+        generation: u64,
+        result: Result<Option<PreviewContent>, String>,
+    },
+    GitStatus {
+        generation: u64,
+        result: Result<GitStatusPayload, String>,
+    },
+    Diff {
+        generation: u64,
+        result: Result<Option<DiffContent>, String>,
+    },
+    Graph {
+        generation: u64,
+        result: Result<GraphPayload, String>,
+    },
+    CommitDetail {
+        generation: u64,
+        result: Result<Option<CommitDetail>, String>,
+    },
+    CommitFileDiff {
+        generation: u64,
+        result: Result<Option<(String, DiffContent)>, String>,
+    },
+}
+
+enum FilesTask {
+    RebuildTree {
+        generation: u64,
+        root: PathBuf,
+        expanded: Vec<PathBuf>,
+        git_statuses: HashMap<String, char>,
+        selected_path: Option<PathBuf>,
+        fallback_selected: usize,
+    },
+    LoadPreview {
+        generation: u64,
+        root: PathBuf,
+        rel_path: PathBuf,
+        dark: bool,
+    },
+}
+
+enum GitTask {
+    RefreshStatus {
+        generation: u64,
+        workdir: PathBuf,
+    },
+    LoadDiff {
+        generation: u64,
+        workdir: PathBuf,
+        path: String,
+        staged: bool,
+        context_lines: u32,
+    },
+}
+
+enum GraphTask {
+    RefreshGraph {
+        generation: u64,
+        workdir: PathBuf,
+        limit: usize,
+    },
+    LoadCommitDetail {
+        generation: u64,
+        workdir: PathBuf,
+        oid: String,
+    },
+    LoadCommitFileDiff {
+        generation: u64,
+        workdir: PathBuf,
+        oid: String,
+        path: String,
+        context_lines: u32,
+    },
+}
+
+pub struct TaskCoordinator {
+    files_tx: mpsc::Sender<FilesTask>,
+    git_tx: mpsc::Sender<GitTask>,
+    graph_tx: mpsc::Sender<GraphTask>,
+    result_rx: mpsc::Receiver<WorkerResult>,
+}
+
+impl TaskCoordinator {
+    pub fn new() -> Self {
+        let (result_tx, result_rx) = mpsc::channel();
+        Self {
+            files_tx: spawn_files_worker(result_tx.clone()),
+            git_tx: spawn_git_worker(result_tx.clone()),
+            graph_tx: spawn_graph_worker(result_tx),
+            result_rx,
+        }
+    }
+
+    pub fn try_recv(&self) -> Result<WorkerResult, mpsc::TryRecvError> {
+        self.result_rx.try_recv()
+    }
+
+    pub fn rebuild_tree(
+        &self,
+        generation: u64,
+        root: PathBuf,
+        expanded: Vec<PathBuf>,
+        git_statuses: HashMap<String, char>,
+        selected_path: Option<PathBuf>,
+        fallback_selected: usize,
+    ) {
+        let _ = self.files_tx.send(FilesTask::RebuildTree {
+            generation,
+            root,
+            expanded,
+            git_statuses,
+            selected_path,
+            fallback_selected,
+        });
+    }
+
+    pub fn load_preview(&self, generation: u64, root: PathBuf, rel_path: PathBuf, dark: bool) {
+        let _ = self.files_tx.send(FilesTask::LoadPreview {
+            generation,
+            root,
+            rel_path,
+            dark,
+        });
+    }
+
+    pub fn refresh_status(&self, generation: u64, workdir: PathBuf) {
+        let _ = self.git_tx.send(GitTask::RefreshStatus {
+            generation,
+            workdir,
+        });
+    }
+
+    pub fn load_diff(
+        &self,
+        generation: u64,
+        workdir: PathBuf,
+        path: String,
+        staged: bool,
+        context_lines: u32,
+    ) {
+        let _ = self.git_tx.send(GitTask::LoadDiff {
+            generation,
+            workdir,
+            path,
+            staged,
+            context_lines,
+        });
+    }
+
+    pub fn refresh_graph(&self, generation: u64, workdir: PathBuf, limit: usize) {
+        let _ = self.graph_tx.send(GraphTask::RefreshGraph {
+            generation,
+            workdir,
+            limit,
+        });
+    }
+
+    pub fn load_commit_detail(&self, generation: u64, workdir: PathBuf, oid: String) {
+        let _ = self.graph_tx.send(GraphTask::LoadCommitDetail {
+            generation,
+            workdir,
+            oid,
+        });
+    }
+
+    pub fn load_commit_file_diff(
+        &self,
+        generation: u64,
+        workdir: PathBuf,
+        oid: String,
+        path: String,
+        context_lines: u32,
+    ) {
+        let _ = self.graph_tx.send(GraphTask::LoadCommitFileDiff {
+            generation,
+            workdir,
+            oid,
+            path,
+            context_lines,
+        });
+    }
+}
+
+fn spawn_files_worker(result_tx: mpsc::Sender<WorkerResult>) -> mpsc::Sender<FilesTask> {
+    let (tx, rx) = mpsc::channel();
+    let _ = thread::Builder::new()
+        .name("reef-files-worker".into())
+        .spawn(move || {
+            while let Ok(task) = rx.recv() {
+                match task {
+                    FilesTask::RebuildTree {
+                        generation,
+                        root,
+                        expanded,
+                        git_statuses,
+                        selected_path,
+                        fallback_selected,
+                    } => {
+                        let result = Ok(build_file_tree_payload(
+                            root,
+                            expanded,
+                            git_statuses,
+                            selected_path,
+                            fallback_selected,
+                        ));
+                        let _ = result_tx.send(WorkerResult::FileTree { generation, result });
+                    }
+                    FilesTask::LoadPreview {
+                        generation,
+                        root,
+                        rel_path,
+                        dark,
+                    } => {
+                        let result = Ok(file_tree::load_preview(&root, &rel_path, dark));
+                        let _ = result_tx.send(WorkerResult::Preview { generation, result });
+                    }
+                }
+            }
+        });
+    tx
+}
+
+fn spawn_git_worker(result_tx: mpsc::Sender<WorkerResult>) -> mpsc::Sender<GitTask> {
+    let (tx, rx) = mpsc::channel();
+    let _ = thread::Builder::new()
+        .name("reef-git-worker".into())
+        .spawn(move || {
+            while let Ok(task) = rx.recv() {
+                match task {
+                    GitTask::RefreshStatus {
+                        generation,
+                        workdir,
+                    } => {
+                        let result = open_repo(&workdir).map(|repo| {
+                            let (staged, unstaged) = repo.get_status();
+                            GitStatusPayload {
+                                staged,
+                                unstaged,
+                                ahead_behind: repo.ahead_behind(),
+                                branch_name: repo.branch_name(),
+                            }
+                        });
+                        let _ = result_tx.send(WorkerResult::GitStatus { generation, result });
+                    }
+                    GitTask::LoadDiff {
+                        generation,
+                        workdir,
+                        path,
+                        staged,
+                        context_lines,
+                    } => {
+                        let result = open_repo(&workdir)
+                            .map(|repo| repo.get_diff(&path, staged, context_lines));
+                        let _ = result_tx.send(WorkerResult::Diff { generation, result });
+                    }
+                }
+            }
+        });
+    tx
+}
+
+fn spawn_graph_worker(result_tx: mpsc::Sender<WorkerResult>) -> mpsc::Sender<GraphTask> {
+    let (tx, rx) = mpsc::channel();
+    let _ = thread::Builder::new()
+        .name("reef-graph-worker".into())
+        .spawn(move || {
+            while let Ok(task) = rx.recv() {
+                match task {
+                    GraphTask::RefreshGraph {
+                        generation,
+                        workdir,
+                        limit,
+                    } => {
+                        let result = open_repo(&workdir).map(|repo| {
+                            let head = repo.head_oid().unwrap_or_default();
+                            let ref_map = repo.list_refs();
+                            let refs_hash = hash_ref_map(&ref_map);
+                            let commits = repo.list_commits(limit);
+                            let rows = crate::git::graph::build_graph(&commits);
+                            GraphPayload {
+                                rows,
+                                ref_map,
+                                cache_key: (head, refs_hash),
+                            }
+                        });
+                        let _ = result_tx.send(WorkerResult::Graph { generation, result });
+                    }
+                    GraphTask::LoadCommitDetail {
+                        generation,
+                        workdir,
+                        oid,
+                    } => {
+                        let result = open_repo(&workdir).map(|repo| repo.get_commit(&oid));
+                        let _ = result_tx.send(WorkerResult::CommitDetail { generation, result });
+                    }
+                    GraphTask::LoadCommitFileDiff {
+                        generation,
+                        workdir,
+                        oid,
+                        path,
+                        context_lines,
+                    } => {
+                        let result = open_repo(&workdir).map(|repo| {
+                            repo.get_commit_file_diff(&oid, &path, context_lines)
+                                .map(|diff| (path, diff))
+                        });
+                        let _ = result_tx.send(WorkerResult::CommitFileDiff { generation, result });
+                    }
+                }
+            }
+        });
+    tx
+}
+
+fn build_file_tree_payload(
+    root: PathBuf,
+    expanded: Vec<PathBuf>,
+    git_statuses: HashMap<String, char>,
+    selected_path: Option<PathBuf>,
+    fallback_selected: usize,
+) -> FileTreePayload {
+    let expanded: std::collections::HashSet<PathBuf> = expanded.into_iter().collect();
+    let entries = file_tree::build_entries(&root, &expanded, &git_statuses);
+    let selected_idx = selected_path
+        .as_ref()
+        .and_then(|path| entries.iter().position(|entry| &entry.path == path))
+        .unwrap_or_else(|| fallback_selected.min(entries.len().saturating_sub(1)));
+    FileTreePayload {
+        entries,
+        selected_idx,
+    }
+}
+
+fn open_repo(workdir: &Path) -> Result<GitRepo, String> {
+    GitRepo::open_at(workdir).map_err(|e| e.message().to_string())
+}
+
+fn hash_ref_map(map: &HashMap<String, Vec<RefLabel>>) -> u64 {
+    let mut entries: Vec<(&String, &Vec<RefLabel>)> = map.iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for (oid, labels) in entries {
+        oid.hash(&mut hasher);
+        for label in labels {
+            match label {
+                RefLabel::Head => 0u8.hash(&mut hasher),
+                RefLabel::Branch(s) => {
+                    1u8.hash(&mut hasher);
+                    s.hash(&mut hasher);
+                }
+                RefLabel::RemoteBranch(s) => {
+                    2u8.hash(&mut hasher);
+                    s.hash(&mut hasher);
+                }
+                RefLabel::Tag(s) => {
+                    3u8.hash(&mut hasher);
+                    s.hash(&mut hasher);
+                }
+            }
+        }
+    }
+    hasher.finish()
+}

--- a/src/ui/git_graph_panel.rs
+++ b/src/ui/git_graph_panel.rs
@@ -17,11 +17,6 @@ use std::ops::Range;
 use unicode_width::UnicodeWidthStr;
 
 pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
-    // Rebuild the graph when HEAD/refs moved. The cache lookup inside
-    // `App::refresh_graph` guards against workdir-only changes triggering a
-    // full revwalk on every keystroke.
-    app.refresh_graph();
-
     if app.git_graph.rows.is_empty() {
         let line = Line::from(Span::styled(
             t(Msg::NoCommits),
@@ -33,7 +28,11 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
 
     let show_meta = area.width >= 60;
     let max_subject = (area.width as usize).saturating_sub(if show_meta { 40 } else { 14 });
-    let head_oid = app.repo.as_ref().and_then(|r| r.head_oid());
+    let head_oid = app
+        .git_graph
+        .cache_key
+        .as_ref()
+        .map(|(head, _)| head.as_str());
 
     // Clamp scroll to a valid range. Auto-scroll into view only when the
     // selection actually moved since the last render — running this every
@@ -69,7 +68,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
             idx == app.git_graph.selected_idx,
             show_meta,
             max_subject,
-            head_oid.as_deref(),
+            head_oid,
             &app.git_graph.ref_map,
             hover,
             &theme,

--- a/src/ui/git_status_panel.rs
+++ b/src/ui/git_status_panel.rs
@@ -25,15 +25,6 @@ use unicode_width::UnicodeWidthStr;
 // ─── Public entry points ──────────────────────────────────────────────────────
 
 pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
-    // Pull fresh git state on every render so an external `git add`,
-    // `git commit`, `git reset`, etc. (which change `.git/index` or
-    // `.git/HEAD` — both filtered out by the fs-watcher) still reflect in
-    // the sidebar without the user having to press `r`. Matches the
-    // plugin-era behaviour where the plugin refreshed on every render
-    // request. `repo.statuses` is cheap enough on typical repos; we only
-    // do it while the Git tab is being drawn.
-    app.refresh_status();
-
     let theme = app.theme;
     let rows = build_rows(app, area.width, &theme);
     let total = rows.len();
@@ -493,12 +484,7 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
     // Push / force-push confirmation banner
     if status.confirm_push || status.confirm_force_push {
         let force = status.confirm_force_push;
-        let ahead = app
-            .repo
-            .as_ref()
-            .and_then(|r| r.ahead_behind())
-            .map(|(a, _)| a)
-            .unwrap_or(0);
+        let ahead = app.git_status.ahead_behind.map(|(a, _)| a).unwrap_or(0);
 
         if force {
             rows.push(Row::new(vec![
@@ -566,7 +552,7 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
         && !status.confirm_force_push
         && !app.push_in_flight
     {
-        if let Some((ahead, behind)) = app.repo.as_ref().and_then(|r| r.ahead_behind()) {
+        if let Some((ahead, behind)) = app.git_status.ahead_behind {
             if let Some(row) = push_indicator_row(ahead, behind) {
                 rows.push(row);
                 rows.push(Row::blank());

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -225,16 +225,12 @@ fn render_tab_bar(f: &mut Frame, app: &mut App, area: Rect) {
 
 fn render_title_bar(f: &mut Frame, app: &App, area: Rect) {
     let th = app.theme;
-    let repo_name = app
-        .repo
-        .as_ref()
-        .map(|r| r.workdir_name())
-        .unwrap_or_else(|| "—".to_string());
-    let branch = app
-        .repo
-        .as_ref()
-        .map(|r| r.branch_name())
-        .unwrap_or_default();
+    let repo_name = if app.repo.is_some() {
+        app.workdir_name.as_str()
+    } else {
+        "—"
+    };
+    let branch = app.branch_name.as_str();
 
     let title = Line::from(vec![
         Span::styled(
@@ -246,7 +242,7 @@ fn render_title_bar(f: &mut Frame, app: &App, area: Rect) {
         ),
         Span::styled(" ", Style::default().bg(th.chrome_bg)),
         Span::styled(
-            &repo_name,
+            repo_name,
             Style::default()
                 .fg(th.chrome_fg)
                 .bg(th.chrome_bg)
@@ -318,7 +314,10 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
                 ToastLevel::Info => Color::Cyan,
             },
         ),
-        None => (String::new(), Color::Cyan),
+        None => match app.activity_message() {
+            Some(msg) => (format!("  {} ", msg), Color::Cyan),
+            None => (String::new(), Color::Cyan),
+        },
     };
 
     let status = Line::from(vec![

--- a/tests/ui_snapshots.rs
+++ b/tests/ui_snapshots.rs
@@ -13,6 +13,8 @@ use reef::app::App;
 use reef::ui;
 use reef::ui::theme::Theme;
 use std::sync::Mutex;
+use std::thread;
+use std::time::{Duration, Instant};
 use test_support::{HomeGuard, commit_file, tempdir_repo, write_file};
 
 static CWD_LOCK: Mutex<()> = Mutex::new(());
@@ -74,6 +76,18 @@ fn render_app(app: &mut App, width: u16, height: u16) -> String {
     buffer_to_text(terminal.backend().buffer())
 }
 
+fn wait_for_git_status(app: &mut App) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        app.tick();
+        if !app.git_status_load.loading {
+            return;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    panic!("timed out waiting for background git status");
+}
+
 /// Apply filters to mask nondeterministic tokens (tempdir name, path segments).
 fn with_filters<F: FnOnce()>(body: F) {
     let mut settings = insta::Settings::clone_current();
@@ -113,8 +127,9 @@ fn snapshot_with_staged_and_unstaged() {
 
     let mut app = App::new(Theme::dark());
     // Switch to Git tab to show staged/unstaged sections
-    app.active_tab = reef::app::Tab::Git;
+    app.set_active_tab(reef::app::Tab::Git);
     app.refresh_status();
+    wait_for_git_status(&mut app);
     let output = render_app(&mut app, 80, 20);
     with_filters(|| insta::assert_snapshot!("with_staged_and_unstaged", output));
 }
@@ -137,8 +152,9 @@ fn snapshot_with_staged_and_unstaged_light_theme() {
     let _g = CwdGuard::enter(tmp.path());
 
     let mut app = App::new(Theme::light());
-    app.active_tab = reef::app::Tab::Git;
+    app.set_active_tab(reef::app::Tab::Git);
     app.refresh_status();
+    wait_for_git_status(&mut app);
     let output = render_app(&mut app, 80, 20);
     with_filters(|| insta::assert_snapshot!("with_staged_and_unstaged_light", output));
 }


### PR DESCRIPTION
## Summary
- move git, graph, diff, preview, and file-tree rebuild work off the render path
- add background task coordination with stale/loading states and generation-based result dropping
- keep file-tree git decorations in sync without rebuilding the visible tree, and update snapshot tests for async loading

## Validation
- rtk cargo check
- rtk cargo fmt --all -- --check
- rtk cargo clippy --workspace --all-targets -- -D warnings
- rtk cargo test --lib
- rtk cargo test --test ui_snapshots && rtk cargo test --test ui_snapshots
- rtk cargo test --test git_repo_integration
- rtk cargo test --test git_graph_properties
- rtk cargo test --test app_error_paths

## Notes
- rtk cargo test --test fs_watcher_integration still times out in this environment (existing watcher issue, unrelated to the render/task split)