### PR TITLE
feat(search): Alt/Ctrl editing shortcuts in / and ? prompt

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -11,6 +11,7 @@
 //! consumes them.
 
 use crate::app::{App, Panel, SelectedFile, Tab};
+use crate::input_edit;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use std::ops::Range;
 
@@ -60,6 +61,8 @@ pub struct SearchState {
     pub active: bool,
     pub backwards: bool,
     pub query: String,
+    /// Byte offset into `query`. Always on a char boundary.
+    pub cursor: usize,
     pub target: Option<SearchTarget>,
     pub matches: Vec<MatchLoc>,
     pub current: Option<usize>,
@@ -117,6 +120,7 @@ pub fn begin(app: &mut App, backwards: bool) {
         active: true,
         backwards,
         query: String::new(),
+        cursor: 0,
         target: Some(target),
         matches: Vec::new(),
         current: None,
@@ -149,23 +153,96 @@ pub fn exit_cancel(app: &mut App) {
 /// handled (always true when active — we fully own input while the prompt
 /// is up).
 pub fn handle_key_in_search_mode(key: KeyEvent, app: &mut App) {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
+
+    // Helper: called after any op that mutates `query`. Pure cursor moves
+    // don't need this — they leave matches / wrap_msg untouched.
+    fn after_edit(app: &mut App) {
+        app.search.wrap_msg = None;
+        recompute_and_jump(app, /*from_step=*/ false);
+    }
+
     match key.code {
+        // ── Exit ────────────────────────────────────────────────
         KeyCode::Esc => exit_cancel(app),
-        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => exit_cancel(app),
+        KeyCode::Char('c') if ctrl => exit_cancel(app),
         KeyCode::Enter => exit_confirm(app),
-        KeyCode::Backspace => {
-            app.search.query.pop();
-            app.search.wrap_msg = None;
-            recompute_and_jump(app, /*from_step=*/ false);
+
+        // ── Deletion ─────────────────────────────────────────────
+        // Word-delete variants come before plain Backspace so modifier
+        // combos win the match.
+        KeyCode::Backspace if alt || ctrl => {
+            input_edit::delete_word_backward(&mut app.search.query, &mut app.search.cursor);
+            after_edit(app);
         }
-        KeyCode::Char(c) => {
-            // Ignore control-modified chars other than Ctrl+C (handled above).
-            if key.modifiers.contains(KeyModifiers::CONTROL) {
-                return;
-            }
-            app.search.query.push(c);
-            app.search.wrap_msg = None;
-            recompute_and_jump(app, /*from_step=*/ false);
+        KeyCode::Char('w') if ctrl => {
+            input_edit::delete_word_backward(&mut app.search.query, &mut app.search.cursor);
+            after_edit(app);
+        }
+        KeyCode::Char('u') if ctrl => {
+            input_edit::clear(&mut app.search.query, &mut app.search.cursor);
+            after_edit(app);
+        }
+        KeyCode::Backspace => {
+            input_edit::backspace(&mut app.search.query, &mut app.search.cursor);
+            after_edit(app);
+        }
+
+        // ── Cursor movement ─────────────────────────────────────
+        // Alt/Ctrl + arrow = jump by word; must precede bare-arrow arms.
+        KeyCode::Left if alt || ctrl => {
+            input_edit::move_cursor_word_backward(&app.search.query, &mut app.search.cursor);
+        }
+        KeyCode::Right if alt || ctrl => {
+            input_edit::move_cursor_word_forward(&app.search.query, &mut app.search.cursor);
+        }
+        KeyCode::Left => {
+            input_edit::move_cursor(&app.search.query, &mut app.search.cursor, -1);
+        }
+        KeyCode::Right => {
+            input_edit::move_cursor(&app.search.query, &mut app.search.cursor, 1);
+        }
+        KeyCode::Home => {
+            app.search.cursor = 0;
+        }
+        KeyCode::End => {
+            app.search.cursor = app.search.query.len();
+        }
+
+        // ── Forward-delete ──────────────────────────────────────
+        KeyCode::Delete if alt || ctrl => {
+            input_edit::delete_word_forward(&mut app.search.query, &mut app.search.cursor);
+            after_edit(app);
+        }
+        KeyCode::Delete => {
+            input_edit::delete_char_forward(&mut app.search.query, &mut app.search.cursor);
+            after_edit(app);
+        }
+
+        // ── Readline aliases ────────────────────────────────────
+        // Fallback for terminals that don't forward Alt/Ctrl+Arrow cleanly.
+        KeyCode::Char('b') if alt => {
+            input_edit::move_cursor_word_backward(&app.search.query, &mut app.search.cursor);
+        }
+        KeyCode::Char('f') if alt => {
+            input_edit::move_cursor_word_forward(&app.search.query, &mut app.search.cursor);
+        }
+        KeyCode::Char('d') if alt => {
+            input_edit::delete_word_forward(&mut app.search.query, &mut app.search.cursor);
+            after_edit(app);
+        }
+        KeyCode::Char('a') if ctrl => {
+            app.search.cursor = 0;
+        }
+        KeyCode::Char('e') if ctrl => {
+            app.search.cursor = app.search.query.len();
+        }
+
+        // ── Insertion ───────────────────────────────────────────
+        KeyCode::Char(c) if !ctrl => {
+            input_edit::insert_char(&mut app.search.query, &mut app.search.cursor, c);
+            after_edit(app);
         }
         _ => {}
     }
@@ -182,7 +259,7 @@ pub fn handle_paste(s: &str, app: &mut App) {
         if c == '\n' || c == '\r' {
             continue;
         }
-        app.search.query.push(c);
+        input_edit::insert_char(&mut app.search.query, &mut app.search.cursor, c);
         added = true;
     }
     if added {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -449,7 +449,6 @@ fn render_search_prompt(f: &mut Frame, app: &App, area: Rect) {
     };
 
     let prompt_text = format!("{}{}", prefix, query);
-    let prompt_width = UnicodeWidthStr::width(prompt_text.as_str()) as u16;
     let right_width = UnicodeWidthStr::width(right.as_str()) as u16;
 
     // Draw background fill for the whole row first.
@@ -479,9 +478,13 @@ fn render_search_prompt(f: &mut Frame, app: &App, area: Rect) {
         );
     }
 
-    // Blinking terminal cursor at the tail of the query — lets the user see
-    // their insertion point without a static `█` glyph.
-    let cursor_x = area.x + prompt_width.min(area.width.saturating_sub(1));
+    // Blinking terminal cursor at the current insertion point — lets the user
+    // see where new chars will land without a static `█` glyph.
+    let prefix_w = 1u16; // '/' and '?' are always narrow.
+    let cursor_w =
+        UnicodeWidthStr::width(&app.search.query[..app.search.cursor.min(app.search.query.len())])
+            as u16;
+    let cursor_x = area.x + (prefix_w + cursor_w).min(area.width.saturating_sub(1));
     f.set_cursor_position((cursor_x, area.y));
 }
 


### PR DESCRIPTION
## Summary
- 面内搜索（按 `/` 或 `?` 触发）之前只支持追加 / 单字符 Backspace，与 global-search、quick-open 等输入框的编辑体验不一致
- 在 `SearchState` 上补 `cursor: usize`，把编辑操作全部走 `input_edit::*` 原语：Alt/Ctrl+←/→ 按词移动、Alt/Ctrl+Backspace / Ctrl+W 按词删、Home/End + Ctrl+A/E 瞬移首尾、Delete 及其词变体、Ctrl+U 清空、Alt+B/F/D readline 别名
- `render_search_prompt` 按光标位置而非 prompt 末尾放终端光标；`handle_paste` 也改走 `insert_char`

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --lib`（232 passed；失败的 fs_watcher 集成测试与本改动无关）
- [ ] 人工：在 Files / Git / Graph 三个 tab 里用 `/` 搜索，验证 Alt+Backspace 按词删、Alt+←/→ 按词跳、光标在中间插入、CJK 边界、bracketed paste 落点正确
- [ ] 人工：`Esc` 仍恢复 snapshot；`Enter` 仍确认并保留 `n`/`N` 步进

🤖 Generated with [Claude Code](https://claude.com/claude-code)