### PR TITLE
feat: drag-and-drop file copy with place-mode picker

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -221,6 +221,11 @@ pub struct App {
     /// `ui::file_preview_panel` alongside the in-panel `/` search highlight.
     pub preview_highlight: Option<PreviewHighlight>,
 
+    /// VSCode-style drag-and-drop destination picker. While `place_mode.active`,
+    /// input is routed exclusively to `input::handle_key` / `handle_mouse`
+    /// place-mode branches (see `crate::place_mode`).
+    pub place_mode: crate::place_mode::PlaceModeState,
+
     /// Timestamp of the most recent bare-Space keystroke in the global
     /// keymap. `Some(t)` means a Space leader is primed and waiting for a
     /// follow-up key within `input::LEADER_TIMEOUT`. The palette-side
@@ -250,6 +255,11 @@ pub struct App {
     /// `GlobalSearchDone`; we use `begin()` at kickoff, plain generation
     /// comparisons on each chunk, and `complete_ok` on `Done`.
     pub global_search_load: AsyncState,
+    /// Tracks the in-flight drag-and-drop copy kicked off from place mode.
+    /// Used to drop stale results (the user could cancel + re-enter place
+    /// mode before a long directory copy finishes) and to show a "copying…"
+    /// hint if the operation takes long enough to notice.
+    pub file_copy_load: AsyncState,
     next_git_revalidate_at: Instant,
     next_graph_revalidate_at: Instant,
 }
@@ -362,6 +372,7 @@ impl App {
             quick_open: crate::quick_open::QuickOpenState::from_prefs(),
             global_search: crate::global_search::GlobalSearchState::default(),
             preview_highlight: None,
+            place_mode: crate::place_mode::PlaceModeState::default(),
             space_leader_at: None,
             last_preview_view_h: 0,
             last_diff_view_h: 0,
@@ -375,6 +386,7 @@ impl App {
             commit_detail_load: AsyncState::default(),
             commit_file_diff_load: AsyncState::default(),
             global_search_load: AsyncState::default(),
+            file_copy_load: AsyncState::default(),
             next_git_revalidate_at: now + Duration::from_millis(800),
             next_graph_revalidate_at: now + Duration::from_millis(1200),
         };
@@ -389,6 +401,83 @@ impl App {
         let generation = self.git_status_load.begin();
         self.tasks
             .refresh_status(generation, self.file_tree.root.clone());
+    }
+
+    /// Enter the drag-and-drop destination picker. Switches to the Files
+    /// tab so the user can see the tree they're about to drop into, then
+    /// stores the sources for the banner + eventual copy. Called from
+    /// `input::handle_paste` when a paste payload resolves to existing
+    /// on-disk paths.
+    ///
+    /// Refuses the transition in two situations that would otherwise
+    /// leave the user stranded:
+    ///
+    /// - `select_mode` is active — mouse capture is off in that mode,
+    ///   so the user would have no way to click a drop target. The
+    ///   toast points them at the `v` escape hatch.
+    /// - a place-mode copy is already in flight — overwriting
+    ///   `sources` would invalidate the worker's generation and the
+    ///   previous copy's completion result (including the success
+    ///   toast and tree refresh) would be silently dropped.
+    pub fn enter_place_mode(&mut self, sources: Vec<PathBuf>) {
+        if sources.is_empty() {
+            return;
+        }
+        if self.select_mode {
+            self.toasts
+                .push(Toast::warn(crate::i18n::place_mode_blocked_by_select_mode()));
+            return;
+        }
+        if self.file_copy_load.loading {
+            self.toasts.push(Toast::warn(
+                crate::i18n::place_mode_blocked_by_in_flight_copy(),
+            ));
+            return;
+        }
+        // Close any competing modal UI so place mode is the single
+        // source of truth. Without this, a drop during a quick-open
+        // palette session would leave both modal flags true: the
+        // palette keeps owning keyboard input (priority-ordered above
+        // place mode in `handle_key`), the search prompt would still
+        // commandeer the status bar instead of the PLACE badge, and
+        // the user would need two Esc presses to fully unwind.
+        self.quick_open.active = false;
+        if self.search.active {
+            crate::search::exit_cancel(self);
+        }
+        self.show_help = false;
+        self.set_active_tab(Tab::Files);
+        self.place_mode.active = true;
+        self.place_mode.sources = sources;
+    }
+
+    /// Leave place mode without copying — Esc, right-click, or a click on a
+    /// non-droppable area all land here.
+    pub fn exit_place_mode(&mut self) {
+        self.place_mode.active = false;
+        self.place_mode.sources.clear();
+    }
+
+    /// Kick off the async copy into `dest_dir`. Takes `self.place_mode.sources`
+    /// by clone so the state can be cleared by the caller if it chooses to —
+    /// but in normal flow we keep sources around until the worker result
+    /// arrives so the banner stays visible while copying.
+    ///
+    /// De-duped against in-flight copies: a rage-click on a second folder
+    /// before the first copy returns would otherwise `begin()` a new
+    /// generation and invalidate the prior one — the first copy still
+    /// runs on disk but its completion toast / tree refresh never fire.
+    /// `enter_place_mode` has the same guard for paste-level entry; this
+    /// handles the mouse-level commit path.
+    pub fn request_file_copy(&mut self, sources: Vec<PathBuf>, dest_dir: PathBuf) {
+        if self.file_copy_load.loading {
+            self.toasts.push(Toast::warn(
+                crate::i18n::place_mode_blocked_by_in_flight_copy(),
+            ));
+            return;
+        }
+        let generation = self.file_copy_load.begin();
+        self.tasks.copy_files(generation, sources, dest_dir);
     }
 
     /// Rebuild the file tree from disk, applying git decorations when a repo is open.
@@ -950,6 +1039,35 @@ impl App {
                     }
                 }
             }
+            WorkerResult::FileCopy { generation, result } => match result {
+                Ok(count) => {
+                    if self.file_copy_load.complete_ok(generation) {
+                        self.toasts
+                            .push(Toast::info(crate::i18n::place_mode_copied(count)));
+                        self.exit_place_mode();
+                        // The fs-watcher will eventually notice, but refresh
+                        // synchronously so the user sees their newly-placed
+                        // files immediately.
+                        self.refresh_file_tree();
+                    }
+                }
+                Err(error) => {
+                    if self.file_copy_load.complete_err(generation, error.clone()) {
+                        self.toasts
+                            .push(Toast::error(crate::i18n::place_mode_copy_failed(&error)));
+                        self.exit_place_mode();
+                        // `complete_err` sets stale=true + error=Some so
+                        // `should_request()` would re-fire, and
+                        // `activity_message` would surface "copy error:
+                        // …" in the status bar indefinitely after the
+                        // toast is gone. The error has already been
+                        // surfaced; clear the flags so the status bar
+                        // goes back to normal on the next frame.
+                        self.file_copy_load.stale = false;
+                        self.file_copy_load.error = None;
+                    }
+                }
+            },
         }
     }
 
@@ -991,7 +1109,8 @@ impl App {
         }
 
         match self.active_tab {
-            Tab::Files => from_state("files", &self.file_tree_load)
+            Tab::Files => from_state("copy", &self.file_copy_load)
+                .or_else(|| from_state("files", &self.file_tree_load))
                 .or_else(|| from_state("preview", &self.preview_load)),
             Tab::Git => from_state("git", &self.git_status_load)
                 .or_else(|| from_state("diff", &self.diff_load)),
@@ -1078,6 +1197,33 @@ impl App {
                 if self.active_tab == Tab::Search {
                     self.global_search.tab_input_focused = true;
                 }
+            }
+            ClickAction::PlaceModeFolder(index) => {
+                // Confirm a place-mode drop onto a specific folder. Resolve
+                // the entry's absolute path and hand off to the worker.
+                // Stale indices (e.g. the tree rebuilt out from under us)
+                // or accidental clicks on non-directory rows fall back to a
+                // cancel — safer than silently dropping to an unrelated
+                // destination.
+                let dest = self.file_tree.entries.get(index).and_then(|entry| {
+                    if entry.is_dir {
+                        Some(self.file_tree.root.join(&entry.path))
+                    } else {
+                        None
+                    }
+                });
+                match dest {
+                    Some(dest_dir) => {
+                        let sources = self.place_mode.sources.clone();
+                        self.request_file_copy(sources, dest_dir);
+                    }
+                    None => self.exit_place_mode(),
+                }
+            }
+            ClickAction::PlaceModeRoot => {
+                let sources = self.place_mode.sources.clone();
+                let dest_dir = self.file_tree.root.clone();
+                self.request_file_copy(sources, dest_dir);
             }
         }
     }
@@ -1173,6 +1319,7 @@ impl App {
         self.drain_preview_sync_debounce();
         self.drain_push_result();
         self.kick_active_tab_work();
+        self.tick_place_mode_auto_expand();
         self.drain_task_results();
     }
 
@@ -1279,6 +1426,43 @@ impl App {
             self.file_tree.root.clone(),
             self.global_search.query.clone(),
         );
