### PR TITLE
fix(diff): clamp vertical scroll at last row

### DIFF
--- a/src/ui/diff_panel.rs
+++ b/src/ui/diff_panel.rs
@@ -76,6 +76,13 @@ fn render_unified(f: &mut Frame, app: &mut App, area: Rect, diff: &DiffContent) 
     // Remember viewport height for search-jump centering.
     app.last_diff_view_h = visible_rows as u16;
 
+    // Clamp vertical scroll so we can't scroll past the last displayable row.
+    // Must come before the horizontal max-width calc below, which itself
+    // uses `skip(app.diff_scroll)` and would see an empty slice if we let
+    // the offset run past the end.
+    let max_scroll = all_lines.len().saturating_sub(visible_rows);
+    app.diff_scroll = app.diff_scroll.min(max_scroll);
+
     // Clamp horizontal scroll against the widest Content line currently in view.
     let max_visible_w: usize = all_lines
         .iter()
@@ -333,6 +340,10 @@ fn render_side_by_side(f: &mut Frame, app: &mut App, area: Rect, diff: &DiffCont
     let right_content_w = (right_w as usize).saturating_sub(gutter);
     let visible_rows = max_y.saturating_sub(y) as usize;
     app.last_diff_view_h = visible_rows as u16;
+
+    // Clamp vertical scroll so we can't scroll past the last displayable row.
+    let max_scroll = all_lines.len().saturating_sub(visible_rows);
+    app.diff_scroll = app.diff_scroll.min(max_scroll);
 
     // Clamp horizontal scroll against the widest text column in view (either side).
     let max_visible_w: usize = all_lines


### PR DESCRIPTION
## Summary
- Git-tab diff panel could scroll infinitely past the last hunk — `app.diff_scroll` was never clamped against content length, so `j`/`↓`/`PageDown`/`Ctrl+J` and mouse wheel just ran the offset off the end while the viewport drew nothing.
- Added a render-time vertical clamp in both `render_unified` and `render_side_by_side` (`src/ui/diff_panel.rs`), mirroring the pattern already in `file_preview_panel.rs:100-101` and `commit_detail_panel.rs:32-35`.
- Placed **before** the existing horizontal clamp, which uses `skip(app.diff_scroll)` and would otherwise see an empty slice when the vertical offset is out of range.

## Test plan
- [x] `cargo build`
- [x] `cargo test` (diff_panel: 12/12, lib: 225/225; only the pre-existing flaky `fs_watcher_integration` timeouts failed, unrelated)
- [ ] Git tab → Unified: `j` / `↓` / `Ctrl+J` / `PageDown` / wheel-down stop at last row
- [ ] Git tab → Side-by-side (`m` toggle): same
- [ ] Short file (fewer rows than viewport): cannot scroll down at all
- [ ] Files / Search tab preview: still stops at end (regression check — was already clamped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)