+    }
+
+    /// VSCode-style hover auto-expand. When the cursor rests on a
+    /// collapsed folder for `HOVER_EXPAND_DELAY`, expand it so the user
+    /// can keep drilling into deep targets without round-tripping through
+    /// a click. Render writes the hover tracker; we just check the
+    /// timer here.
+    ///
+    /// Guarded on `file_tree_load.loading` so a slow tree rebuild doesn't
+    /// re-fire the expand on every tick — we'd otherwise pile up tree
+    /// rebuild generations until the worker caught up.
+    fn tick_place_mode_auto_expand(&mut self) {
+        if !self.place_mode.active {
+            return;
+        }
+        if self.file_tree_load.loading {
+            return;
+        }
+        let Some(idx) = self.place_mode.auto_expand_due(Instant::now()) else {
+            return;
+        };
+        let should_expand = self
+            .file_tree
+            .entries
+            .get(idx)
+            .map(|e| e.is_dir && !e.is_expanded)
+            .unwrap_or(false);
+        // Clear the timer regardless of whether we expand — hovering on
+        // an already-expanded folder shouldn't keep re-firing every
+        // frame, and leaving the timestamp set would do exactly that.
+        self.place_mode.hover_since = None;
+        if !should_expand {
+            return;
+        }
+        self.file_tree.toggle_expand(idx);
+        let selected_path = self.file_tree.selected_path();
+        self.refresh_file_tree_with_target(selected_path);
     }
 
     fn kick_active_tab_work(&mut self) {

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -117,6 +117,7 @@ pub enum Msg {
     // Help popup — key column
     HelpKeyAnyKey,
     HelpKeyMouseHScroll,
+    HelpKeyDragDrop,
     // Help popup — descriptions
     HelpQuit,
     HelpSwitchTab,
@@ -140,6 +141,7 @@ pub enum Msg {
     HelpShowHelp,
     HelpQuickOpen,
     HelpGlobalSearch,
+    HelpDragDrop,
     HelpAnyKey,
 }
 
@@ -205,6 +207,7 @@ fn t_zh(m: Msg) -> &'static str {
         EmptyDir => "(空)",
         HelpKeyAnyKey => "任意键",
         HelpKeyMouseHScroll => "Shift+滚轮 / 触控板横划",
+        HelpKeyDragDrop => "拖文件进终端",
         HelpQuit => "退出",
         HelpSwitchTab => "切换顶部标签页（文件 ↔ Git ↔ 图表）",
         HelpSwitchPanel => "切换焦点面板（侧边栏 ↔ 编辑区）",
@@ -227,6 +230,7 @@ fn t_zh(m: Msg) -> &'static str {
         HelpShowHelp => "显示 / 关闭此帮助",
         HelpQuickOpen => "打开 / 关闭快速打开浮层（全局模糊搜索）",
         HelpGlobalSearch => "打开全局内容搜索浮层",
+        HelpDragDrop => "进入放置模式：点击文件夹复制到那里，Esc / 右键 取消",
         HelpAnyKey => "关闭帮助",
     }
 }
@@ -286,6 +290,7 @@ fn t_en(m: Msg) -> &'static str {
         EmptyDir => "(empty)",
         HelpKeyAnyKey => "any key",
         HelpKeyMouseHScroll => "Shift+Wheel / trackpad",
+        HelpKeyDragDrop => "Drag file into terminal",
         HelpQuit => "Quit",
         HelpSwitchTab => "Cycle top tabs (Files ↔ Git ↔ Graph)",
         HelpSwitchPanel => "Switch focused panel (sidebar ↔ editor)",
@@ -308,6 +313,9 @@ fn t_en(m: Msg) -> &'static str {
         HelpShowHelp => "Show / close this help",
         HelpQuickOpen => "Toggle quick-open palette (global fuzzy search)",
         HelpGlobalSearch => "Open global content-search palette",
+        HelpDragDrop => {
+            "Enter place mode: click a folder to copy there, Esc / right-click to cancel"
+        }
         HelpAnyKey => "Close help",
     }
 }
@@ -397,9 +405,92 @@ pub fn search_dormant_with_counter(prefix: char, query: &str, i: usize, n: usize
     }
 }
 
+pub fn place_mode_banner(primary_name: &str, count: usize) -> String {
+    let extra = count.saturating_sub(1);
+    match lang() {
+        Lang::Zh => {
+            if extra == 0 {
+                format!(" 📋 放置 {primary_name} ")
+            } else {
+                format!(" 📋 放置 {primary_name} +{extra} 项 ")
+            }
+        }
+        Lang::En => {
+            if extra == 0 {
+                format!(" 📋 Placing {primary_name} ")
+            } else {
+                format!(" 📋 Placing {primary_name} +{extra} more ")
+            }
+        }
+    }
+}
+
+/// Status-bar hint shown while place mode is active. Mirrors how select-mode
+/// commandeers the status bar with a high-contrast badge — the two
+/// correspond to distinct modal states the user needs to exit explicitly.
+pub fn place_mode_status_hint() -> &'static str {
+    match lang() {
+        Lang::Zh => "  点击文件夹放置 · 点击空白放到根目录 · Esc / 右键 取消",
+        Lang::En => {
+            "  Click a folder to drop · click empty to drop at root · Esc / right-click to cancel"
+        }
+    }
+}
+
+pub fn place_mode_copied(count: usize) -> String {
+    match lang() {
+        Lang::Zh => format!("已复制 {count} 项"),
+        Lang::En => format!("Copied {count} item(s)"),
+    }
+}
+
+pub fn place_mode_copy_failed(e: &str) -> String {
+    match lang() {
+        Lang::Zh => format!("复制失败: {e}"),
+        Lang::En => format!("Copy failed: {e}"),
+    }
+}
+
+/// Warning when a drop arrives while the user is in select-mode. Mouse
+/// capture is off in that state, so entering place mode would leave
+/// the user with no way to click a target.
+pub fn place_mode_blocked_by_select_mode() -> String {
+    match lang() {
+        Lang::Zh => "拖拽被选择模式拦住了：按 v 退出选择模式后再试".to_string(),
+        Lang::En => "Drop blocked by select mode — press v to exit, then retry".to_string(),
+    }
+}
+
+/// Warning when a drop arrives while a previous copy is still running.
+/// Entering place mode would overwrite the sources and invalidate the
+/// in-flight generation, silently losing the earlier result toast.
+pub fn place_mode_blocked_by_in_flight_copy() -> String {
+    match lang() {
+        Lang::Zh => "上次拷贝还没完成，先等一下".to_string(),
+        Lang::En => "A copy is still in progress — please wait".to_string(),
+    }
+}
+
+/// Status hint shown while a place-mode copy is running. Replaces the
+/// normal "Placing X" banner so the user sees that work is actually
+/// happening for large copies that take more than a few frames.
+pub fn place_mode_copying_banner() -> String {
+    match lang() {
+        Lang::Zh => " ⋯ 正在复制… ".to_string(),
+        Lang::En => " ⋯ Copying… ".to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn place_mode_strings_are_nonempty() {
+        assert!(!place_mode_copied(3).is_empty());
+        assert!(!place_mode_copy_failed("boom").is_empty());
+        assert!(!place_mode_banner("x.txt", 1).is_empty());
+    }
 
     #[test]
     fn t_returns_translation_for_both_langs() {

--- a/src/input.rs
+++ b/src/input.rs
@@ -116,11 +116,31 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         return;
     }
 
+    // Place mode (drag-and-drop destination picker) is mouse-first —
+    // most keystrokes are ignored so a stray keypress can't accidentally
+    // commit a copy. Exceptions: Esc cancels the mode, and the two
+    // terminal-standard quit keys (bare `q` and Ctrl+C) still fire so a
+    // user who feels stuck can always bail out of the whole app without
+    // Esc'ing first.
+    if app.place_mode.active {
+        match key.code {
+            KeyCode::Esc => app.exit_place_mode(),
+            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                app.should_quit = true;
+            }
+            KeyCode::Char('q') if key.modifiers.is_empty() => {
+                app.should_quit = true;
+            }
+            _ => {}
+        }
+        return;
+    }
+
     // Space-leader chord: bare Space primes, bare `p` opens the quick-open
     // palette, bare `f` opens the global-search palette. Bare Space has no
     // other global meaning, so the chord doesn't collide with any existing
-    // binding. Context: we're already past the palette / search gates, so
-    // the leader is only in play during normal tab navigation.
+    // binding. Context: we're already past the palette / search / place
+    // gates, so the leader is only in play during normal tab navigation.
     //
     // Exception: when the Tab::Search search input is focused (modal
     // `tab_input_focused`), bare Space is a literal separator in a
@@ -818,6 +838,11 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
         return;
     }
 
+    if app.place_mode.active {
+        handle_mouse_place_mode(mouse, app);
+        return;
+    }
+
     match mouse.kind {
         MouseEventKind::Down(MouseButton::Left) => {
             let now = Instant::now();
@@ -1015,6 +1040,197 @@ fn apply_horizontal_scroll(app: &mut App, column: u16, total_width: u16, delta: 
     };
 }
 
+// ─── Place mode (drag-and-drop destination picker) ───────────────────────────
+
+fn handle_mouse_place_mode(mouse: MouseEvent, app: &mut App) {
+    match mouse.kind {
+        MouseEventKind::Moved => {
+            app.hover_row = Some(mouse.row);
+            app.hover_col = Some(mouse.column);
+        }
+        MouseEventKind::Down(MouseButton::Left) => {
+            // Only PlaceMode* click actions are meaningful here. Any other
+            // hit (e.g. a file row that we no longer register, or the tab
+            // bar) is treated as "clicked outside the droppable area" and
+            // cancels the modal.
+            match app.hit_registry.hit_test(mouse.column, mouse.row) {
+                Some(ui::mouse::ClickAction::PlaceModeFolder(idx)) => {
+                    app.handle_action(ui::mouse::ClickAction::PlaceModeFolder(idx));
+                }
+                Some(ui::mouse::ClickAction::PlaceModeRoot) => {
+                    app.handle_action(ui::mouse::ClickAction::PlaceModeRoot);
+                }
+                _ => {
+                    app.exit_place_mode();
+                }
+            }
+        }
+        MouseEventKind::Down(MouseButton::Right) => {
+            app.exit_place_mode();
+        }
+        MouseEventKind::ScrollUp => {
+            app.tree_scroll = app.tree_scroll.saturating_sub(3);
+        }
+        MouseEventKind::ScrollDown => {
+            app.tree_scroll = app.tree_scroll.saturating_add(3);
+        }
+        _ => {}
+    }
+}
+
+// ─── Bracketed paste dispatch ────────────────────────────────────────────────
+
+/// Entry point for `Event::Paste(s)` from the main loop. Priorities:
+///
+/// 1. If the payload parses as one or more existing absolute paths, enter
+///    drag-and-drop place mode with those sources.
+/// 2. Otherwise, if an input field has focus (quick-open palette, search
+///    prompt), forward the payload as typed text.
+/// 3. Otherwise drop silently — a paste landing on plain tab navigation
+///    has no sensible target.
+pub fn handle_paste(s: String, app: &mut App) {
+    let paths = parse_dropped_paths(&s);
+    if !paths.is_empty() {
+        app.enter_place_mode(paths);
+        return;
+    }
+    if app.quick_open.active {
+        quick_open::handle_paste(&s, app);
+    } else if app.search.active {
+        search::handle_paste(&s, app);
+    }
+    // No focused input; intentionally dropped. A stray paste into the
+    // global keymap has no defined meaning, and we don't want to
+    // accidentally trigger an action.
+}
+
+/// Extract filesystem paths from a bracketed-paste payload.
+///
+/// Terminals normalise file drops into paste content, but the exact
+/// framing varies:
+///
+/// - iTerm2: single-quote wrapped, `\ ` for spaces, one path per line.
+/// - Ghostty / WezTerm / Alacritty / Kitty: raw path with `\ ` escapes.
+/// - GNOME Terminal / older: `file:///…` URI with `%xx` URL-encoding.
+///
+/// We tolerate all of the above, then demand that every candidate be an
+/// absolute path (drops from Finder always are) that `exists()` on disk.
+/// Relative paths and non-existent strings are rejected outright — a
+/// user pasting the word `settings.json` into the quick-open palette
+/// must NOT trip place mode, and the absolute-path requirement is what
+/// makes that reliable.
+///
+/// Returns an empty vector when the payload is "not a drop"; callers
+/// use that as the signal to forward the paste to the focused text input.
+pub fn parse_dropped_paths(s: &str) -> Vec<std::path::PathBuf> {
+    let trimmed = s.trim_matches(|c: char| c == '\n' || c == '\r');
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+    // Newline is the common multi-file separator across every terminal we
+    // support. Single-segment → single path (even if it contains spaces);
+    // multi-segment → one path per line.
+    let mut out = Vec::new();
+    for segment in trimmed.split('\n') {
+        let seg = segment.trim().trim_end_matches('\r');
+        if seg.is_empty() {
+            continue;
+        }
+        let Some(p) = normalize_segment(seg) else {
+            continue;
+        };
+        if p.is_absolute() && p.exists() {
+            out.push(p);
+        }
+    }
+    out
+}
+
+/// Strip one layer of framing from a single dropped-path segment:
+/// matched outer quotes → removed; `file://` scheme → stripped + URL
+/// decoded; backslash escapes → unescaped. Returns `None` if the segment
+/// ends up empty or can't be interpreted as a path.
+fn normalize_segment(raw: &str) -> Option<std::path::PathBuf> {
+    let mut s = raw.to_string();
+
+    // Outer quote pair — some terminals (iTerm2 by default) wrap drag
+    // payloads in single quotes; paste-from-clipboard in others may use
+    // double quotes. Only strip if both ends match.
+    if s.len() >= 2 {
+        let first = s.chars().next().unwrap();
+        let last = s.chars().last().unwrap();
+        if (first == '\'' && last == '\'') || (first == '"' && last == '"') {
+            s = s[1..s.len() - 1].to_string();
+        }
+    }
+
+    // `file://` URI → filesystem path + URL decode. We accept both
+    // `file:///Users/...` (triple-slash, most common) and `file://localhost/...`
+    // (hostname-qualified, older macOS) by stripping the authority.
+    if let Some(rest) = s.strip_prefix("file://") {
+        let path_part = rest.strip_prefix("localhost").unwrap_or(rest).to_string();
+        s = url_decode(&path_part);
+    }
+
+    s = unescape_backslashes(&s);
+
+    if s.is_empty() {
+        return None;
+    }
+    Some(std::path::PathBuf::from(s))
+}
+
+/// Minimal `%xx` percent-decoder, enough for common file URIs. Invalid
+/// escapes are left as-is (we never fail the whole parse over a stray `%`).
+fn url_decode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(hi), Some(lo)) = (hex_digit(bytes[i + 1]), hex_digit(bytes[i + 2])) {
+                out.push((hi * 16 + lo) as char);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
+}
+
+fn hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Unescape shell-style backslash sequences commonly used by terminals
+/// when injecting dropped paths: `\ ` → ` `, `\\` → `\`, `\t` → tab, etc.
+/// A trailing unmatched backslash is passed through verbatim.
+fn unescape_backslashes(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some('n') => out.push('\n'),
+                Some('t') => out.push('\t'),
+                Some('r') => out.push('\r'),
+                Some(other) => out.push(other),
+                None => out.push('\\'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1151,5 +1367,118 @@ mod leader_tests {
         let shift_space = ke(KeyCode::Char(' '), KeyModifiers::SHIFT);
         let v = leader_decision(&shift_space, true, None, now, LEADER_TIMEOUT);
         assert_eq!(v, LeaderVerdict::None);
+    }
+}
+
+#[cfg(test)]
+mod paste_parser_tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn touch(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+        let p = dir.join(name);
+        fs::write(&p, "").unwrap();
+        p
+    }
+
+    #[test]
+    fn non_path_text_is_not_a_drop() {
+        // User pastes a regular word into an input — must not activate
+        // place mode. The absolute-path requirement is what makes this
+        // robust.
+        assert!(parse_dropped_paths("settings.json").is_empty());
+        assert!(parse_dropped_paths("let x = 1;").is_empty());
+        assert!(parse_dropped_paths("").is_empty());
+    }
+
+    #[test]
+    fn relative_paths_rejected_even_if_they_exist() {
+        // Even if `src/main.rs` exists from the cwd, a relative path is
+        // never what a drop would produce — reject to avoid false
+        // positives on pasted code snippets.
+        assert!(parse_dropped_paths("src/main.rs").is_empty());
+    }
+
+    #[test]
+    fn plain_absolute_path_is_accepted() {
+        let tmp = TempDir::new().unwrap();
+        let file = touch(tmp.path(), "a.txt");
+        let paste = file.to_string_lossy().to_string();
+        let got = parse_dropped_paths(&paste);
+        assert_eq!(got, vec![file]);
+    }
+
+    #[test]
+    fn file_uri_is_decoded_and_accepted() {
+        let tmp = TempDir::new().unwrap();
+        let file = touch(tmp.path(), "hello world.txt");
+        let uri = format!("file://{}", file.to_string_lossy().replace(' ', "%20"));
+        let got = parse_dropped_paths(&uri);
+        assert_eq!(got, vec![file]);
+    }
+
+    #[test]
+    fn single_quoted_iterm2_style() {
+        let tmp = TempDir::new().unwrap();
+        let file = touch(tmp.path(), "quoted.txt");
+        let paste = format!("'{}'", file.to_string_lossy());
+        let got = parse_dropped_paths(&paste);
+        assert_eq!(got, vec![file]);
+    }
+
+    #[test]
+    fn backslash_escaped_spaces() {
+        let tmp = TempDir::new().unwrap();
+        let file = touch(tmp.path(), "name with space.txt");
+        let escaped = file.to_string_lossy().replace(' ', r"\ ").to_string();
+        let got = parse_dropped_paths(&escaped);
+        assert_eq!(got, vec![file]);
+    }
+
+    #[test]
+    fn multi_file_newline_separated() {
+        let tmp = TempDir::new().unwrap();
+        let a = touch(tmp.path(), "a.txt");
+        let b = touch(tmp.path(), "b.txt");
+        let paste = format!("{}\n{}", a.to_string_lossy(), b.to_string_lossy());
+        let got = parse_dropped_paths(&paste);
+        assert_eq!(got, vec![a, b]);
+    }
+
+    #[test]
+    fn trailing_newline_tolerated() {
+        let tmp = TempDir::new().unwrap();
+        let file = touch(tmp.path(), "a.txt");
+        let paste = format!("{}\n", file.to_string_lossy());
+        let got = parse_dropped_paths(&paste);
+        assert_eq!(got, vec![file]);
+    }
+
+    #[test]
+    fn non_existent_absolute_path_rejected() {
+        // Absolute and looks like a path, but doesn't exist on disk.
+        // A drop would only ever hand us a real file, so reject to
+        // avoid pasting arbitrary fake paths into place mode.
+        let got = parse_dropped_paths("/this/does/not/exist/abc.xyz");
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn mixed_valid_and_invalid_keeps_only_valid() {
+        let tmp = TempDir::new().unwrap();
+        let file = touch(tmp.path(), "ok.txt");
+        let paste = format!("{}\n/nope/nope/nope", file.to_string_lossy());
+        let got = parse_dropped_paths(&paste);
+        assert_eq!(got, vec![file]);
+    }
+
+    #[test]
+    fn file_localhost_prefix_stripped() {
+        let tmp = TempDir::new().unwrap();
+        let file = touch(tmp.path(), "loc.txt");
+        let paste = format!("file://localhost{}", file.to_string_lossy());
+        let got = parse_dropped_paths(&paste);
+        assert_eq!(got, vec![file]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod global_search;
 pub mod i18n;
 pub mod input;
 pub mod input_edit;
+pub mod place_mode;
 pub mod prefs;
 pub mod quick_open;
 pub mod search;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use crossterm::{
     event::{
-        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind,
-        KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+        self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+        Event, KeyCode, KeyEventKind, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
+        PushKeyboardEnhancementFlags,
     },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
@@ -22,14 +23,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let original_hook = panic::take_hook();
     panic::set_hook(Box::new(move |panic_info| {
         let _ = disable_raw_mode();
-        // Best-effort teardown — also pop the kbd enhancement flags in case
-        // they were pushed. An unmatched pop is harmless on terminals that
-        // don't support the protocol (they ignore the CSI sequence).
+        // Best-effort teardown — pop the kbd enhancement flags and disable
+        // bracketed paste in case they were enabled. An unmatched pop / a
+        // redundant disable is harmless on terminals that never received
+        // the matching push (they ignore the CSI sequence).
         let _ = execute!(
             io::stdout(),
             PopKeyboardEnhancementFlags,
             LeaveAlternateScreen,
-            DisableMouseCapture
+            DisableMouseCapture,
+            DisableBracketedPaste
         );
         original_hook(panic_info);
     }));
@@ -42,7 +45,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Terminal setup
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        EnableMouseCapture,
+        EnableBracketedPaste
+    )?;
     // Kitty keyboard protocol: ask the terminal to disambiguate escape
     // sequences so `Alt+Arrow` / `Ctrl+Arrow` / `Shift+Enter` etc. arrive
     // as `KeyEvent { code, modifiers }` instead of being collapsed onto
@@ -123,6 +131,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         input::handle_mouse(mouse, &mut app, &terminal);
                     }
                 }
+                Event::Paste(s) => {
+                    input::handle_paste(s, &mut app);
+                }
                 Event::Resize(_, _) => {}
                 _ => {}
             }
@@ -171,7 +182,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     execute!(
         terminal.backend_mut(),
         LeaveAlternateScreen,
-        DisableMouseCapture
+        DisableMouseCapture,
+        DisableBracketedPaste
     )?;
     terminal.show_cursor()?;
 

--- a/src/place_mode.rs
+++ b/src/place_mode.rs
@@ -1,0 +1,365 @@
+//! VSCode-style drag-and-drop destination picker.
+//!
+//! The OS-level drag session ends at the terminal boundary — crossterm only
+//! sees the dropped paths as a bracketed-paste payload, with no way to
+//! observe drag-over or hover position during the drag itself. We sidestep
+//! that by splitting the interaction in two:
+//!
+//! 1. Detect the drop (`input::handle_paste` parses the paste, and if every
+//!    segment resolves to an existing path we call `App::enter_place_mode`).
+//! 2. Hand control to this modal picker: the file tree sprouts a dashed
+//!    root drop-zone border, hovered folder rows highlight, a banner pins
+//!    to the top reminding the user what's about to land, and a click on a
+//!    folder row / the root kicks off an async copy.
+//!
+//! `PlaceModeState` is intentionally tiny — just enough cheap UI state to
+//! drive rendering and input gating. Everything expensive (the recursive
+//! copy itself, name-conflict resolution) runs on the files worker.
+
+use crate::file_tree::TreeEntry;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+/// How long the cursor must rest on a collapsed folder before we auto-expand
+/// it. VSCode's Explorer uses ~500ms; 600ms feels slightly less twitchy on
+/// a terminal where mouse movement is coarser. Tuned by feel.
+pub const HOVER_EXPAND_DELAY: Duration = Duration::from_millis(600);
+
+#[derive(Debug, Default)]
+pub struct PlaceModeState {
+    /// `true` while the modal picker owns input. When set, `input::handle_key`
+    /// and `input::handle_mouse` short-circuit: Esc / right-click cancel,
+    /// clicks on folder rows or the root drop-zone confirm, everything else
+    /// is either scroll (to reach deep folders) or ignored.
+    pub active: bool,
+
+    /// Absolute paths of the items the user is placing. All go to the same
+    /// destination — no per-item picking.
+    pub sources: Vec<PathBuf>,
+
+    /// Index (into `file_tree.entries`) of the folder currently resolved as
+    /// the hover target (either the hovered folder itself, or the parent
+    /// folder of the hovered nested file). Tracks the auto-expand timer
+    /// and the render-time block highlight. `None` when the hover target
+    /// is the root drop zone.
+    pub hover_folder_idx: Option<usize>,
+
+    /// When `hover_folder_idx` was first set to its current value. Cleared
+    /// after we fire the auto-expand so a single long hover expands once,
+    /// not repeatedly.
+    pub hover_since: Option<Instant>,
+}
+
+impl PlaceModeState {
+    /// Primary filename shown in the banner. Picks the first source and
+    /// falls back to `"?"` if the list is somehow empty so the UI never
+    /// renders a naked `Placing 0 file(s)`.
+    ///
+    /// Filenames are sanitised for display: macOS allows control
+    /// characters (`\n`, `\t`, bell, …) in file names and an embedded
+    /// newline would break `Line::from` rendering, splitting the banner
+    /// mid-row and misaligning the accent background. We replace any
+    /// control char with `?` — paths stay recoverable from the sources
+    /// list, the UI stays tidy.
+    pub fn primary_name(&self) -> String {
+        self.sources
+            .first()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .map(sanitize_display)
+            .unwrap_or_else(|| "?".to_string())
+    }
+
+    pub fn count(&self) -> usize {
+        self.sources.len()
+    }
+
+    /// Update the auto-expand tracker. Called on every mouse move in place
+    /// mode. Changing the hovered folder (or moving off any folder) resets
+    /// the timer — otherwise dragging the cursor across a row of folders
+    /// would inherit a timer from the previous one and misfire.
+    pub fn update_hover(&mut self, folder_idx: Option<usize>) {
+        if self.hover_folder_idx != folder_idx {
+            self.hover_folder_idx = folder_idx;
+            self.hover_since = folder_idx.map(|_| Instant::now());
+        }
+    }
+
+    /// Whether enough time has elapsed on the current hover to justify
+    /// firing an auto-expand. Caller is responsible for then clearing
+    /// `hover_since` so we don't re-fire on the next tick.
+    pub fn auto_expand_due(&self, now: Instant) -> Option<usize> {
+        match (self.hover_folder_idx, self.hover_since) {
+            (Some(idx), Some(t)) if now.duration_since(t) >= HOVER_EXPAND_DELAY => Some(idx),
+            _ => None,
+        }
+    }
+}
+
+/// Replace ASCII / Unicode control characters (except space) in a
+/// filename for safe single-line display. Embedded newlines and tabs
+/// are the common offenders on macOS, where the filesystem will happily
+/// accept them and terminals then mis-render the `Line`.
+fn sanitize_display(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_control() { '?' } else { c })
+        .collect()
+}
+
+/// Resolves what a click at `hovered_idx` should drop INTO, given the
+/// current flattened tree. VSCode semantics: folders drop into themselves;
+/// files drop into their parent folder; top-level files drop into the
+/// project root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HoverTarget {
+    /// No folder target — click goes to the project root. Either the
+    /// cursor is on an empty area, or it's on a depth-0 file (whose
+    /// "parent" is the root).
+    Root,
+    /// Click drops INTO `folder_idx`. `block_start .. block_end` is the
+    /// range of visible rows that make up the folder's "block"
+    /// (folder row + all its expanded descendants). Used by render to
+    /// highlight the whole block on hover.
+    Folder {
+        folder_idx: usize,
+        block_start: usize,
+        block_end: usize,
+    },
+}
+
+impl HoverTarget {
+    /// True if `row` falls inside the folder block (for per-row highlight
+    /// during render). Root hovers highlight the whole panel instead of
+    /// any specific block, so this always returns false for `Root`.
+    pub fn contains_row(&self, row: usize) -> bool {
+        matches!(
+            self,
+            HoverTarget::Folder { block_start, block_end, .. }
+                if row >= *block_start && row < *block_end
+        )
+    }
+}
+
+/// Given a flattened tree and a hovered row, compute what the click would
+/// actually target — and, for folder targets, the range of rows that
+/// should light up together as a "block".
+///
+/// Invariant assumed from the file-tree builder: if an entry at depth D
+/// appears at index I, there exists a directory entry at depth D-1
+/// somewhere in `entries[0..I]`. (A nested entry must have a parent.)
+/// If that invariant breaks we fail soft into `Root` rather than panic.
+pub fn resolve_hover_target(entries: &[TreeEntry], hovered_idx: usize) -> HoverTarget {
+    let Some(entry) = entries.get(hovered_idx) else {
+        return HoverTarget::Root;
+    };
+
+    // Pick the folder whose block this row belongs to.
+    let (folder_idx, folder_depth) = if entry.is_dir {
+        (hovered_idx, entry.depth)
+    } else {
+        // Files at depth 0 have no parent folder in the tree — they belong
+        // to the root drop zone.
+        let Some(parent_depth) = entry.depth.checked_sub(1) else {
+            return HoverTarget::Root;
+        };
+        // Walk backwards to the nearest directory entry at `parent_depth`.
+        // The loop can't miss thanks to the invariant above, but we guard
+        // against `idx == 0` so a broken tree degrades instead of panicking.
+        let mut idx = hovered_idx;
+        loop {
+            if idx == 0 {
+                return HoverTarget::Root;
+            }
+            idx -= 1;
+            let e = &entries[idx];
+            if e.is_dir && e.depth == parent_depth {
+                break (idx, parent_depth);
+            }
+        }
+    };
+
+    // Block ends at the first subsequent row with depth <= folder_depth —
+    // that's either a sibling, an uncle, or the end of the tree.
+    let mut block_end = entries.len();
+    for (j, e) in entries.iter().enumerate().skip(folder_idx + 1) {
+        if e.depth <= folder_depth {
+            block_end = j;
+            break;
+        }
+    }
+
+    HoverTarget::Folder {
+        folder_idx,
+        block_start: folder_idx,
+        block_end,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dir(path: &str, depth: usize) -> TreeEntry {
+        TreeEntry {
+            path: PathBuf::from(path),
+            name: path.rsplit('/').next().unwrap_or(path).to_string(),
+            depth,
+            is_dir: true,
+            is_expanded: true,
+            git_status: None,
+        }
+    }
+
+    fn file(path: &str, depth: usize) -> TreeEntry {
+        TreeEntry {
+            path: PathBuf::from(path),
+            name: path.rsplit('/').next().unwrap_or(path).to_string(),
+            depth,
+            is_dir: false,
+            is_expanded: false,
+            git_status: None,
+        }
+    }
+
+    #[test]
+    fn default_is_inactive_and_empty() {
+        let s = PlaceModeState::default();
+        assert!(!s.active);
+        assert_eq!(s.count(), 0);
+        assert_eq!(s.primary_name(), "?");
+    }
+
+    #[test]
+    fn primary_name_reads_basename() {
+        let s = PlaceModeState {
+            active: true,
+            sources: vec![PathBuf::from("/tmp/alpha/beta.txt")],
+            ..PlaceModeState::default()
+        };
+        assert_eq!(s.primary_name(), "beta.txt");
+        assert_eq!(s.count(), 1);
+    }
+
+    #[test]
+    fn primary_name_strips_control_chars() {
+        // Embedded newline (legal on macOS) must not bleed into the
+        // banner — the Line widget would otherwise split mid-row and
+        // misalign the accent background.
+        let s = PlaceModeState {
+            active: true,
+            sources: vec![PathBuf::from("/tmp/na\nme.txt")],
+            ..PlaceModeState::default()
+        };
+        assert_eq!(s.primary_name(), "na?me.txt");
+    }
+
+    #[test]
+    fn sanitize_display_replaces_control_chars() {
+        assert_eq!(sanitize_display("plain.txt"), "plain.txt");
+        assert_eq!(sanitize_display("a\tb"), "a?b");
+        assert_eq!(sanitize_display("a\nb\rc"), "a?b?c");
+        assert_eq!(sanitize_display("中文.rs"), "中文.rs");
+    }
+
+    #[test]
+    fn depth_zero_file_resolves_to_root() {
+        let entries = vec![file("README.md", 0), dir("src", 0)];
+        assert_eq!(resolve_hover_target(&entries, 0), HoverTarget::Root);
+    }
+
+    #[test]
+    fn folder_resolves_to_self_with_full_block() {
+        //  0: ▾ src        (depth 0, folder)
+        //  1:   ▸ ui       (depth 1, folder, collapsed)
+        //  2:   main.rs    (depth 1, file)
+        //  3: README.md    (depth 0, file)
+        let entries = vec![
+            dir("src", 0),
+            TreeEntry {
+                path: "src/ui".into(),
+                name: "ui".into(),
+                depth: 1,
+                is_dir: true,
+                is_expanded: false,
+                git_status: None,
+            },
+            file("src/main.rs", 1),
+            file("README.md", 0),
+        ];
+        let t = resolve_hover_target(&entries, 0); // hovering src
+        assert_eq!(
+            t,
+            HoverTarget::Folder {
+                folder_idx: 0,
+                block_start: 0,
+                block_end: 3, // stops at README.md (depth 0)
+            }
+        );
+    }
+
+    #[test]
+    fn nested_file_resolves_to_parent_folder_block() {
+        //  0: ▾ src
+        //  1:   ▾ ui
+        //  2:     main.rs    ← hover here
+        //  3:     helper.rs
+        //  4:   mod.rs
+        //  5: README.md
+        let entries = vec![
+            dir("src", 0),
+            dir("src/ui", 1),
+            file("src/ui/main.rs", 2),
+            file("src/ui/helper.rs", 2),
+            file("src/mod.rs", 1),
+            file("README.md", 0),
+        ];
+        let t = resolve_hover_target(&entries, 2);
+        assert_eq!(
+            t,
+            HoverTarget::Folder {
+                folder_idx: 1, // ui
+                block_start: 1,
+                block_end: 4, // stops at mod.rs (depth 1)
+            }
+        );
+    }
+
+    #[test]
+    fn contains_row_uses_half_open_range() {
+        let block = HoverTarget::Folder {
+            folder_idx: 1,
+            block_start: 1,
+            block_end: 4,
+        };
+        assert!(block.contains_row(1));
+        assert!(block.contains_row(3));
+        assert!(!block.contains_row(4));
+        assert!(!block.contains_row(0));
+        assert!(!HoverTarget::Root.contains_row(0));
+    }
+
+    #[test]
+    fn update_hover_resets_timer_only_on_change() {
+        let mut s = PlaceModeState::default();
+        s.update_hover(Some(3));
+        let first = s.hover_since;
+        assert!(first.is_some());
+        std::thread::sleep(Duration::from_millis(2));
+        s.update_hover(Some(3)); // same → unchanged
+        assert_eq!(s.hover_since, first);
+        s.update_hover(Some(5)); // different → reset
+        assert!(s.hover_since > first);
+        s.update_hover(None); // clear
+        assert_eq!(s.hover_folder_idx, None);
+        assert_eq!(s.hover_since, None);
+    }
+
+    #[test]
+    fn auto_expand_fires_after_delay() {
+        let mut s = PlaceModeState::default();
+        s.update_hover(Some(2));
+        let start = s.hover_since.unwrap();
+        assert_eq!(s.auto_expand_due(start), None);
+        assert_eq!(s.auto_expand_due(start + HOVER_EXPAND_DELAY), Some(2));
+    }
+}

--- a/src/quick_open.rs
+++ b/src/quick_open.rs
@@ -294,6 +294,24 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
     }
 }
 
+/// Bracketed-paste arrival while the palette is active. Stripping newlines
+/// keeps a multi-line paste from breaking the single-line query model; CRs
+/// from Windows clipboards get the same treatment. Tabs stay as literal
+/// characters — users searching for odd filenames can type them on purpose
+/// and we don't want to drop that signal.
+///
+/// Called from `input::handle_paste` after the drop-path parser has already
+/// ruled out the payload as a file drop.
+pub fn handle_paste(s: &str, app: &mut App) {
+    for c in s.chars() {
+        if c == '\n' || c == '\r' {
+            continue;
+        }
+        input_edit::insert_char(&mut app.quick_open.query, &mut app.quick_open.cursor, c);
+    }
+    filter(&mut app.quick_open);
+}
+
 /// Dispatch one mouse event while the palette is active. The caller
 /// (input.rs) routes all events here instead of the normal mouse pipeline,
 /// so the underlying panels can't receive clicks through the overlay.

--- a/src/search.rs
+++ b/src/search.rs
@@ -171,6 +171,26 @@ pub fn handle_key_in_search_mode(key: KeyEvent, app: &mut App) {
     }
 }
 
+/// Bracketed-paste arrival while the search prompt is active. Same shape
+/// as `quick_open::handle_paste`: fold the payload in as typed chars,
+/// dropping newlines so a multi-line paste doesn't break the single-line
+/// prompt model. Called from `input::handle_paste` after the drop-path
+/// parser has declined the payload.
+pub fn handle_paste(s: &str, app: &mut App) {
+    let mut added = false;
+    for c in s.chars() {
+        if c == '\n' || c == '\r' {
+            continue;
+        }
+        app.search.query.push(c);
+        added = true;
+    }
+    if added {
+        app.search.wrap_msg = None;
+        recompute_and_jump(app, /*from_step=*/ false);
+    }
+}
+
 /// Move to next (`reverse=false`) or previous (`reverse=true`) match. Wraps
 /// around with a Top/Bottom status flash.
 pub fn step(app: &mut App, reverse: bool) {

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -124,6 +124,14 @@ pub enum WorkerResult {
     /// End-of-stream marker for a global search. `truncated=true` means we
     /// hit the result cap; the UI shows "refine query" hinting.
     GlobalSearchDone { generation: u64, truncated: bool },
+    /// Place-mode drag-and-drop copy completion.
+    /// `Ok(count)` is the number of top-level items successfully placed
+    /// at the destination (a directory source counts as 1 regardless of
+    /// how many files were recursively copied beneath it).
+    FileCopy {
+        generation: u64,
+        result: Result<usize, String>,
+    },
 }
 
 enum FilesTask {
@@ -140,6 +148,15 @@ enum FilesTask {
         root: PathBuf,
         rel_path: PathBuf,
         dark: bool,
+    },
+    /// Drag-and-drop copy: each source lands under `dest_dir`. A name
+    /// collision auto-renames VSCode-style (`foo.txt` → `foo (1).txt`).
+    /// Directory sources are copied recursively; symlinks are skipped
+    /// (documented in `copy_sources`).
+    CopyFiles {
+        generation: u64,
+        sources: Vec<PathBuf>,
+        dest_dir: PathBuf,
     },
 }
 
@@ -235,6 +252,14 @@ impl TaskCoordinator {
             root,
             rel_path,
             dark,
+        });
+    }
+
+    pub fn copy_files(&self, generation: u64, sources: Vec<PathBuf>, dest_dir: PathBuf) {
+        let _ = self.files_tx.send(FilesTask::CopyFiles {
+            generation,
+            sources,
+            dest_dir,
         });
     }
 
@@ -351,10 +376,157 @@ fn spawn_files_worker(result_tx: mpsc::Sender<WorkerResult>) -> mpsc::Sender<Fil
                         let result = Ok(file_tree::load_preview(&root, &rel_path, dark));
                         let _ = result_tx.send(WorkerResult::Preview { generation, result });
                     }
+                    FilesTask::CopyFiles {
+                        generation,
+                        sources,
+                        dest_dir,
+                    } => {
+                        let result = copy_sources(&sources, &dest_dir);
+                        let _ = result_tx.send(WorkerResult::FileCopy { generation, result });
+                    }
                 }
             }
         });
     tx
+}
+
+// ─── Drag-and-drop copy helpers ──────────────────────────────────────────────
+
+/// Copy every `source` into `dest_dir`, auto-renaming on name collision
+/// (`foo.txt` → `foo (1).txt` → `foo (2).txt`, …). Directory sources are
+/// recursively copied; the rename rule only applies to the top-level name.
+///
+/// Symlinks encountered during a recursive directory walk are skipped —
+/// Finder's default would be to dereference them and copy the target, but
+/// that widens scope (cycles, broken links, permission surprises) beyond
+/// what this first cut needs to handle. The renderer-side banner flags
+/// "recursive copy"; if symlink fidelity becomes important we can revisit.
+///
+/// Returns the count of top-level items successfully placed, or the first
+/// error encountered. We fail fast on the first error rather than
+/// best-effort so a partial copy doesn't silently miss a file and leave
+/// the user thinking everything succeeded.
+fn copy_sources(sources: &[PathBuf], dest_dir: &Path) -> Result<usize, String> {
+    if !dest_dir.is_dir() {
+        return Err(format!("destination is not a directory: {:?}", dest_dir));
+    }
+    // Canonicalise dest_dir once up front so the self-reference check below
+    // works even when `dest_dir` was passed in as a relative or symlinked
+    // path. `canonicalize` resolves symlinks to their real targets, which
+    // is exactly what we want — a symlinked dest pointing INTO a source
+    // is just as dangerous as a direct path.
+    let canon_dest = dest_dir
+        .canonicalize()
+        .map_err(|e| format!("cannot canonicalize destination {:?}: {}", dest_dir, e))?;
+    let mut count = 0;
+    for source in sources {
+        let basename = source
+            .file_name()
+            .ok_or_else(|| format!("source has no basename: {:?}", source))?;
+
+        // P0 safety: block copying a directory INTO itself or any of its
+        // descendants. Without this, `copy_dir_recursive` walks the
+        // source tree while the destination (which we just created under
+        // it) keeps appearing as a new subdirectory — producing an
+        // infinite nest of folders until the filesystem rejects the
+        // path length. Seen concretely when a user drags a project's
+        // `src/` folder out of Finder and drops it back onto `src/` in
+        // the file tree.
+        if source.is_dir() {
+            let canon_src = source
+                .canonicalize()
+                .map_err(|e| format!("cannot canonicalize source {:?}: {}", source, e))?;
+            if canon_dest == canon_src || canon_dest.starts_with(&canon_src) {
+                return Err(format!(
+                    "cannot copy {:?} into itself or a descendant {:?}",
+                    source, dest_dir
+                ));
+            }
+        }
+
+        let final_dest = resolve_name_conflict(dest_dir, basename);
+        if source.is_dir() {
+            copy_dir_recursive(source, &final_dest)
+                .map_err(|e| format!("copy {:?} → {:?}: {}", source, final_dest, e))?;
+        } else {
+            std::fs::copy(source, &final_dest)
+                .map_err(|e| format!("copy {:?} → {:?}: {}", source, final_dest, e))?;
+        }
+        count += 1;
+    }
+    Ok(count)
+}
+
+/// Find the first non-existing destination filename by appending
+/// ` (N)` to the stem for N = 1, 2, 3… . Matches VSCode's Finder-style
+/// duplicate behavior. Dotfiles (leading-dot, no extension) get the
+/// counter after the whole name: `.env` → `.env (1)`.
+fn resolve_name_conflict(dest_dir: &Path, basename: &std::ffi::OsStr) -> PathBuf {
+    let candidate = dest_dir.join(basename);
+    if !candidate.exists() {
+        return candidate;
+    }
+    let name = basename.to_string_lossy().into_owned();
+    let (stem, ext) = split_stem_ext(&name);
+    for n in 1..u32::MAX {
+        let renamed = match ext {
+            Some(e) => format!("{} ({}).{}", stem, n, e),
+            None => format!("{} ({})", stem, n),
+        };
+        let c = dest_dir.join(&renamed);
+        if !c.exists() {
+            return c;
+        }
+    }
+    // Astronomically unlikely; fall back to a timestamp-style name so we
+    // never loop forever or panic in a production run.
+    dest_dir.join(format!(
+        "{}-{}",
+        name,
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ))
+}
+
+/// Split a filename into `(stem, ext)` at the LAST dot — matching the way
+/// users read filenames. Leading-dot files (no embedded dot) are treated
+/// as "no extension" so `.env` → (".env", None), not ("", "env").
+fn split_stem_ext(name: &str) -> (&str, Option<&str>) {
+    // A leading dot doesn't count as an extension separator.
+    let trimmed = name.trim_start_matches('.');
+    let leading_dots = name.len() - trimmed.len();
+    match trimmed.rfind('.') {
+        Some(rel) => {
+            let abs = leading_dots + rel;
+            let (stem, ext) = name.split_at(abs);
+            // ext starts with '.', skip it
+            (stem, Some(&ext[1..]))
+        }
+        None => (name, None),
+    }
+}
+
+/// Recursive directory copy using a plain DFS walk. Mirrors the source
+/// tree under `dst`, creating intermediate directories as needed.
+/// Symlinks are intentionally skipped (see `copy_sources` doc comment).
+fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let sub_src = entry.path();
+        let sub_dst = dst.join(entry.file_name());
+        if file_type.is_symlink() {
+            continue;
+        } else if file_type.is_dir() {
+            copy_dir_recursive(&sub_src, &sub_dst)?;
+        } else if file_type.is_file() {
+            std::fs::copy(&sub_src, &sub_dst)?;
+        }
+    }
+    Ok(())
 }
 
 fn spawn_git_worker(result_tx: mpsc::Sender<WorkerResult>) -> mpsc::Sender<GitTask> {
@@ -740,4 +912,172 @@ fn strip_trailing_newline(bytes: &[u8]) -> &[u8] {
         end -= 1;
     }
     &bytes[..end]
+}
+
+#[cfg(test)]
+mod copy_tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn split_stem_ext_basic() {
+        assert_eq!(split_stem_ext("foo.txt"), ("foo", Some("txt")));
+        assert_eq!(
+            split_stem_ext("archive.tar.gz"),
+            ("archive.tar", Some("gz"))
+        );
+        assert_eq!(split_stem_ext("README"), ("README", None));
+        // Leading dot alone is not an extension separator.
+        assert_eq!(split_stem_ext(".env"), (".env", None));
+        // But `.env.local` has a real separator after the leading dot.
+        assert_eq!(split_stem_ext(".env.local"), (".env", Some("local")));
+    }
+
+    #[test]
+    fn resolve_name_conflict_increments() {
+        let tmp = TempDir::new().unwrap();
+        let basename = std::ffi::OsString::from("foo.txt");
+
+        // First call returns the plain name.
+        let p0 = resolve_name_conflict(tmp.path(), &basename);
+        assert_eq!(p0.file_name().unwrap(), "foo.txt");
+
+        // Once the plain name exists, the next call renames to "(1)".
+        fs::write(&p0, "").unwrap();
+        let p1 = resolve_name_conflict(tmp.path(), &basename);
+        assert_eq!(p1.file_name().unwrap(), "foo (1).txt");
+
+        fs::write(&p1, "").unwrap();
+        let p2 = resolve_name_conflict(tmp.path(), &basename);
+        assert_eq!(p2.file_name().unwrap(), "foo (2).txt");
+    }
+
+    #[test]
+    fn resolve_name_conflict_dotfile() {
+        let tmp = TempDir::new().unwrap();
+        let basename = std::ffi::OsString::from(".env");
+        fs::write(tmp.path().join(".env"), "").unwrap();
+        let p = resolve_name_conflict(tmp.path(), &basename);
+        assert_eq!(p.file_name().unwrap(), ".env (1)");
+    }
+
+    #[test]
+    fn copy_sources_file_into_dir() {
+        let src_tmp = TempDir::new().unwrap();
+        let dst_tmp = TempDir::new().unwrap();
+        let src = src_tmp.path().join("alpha.txt");
+        fs::write(&src, "hello").unwrap();
+
+        let count = copy_sources(&[src], dst_tmp.path()).unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(
+            fs::read_to_string(dst_tmp.path().join("alpha.txt")).unwrap(),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn copy_sources_recurses_into_directories() {
+        let src_tmp = TempDir::new().unwrap();
+        let dst_tmp = TempDir::new().unwrap();
+
+        let pkg = src_tmp.path().join("pkg");
+        fs::create_dir(&pkg).unwrap();
+        fs::write(pkg.join("one.txt"), "1").unwrap();
+        fs::create_dir(pkg.join("nested")).unwrap();
+        fs::write(pkg.join("nested").join("two.txt"), "2").unwrap();
+
+        let count = copy_sources(std::slice::from_ref(&pkg), dst_tmp.path()).unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(
+            fs::read_to_string(dst_tmp.path().join("pkg").join("one.txt")).unwrap(),
+            "1"
+        );
+        assert_eq!(
+            fs::read_to_string(dst_tmp.path().join("pkg").join("nested").join("two.txt")).unwrap(),
+            "2"
+        );
+    }
+
+    #[test]
+    fn copy_sources_auto_renames_on_collision() {
+        let src_tmp = TempDir::new().unwrap();
+        let dst_tmp = TempDir::new().unwrap();
+
+        let src = src_tmp.path().join("dup.txt");
+        fs::write(&src, "new").unwrap();
+        // Pre-populate dest with the same basename.
+        fs::write(dst_tmp.path().join("dup.txt"), "old").unwrap();
+
+        copy_sources(&[src], dst_tmp.path()).unwrap();
+        // Original untouched.
+        assert_eq!(
+            fs::read_to_string(dst_tmp.path().join("dup.txt")).unwrap(),
+            "old"
+        );
+        // New landed with counter.
+        assert_eq!(
+            fs::read_to_string(dst_tmp.path().join("dup (1).txt")).unwrap(),
+            "new"
+        );
+    }
+
+    #[test]
+    fn copy_sources_rejects_non_directory_dest() {
+        let dst_tmp = TempDir::new().unwrap();
+        let not_a_dir = dst_tmp.path().join("nope.txt");
+        fs::write(&not_a_dir, "").unwrap();
+        let src_tmp = TempDir::new().unwrap();
+        let src = src_tmp.path().join("x");
+        fs::write(&src, "").unwrap();
+        assert!(copy_sources(&[src], &not_a_dir).is_err());
+    }
+
+    #[test]
+    fn copy_sources_blocks_copy_into_self() {
+        // Regression guard for the infinite-recursion bug where dropping
+        // a directory onto itself would walk the tree while creating
+        // new subdirectories under the walked path, blowing out
+        // PATH_MAX. Users hit this by dragging `src/` from Finder and
+        // dropping it onto `src/` in the tree — the bug fills disk.
+        let tmp = TempDir::new().unwrap();
+        let pkg = tmp.path().join("pkg");
+        fs::create_dir(&pkg).unwrap();
+        fs::write(pkg.join("a.txt"), "").unwrap();
+        let err = copy_sources(std::slice::from_ref(&pkg), &pkg).unwrap_err();
+        assert!(
+            err.contains("into itself") || err.contains("descendant"),
+            "expected self-copy rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn copy_sources_blocks_copy_into_descendant() {
+        // Subcase: dropping `src/` onto `src/ui/` — still recursive,
+        // still blocked.
+        let tmp = TempDir::new().unwrap();
+        let pkg = tmp.path().join("pkg");
+        let nested = pkg.join("nested");
+        fs::create_dir_all(&nested).unwrap();
+        let err = copy_sources(std::slice::from_ref(&pkg), &nested).unwrap_err();
+        assert!(err.contains("into itself") || err.contains("descendant"));
+    }
+
+    #[test]
+    fn copy_sources_allows_sibling_dest_same_parent() {
+        // Sanity check: dropping `src/` onto its parent directory (so
+        // the copy lands as an auto-renamed sibling) must still work.
+        // This is the most common "duplicate" case.
+        let tmp = TempDir::new().unwrap();
+        let pkg = tmp.path().join("pkg");
+        fs::create_dir(&pkg).unwrap();
+        fs::write(pkg.join("a.txt"), "hello").unwrap();
+        let count = copy_sources(std::slice::from_ref(&pkg), tmp.path()).unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("pkg (1)").join("a.txt")).unwrap(),
+            "hello"
+        );
+    }
 }

--- a/src/ui/file_tree_panel.rs
+++ b/src/ui/file_tree_panel.rs
@@ -7,9 +7,17 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders};
+use ratatui::widgets::{Block, BorderType, Borders};
 
 pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
+    if app.place_mode.active {
+        render_place_mode(f, app, area);
+    } else {
+        render_normal(f, app, area);
+    }
+}
+
+fn render_normal(f: &mut Frame, app: &mut App, area: Rect) {
     let th = app.theme;
     let block = Block::default()
         .borders(Borders::RIGHT)
@@ -150,5 +158,290 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
         // Register click zone
         app.hit_registry
             .register_row(area.x, y, area.width, ClickAction::TreeClick(global_idx));
+    }
+}
+
+// ─── Place-mode rendering ────────────────────────────────────────────────────
+//
+// Renders the file tree as a VSCode-style drag-and-drop destination picker.
+// Hard-swapped from `render_normal` when `app.place_mode.active`. Shares the
+// same rect layout so the panel slot doesn't shift mid-interaction.
+//
+// Visual contract:
+// - Full double-line accent border around the whole tree panel. This is
+//   *the* root drop zone: any click inside the panel that doesn't hit a
+//   folder row drops into the project root.
+// - A top-inset banner line showing "Placing <name> → click folder, Esc to
+//   cancel", styled with the accent background so it reads as modal.
+// - Folder rows get an accent-colored bold label and highlight-on-hover
+//   with `selection_bg`; they register `ClickAction::PlaceModeFolder(idx)`.
+// - File rows are dimmed and register no click zone, so clicks fall
+//   through to the underlying `PlaceModeRoot` zone (= drop to root).
+//
+// Hit-registry ordering matters: we register the panel-wide `PlaceModeRoot`
+// zone FIRST, then per-folder zones on top. `HitTestRegistry::hit_test`
+// returns the last-registered match, so folder rows shadow the root zone
+// cleanly.
+
+fn render_place_mode(f: &mut Frame, app: &mut App, area: Rect) {
+    use crate::place_mode::{HoverTarget, resolve_hover_target};
+    let th = app.theme;
+
+    // Double-line accent border — the visual cue for "this entire panel is
+    // the root drop zone". Rendering the block consumes one cell on each
+    // side; `inner` is what remains for content.
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Double)
+        .border_style(Style::default().fg(th.accent));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    // Panel-wide root drop zone. Registered first so folder/nested-file
+    // zones can shadow it. Covers the full `area` so there's no dead
+    // strip where clicks vanish.
+    for y in area.y..area.y + area.height {
+        app.hit_registry
+            .register_row(area.x, y, area.width, ClickAction::PlaceModeRoot);
+    }
+
+    // Banner line, inset 1 from the top of the inner area. The accent bg
+    // + contrast fg make this a high-visibility "modal active" marker —
+    // the previous `selection_bg` tint blended in with the rest of the UI
+    // so users couldn't tell they were in place mode. `unicode_width`
+    // (not `.chars().count()`) is load-bearing because the banner holds
+    // a wide emoji; char count would under-pad the right edge by a cell.
+    //
+    // While a copy worker is actually running, swap the banner to a
+    // "⋯ Copying…" indicator so large directory copies show evidence of
+    // life. Without this, the UI looks identical to "nothing happened"
+    // for the duration of a 10GB folder copy.
+    let banner_text = if app.file_copy_load.loading {
+        crate::i18n::place_mode_copying_banner()
+    } else {
+        crate::i18n::place_mode_banner(&app.place_mode.primary_name(), app.place_mode.count())
+    };
+    let banner_style = Style::default()
+        .fg(th.chrome_bg)
+        .bg(th.accent)
+        .add_modifier(Modifier::BOLD);
+    let banner_width = inner.width as usize;
+    let used = unicode_width::UnicodeWidthStr::width(banner_text.as_str());
+    let mut banner_line = banner_text.clone();
+    if used < banner_width {
+        banner_line.push_str(&" ".repeat(banner_width - used));
+    }
+    f.render_widget(
+        Line::from(Span::styled(banner_line.clone(), banner_style)),
+        Rect::new(inner.x, inner.y, inner.width, 1),
+    );
+
+    // Tree content starts one row below the banner.
+    let tree_area = Rect::new(
+        inner.x,
+        inner.y.saturating_add(1),
+        inner.width,
+        inner.height.saturating_sub(1),
+    );
+    let padded = Rect::new(
+        tree_area.x + 1,
+        tree_area.y,
+        tree_area.width.saturating_sub(1),
+        tree_area.height,
+    );
+
+    // ── Compute the current hover target ──
+    //
+    // `hover_row` / `hover_col` are written by the last mouse Moved event.
+    // Translate that back to an entry index (taking scroll into account),
+    // then let `resolve_hover_target` figure out which block (if any) the
+    // click would land in.
+    let cursor_in_panel = app
+        .hover_col
+        .map(|c| c >= area.x && c < area.x + area.width)
+        .zip(
+            app.hover_row
+                .map(|r| r >= area.y && r < area.y + area.height),
+        )
+        .map(|(a, b)| a && b)
+        .unwrap_or(false);
+
+    let scroll = {
+        let max_scroll = app
+            .file_tree
+            .entries
+            .len()
+            .saturating_sub(padded.height as usize);
+        let s = app.tree_scroll.min(max_scroll);
+        app.tree_scroll = s;
+        s
+    };
+    let max_y = padded.y + padded.height;
+
+    let hovered_entry_idx = if cursor_in_panel {
+        app.hover_row.and_then(|r| {
+            if r >= padded.y && r < max_y {
+                let visual = (r - padded.y) as usize;
+                let idx = scroll + visual;
+                if idx < app.file_tree.entries.len() {
+                    Some(idx)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+    } else {
+        None
+    };
+
+    let hover_target = match hovered_entry_idx {
+        Some(idx) => resolve_hover_target(&app.file_tree.entries, idx),
+        None if cursor_in_panel => HoverTarget::Root,
+        None => HoverTarget::Root, // cursor elsewhere — no highlight applied below
+    };
+
+    // Drive the auto-expand tracker. Only folder targets count; root-target
+    // hovers shouldn't keep a timer running for the most recent folder.
+    let active_folder_idx = match &hover_target {
+        HoverTarget::Folder { folder_idx, .. } if cursor_in_panel => Some(*folder_idx),
+        _ => None,
+    };
+    app.place_mode.update_hover(active_folder_idx);
+
+    // ── Root-hover whole-panel fill ──
+    //
+    // User asked for "hovering empty space highlights the entire left side
+    // as a signal for root-drop". We paint a bright tint over the whole
+    // interior when the hover target is Root AND the cursor is inside the
+    // panel — otherwise the modal is quiet until the mouse enters. Using
+    // `selection_bg` (a clearly-blue tint) rather than `hover_bg` (which
+    // in dark theme is almost indistinguishable from the default bg) so
+    // the "drop-at-root" state reads at a glance.
+    let root_hover = cursor_in_panel && matches!(hover_target, HoverTarget::Root);
+    if root_hover {
+        f.render_widget(
+            Block::default().style(Style::default().bg(th.selection_bg)),
+            inner,
+        );
+        // Re-draw the banner on top so the fill doesn't cover it.
+        f.render_widget(
+            Line::from(Span::styled(banner_line.clone(), banner_style)),
+            Rect::new(inner.x, inner.y, inner.width, 1),
+        );
+    }
+
+    let entries = &app.file_tree.entries;
+    if entries.is_empty() {
+        let msg = Line::from(Span::styled(
+            t(Msg::EmptyDir),
+            Style::default().fg(th.fg_secondary),
+        ));
+        f.render_widget(msg, Rect::new(padded.x, padded.y, padded.width, 1));
+        return;
+    }
+
+    for (i, entry) in entries.iter().skip(scroll).enumerate() {
+        let y = padded.y + i as u16;
+        if y >= max_y {
+            break;
+        }
+        let global_idx = scroll + i;
+
+        let in_block = hover_target.contains_row(global_idx);
+
+        let indent = "  ".repeat(entry.depth);
+        let icon = if entry.is_dir {
+            if entry.is_expanded { "▾ " } else { "▸ " }
+        } else {
+            "  "
+        };
+
+        // Row bg + fg are a package deal in place mode. We pick a mode
+        // based on where this row sits relative to the current hover:
+        //
+        // - `in_block` (hovered folder block)   → accent bg + chrome-bg fg.
+        //   Maximum contrast: whatever the theme's loud colour is becomes
+        //   a solid bar behind the block, with dark-on-light (or
+        //   light-on-dark) text. This is what the user reaches for.
+        // - `root_hover` (whole panel drop-to-root)
+        //                                       → selection_bg + normal fg.
+        //   Softer than the block highlight so the two modes are
+        //   visually distinct — the user can tell "I'm dropping into THIS
+        //   folder" vs. "I'm dropping to the project root".
+        // - everything else                     → no bg, dimmed fg for
+        //   files, accent fg for folders. The row just sits there.
+        enum RowMode {
+            InBlock,
+            RootHover,
+            Idle,
+        }
+        let mode = if in_block {
+            RowMode::InBlock
+        } else if root_hover {
+            RowMode::RootHover
+        } else {
+            RowMode::Idle
+        };
+
+        let row_bg = match mode {
+            RowMode::InBlock => Some(th.accent),
+            RowMode::RootHover => Some(th.selection_bg),
+            RowMode::Idle => None,
+        };
+        let bg_style = match row_bg {
+            Some(c) => Style::default().bg(c),
+            None => Style::default(),
+        };
+
+        let name_fg = match mode {
+            RowMode::InBlock => th.chrome_bg, // high-contrast on the accent bg
+            _ => {
+                if entry.is_dir {
+                    th.accent
+                } else {
+                    th.fg_secondary
+                }
+            }
+        };
+        let icon_fg = match mode {
+            RowMode::InBlock => th.chrome_bg,
+            _ => th.fg_secondary,
+        };
+        let mut name_style = Style::default().fg(name_fg);
+        if entry.is_dir {
+            name_style = name_style.add_modifier(Modifier::BOLD);
+        }
+
+        let mut spans = vec![
+            Span::styled(indent.clone(), bg_style),
+            Span::styled(icon, Style::default().fg(icon_fg).patch(bg_style)),
+        ];
+        spans.push(Span::styled(entry.name.clone(), name_style.patch(bg_style)));
+
+        let content_width: usize = indent.len() + icon.len() + entry.name.len();
+        let pad = (padded.width as usize).saturating_sub(content_width);
+        if pad > 0 {
+            spans.push(Span::styled(" ".repeat(pad), bg_style));
+        }
+
+        let line = Line::from(spans);
+        f.render_widget(line, Rect::new(padded.x, y, padded.width, 1));
+
+        // Per-row click zone:
+        // - Folder row → dropping lands in that folder.
+        // - Nested file (depth > 0) → lands in its parent folder.
+        // - Top-level file (depth 0) → no zone, falls through to the
+        //   panel-wide `PlaceModeRoot` registered above.
+        let action = match resolve_hover_target(entries, global_idx) {
+            HoverTarget::Folder { folder_idx, .. } => {
+                Some(ClickAction::PlaceModeFolder(folder_idx))
+            }
+            HoverTarget::Root => None,
+        };
+        if let Some(a) = action {
+            app.hit_registry.register_row(area.x, y, area.width, a);
+        }
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -316,6 +316,39 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
         return;
     }
 
+    // Place-mode modal indicator. Mirrors the select-mode pattern: a loud
+    // badge in the accent color so the user can't miss that a mode is
+    // active, plus a hint describing how to commit or cancel. When a
+    // copy is actively running the hint swaps to a copying indicator so
+    // the status bar proves the worker is still alive on big transfers.
+    if app.place_mode.active {
+        let copying = app.file_copy_load.loading;
+        let (badge_text, hint_text) = if copying {
+            (" 📋 COPYING ", crate::i18n::place_mode_copying_banner())
+        } else {
+            (
+                " 📋 PLACE ",
+                crate::i18n::place_mode_status_hint().to_string(),
+            )
+        };
+        let hint = Line::from(vec![
+            Span::styled(
+                badge_text,
+                Style::default()
+                    .fg(th.chrome_bg)
+                    .bg(th.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(hint_text, Style::default().fg(th.accent).bg(th.chrome_bg)),
+            Span::styled(
+                " ".repeat(area.width.saturating_sub(80) as usize),
+                Style::default().bg(th.chrome_bg),
+            ),
+        ]);
+        f.render_widget(hint, area);
+        return;
+    }
+
     // Show the most recent toast (push success/failure etc.) inline.
     let (notif, notif_color) = match app.toasts.last() {
         Some(t) => (
@@ -451,6 +484,7 @@ fn render_help(f: &mut Frame, app: &App, screen: Rect) {
         ("h", t(Msg::HelpShowHelp)),
         ("Space p", t(Msg::HelpQuickOpen)),
         ("Space f", t(Msg::HelpGlobalSearch)),
+        (t(Msg::HelpKeyDragDrop), t(Msg::HelpDragDrop)),
         (t(Msg::HelpKeyAnyKey), t(Msg::HelpAnyKey)),
     ];
 

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -39,6 +39,13 @@ pub enum ClickAction {
         dbl_command: Option<String>,
         dbl_args: Option<serde_json::Value>,
     },
+    /// Place-mode destination: dropping onto a specific folder row.
+    /// Index into `file_tree.entries`; must point at a directory entry.
+    PlaceModeFolder(usize),
+    /// Place-mode destination: dropping onto the root drop-zone (the dashed
+    /// border surrounding the whole file tree, or any tree-panel spot that
+    /// isn't a folder row).
+    PlaceModeRoot,
 }
 
 #[derive(Debug, Clone)]

--- a/tests/snapshots/ui_snapshots__place_mode.snap
+++ b/tests/snapshots/ui_snapshots__place_mode.snap
@@ -1,0 +1,24 @@
+---
+source: tests/ui_snapshots.rs
+expression: output
+---
+ reef  [TMPDIR]  ⎇ master
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph           1:Files 2:Search 3:Git 4:Graph
+╔══════════════════════╗
+║ 📋  Placing README.md ║
+║ ▸ src                ║
+║   README.md          ║
+║                      ║
+║                      ║
+║                      ║
+║                      ║
+║                      ║                  Select a file to preview
+║                      ║
+║                      ║
+║                      ║
+║                      ║
+║                      ║
+║                      ║
+║                      ║
+╚══════════════════════╝
+ 📋  PLACE   Click a folder to drop · click empty to drop at root · Esc / right-c

--- a/tests/ui_snapshots.rs
+++ b/tests/ui_snapshots.rs
@@ -135,6 +135,50 @@ fn snapshot_with_staged_and_unstaged() {
 }
 
 #[test]
+fn snapshot_place_mode_renders_banner_and_border() {
+    // Lock in the VSCode-style drag-and-drop picker visuals: double-line
+    // accent border + top banner + dimmed file rows vs. accent folder rows.
+    // Regressions here would indicate the place-mode render path drifted
+    // — the shape of the banner and the root drop zone are both part of
+    // the feature's UX contract.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    force_en_lang();
+    let (tmp, raw) = tempdir_repo();
+    // A small tree with a folder and a file so the snapshot exercises
+    // both row styles.
+    commit_file(&raw, "README.md", "# hi\n", "init");
+    std::fs::create_dir(tmp.path().join("src")).unwrap();
+    write_file(&raw, "src/main.rs", "fn main() {}\n");
+    let home = tempfile::TempDir::new().expect("home tempdir");
+    let _h = HomeGuard::enter(home.path());
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark());
+    // Force a tree rebuild so `src/` and `README.md` show up before the
+    // snapshot draw (the async load fires from `App::new` via tick).
+    app.refresh_file_tree();
+    // Drain worker results until the tree is populated.
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        app.tick();
+        if !app.file_tree_load.loading && !app.file_tree.entries.is_empty() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    // Source file used for the banner — has to exist on disk because
+    // place mode itself is entered via `enter_place_mode` which accepts
+    // any `Vec<PathBuf>`, but users would only ever land here with real
+    // paths thanks to `parse_dropped_paths`.
+    let source = tmp.path().join("README.md");
+    app.enter_place_mode(vec![source]);
+
+    let output = render_app(&mut app, 80, 20);
+    with_filters(|| insta::assert_snapshot!("place_mode", output));
+}
+
+#[test]
 fn snapshot_with_staged_and_unstaged_light_theme() {
     // Locks in the light-theme wiring: a dark-vs-light snapshot diff must exist
     // somewhere, otherwise the Theme plumbing could silently regress to dark.


### PR DESCRIPTION
## Summary

- Drop a file or folder from Finder/Explorer onto the terminal → modal "place mode" lights up the file tree. Hover a folder to highlight its block, click to copy there; hover empty space to drop at the project root; Esc / right-click / q / Ctrl+C cancel.
- Copy runs on the files worker with VSCode-style auto-rename on conflict (`foo.txt` → `foo (1).txt`), recursive directory copy (symlinks skipped), and canonical self-reference guard so dragging `src/` onto `src/` errors with a toast instead of filling the disk up to PATH_MAX.
- Hover 600ms auto-expands collapsed folders. `📋 PLACE` / `📋 COPYING` status-bar badge + double-line accent border + banner make the modal impossible to miss. Refuses to enter while in select mode or during an in-flight copy.

## Why two-phase

Terminals don't forward OS drag-over events. Crossterm only sees the dropped path as **bracketed paste** when the cursor lands, so a one-phase "drop at hover position" UX is impossible. The paste enters place mode, and the user picks a destination with normal TUI hover + click.

## Path parser

`parse_dropped_paths` handles the real-world formats:
- iTerm2 single-quoted + `\ `-escaped
- Ghostty / WezTerm / Alacritty raw path
- GNOME Terminal `file://` URI with `%xx` encoding
- Newline-separated multi-drops

Absolute-path + `exists()` is required — keeps typing "settings.json" into quick-open from false-positive-ing into place mode.

## Footgun guards

| Situation | Behavior |
|---|---|
| Drop in select mode (`v`) | Refused — mouse capture off, no way to click. Toast points at `v` |
| In-flight copy + new drop | Refused — generation invalidation would silently drop the earlier copy's success toast |
| Rage-click second folder during copy | Same guard (request_file_copy dedupe) |
| Dir onto itself / descendant | Canonical path check, error toast |
| Filename with `\n` / `\t` | Replaced with `?` in display — stops `Line::from` breaking mid-row |
| Help / quick-open / search active | Closed on enter_place_mode so modal UI stays unambiguous |
| Failed copy | Stale state + error cleared after toast so activity bar doesn't show "copy error: …" indefinitely |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (250 tests pass — 205 lib + 45 integration/snapshot; 26 new)
  - `parse_dropped_paths` table-driven: plain, `file://`, single/double quoted, `\ `-escaped, multi-line, mixed valid/invalid, `localhost` URI
  - `resolve_name_conflict`: sequence `foo.txt → foo (1).txt → foo (2).txt`; dotfile `.env → .env (1)`
  - `copy_sources`: file copy, nested directory recursion, auto-rename on collision, rejects non-dir dest
  - Self-reference guard: blocks copy-into-self, blocks copy-into-descendant, allows sibling
  - `HoverTarget::resolve_hover_target`: depth-0 file → Root, folder → self-block, nested file → parent block
  - `PlaceModeState`: update_hover reset-on-change, auto_expand_due timing, primary_name control-char sanitization
  - `snapshot_place_mode_renders_banner_and_border`: locks in the double-line border + banner + tree rendering
- [ ] Cross-terminal manual pass (can't automate — paste format varies):
  - [ ] iTerm2 / Ghostty / WezTerm: single file, multiple files, folder, spaces-in-name
  - [ ] tmux (inside iTerm2) — confirm bracketed paste passes through
  - [ ] Auto-rename: drop `foo.txt` onto folder with existing `foo.txt`
  - [ ] Paste a code snippet into quick-open → should type as text, **not** trigger place mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)