### PR TITLE
feat(git-status): show +N -M numstat and discard-all actions

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -58,12 +58,24 @@ pub enum DiffMode {
     FullFile, // 显示整个文件
 }
 
+/// What the user is about to discard when the confirmation banner is up.
+/// `File` is the original single-file ↺ flow; `Folder` covers the tree-mode
+/// per-directory button; `Section` covers the header-level "discard all"
+/// button for the staged or unstaged list. Staged targets get reset to
+/// HEAD (unstage + restore); unstaged targets just restore from the index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscardTarget {
+    File(String),
+    Folder { is_staged: bool, path: String },
+    Section { is_staged: bool },
+}
+
 /// State for the inline Git status sidebar.
 #[derive(Debug, Default)]
 pub struct GitStatusState {
     pub tree_mode: bool,
     pub collapsed_dirs: HashSet<String>,
-    pub confirm_discard: Option<String>,
+    pub confirm_discard: Option<DiscardTarget>,
     pub confirm_push: bool,
     pub confirm_force_push: bool,
     /// Last `git push` failure surfaced as an in-panel banner. Cleared by a
@@ -1040,27 +1052,69 @@ impl App {
         self.load_diff();
     }
 
-    /// Restore the currently-confirmed unstaged file to its HEAD state.
-    /// Clears the confirmation banner and selection if the discarded file
-    /// was selected, then refreshes status + diff.
+    /// Apply the currently-pending discard target. Clears the confirmation
+    /// banner, drops the selection if the discarded path(s) include it,
+    /// then refreshes status + diff.
+    ///
+    /// Semantics by target:
+    /// * `File` — restore a single unstaged file to its HEAD state (existing
+    ///   ↺ behaviour).
+    /// * `Folder { is_staged }` — for every file currently listed under that
+    ///   directory prefix, do a section-flavoured revert (see `Section`).
+    /// * `Section { is_staged }` — for every file in the section: if staged,
+    ///   unstage then restore workdir to HEAD (full revert); if unstaged,
+    ///   restore workdir to index.
     pub fn confirm_discard(&mut self) {
-        let Some(path) = self.git_status.confirm_discard.take() else {
+        let Some(target) = self.git_status.confirm_discard.take() else {
             return;
         };
-        if let Some(ref repo) = self.repo {
-            let _ = repo.restore_file(&path);
-        }
-        if self
-            .selected_file
-            .as_ref()
-            .map(|s| s.path == path)
-            .unwrap_or(false)
-        {
-            self.selected_file = None;
-            self.diff_content = None;
+        let discarded_paths = self.apply_discard_target(&target);
+        if let Some(sel) = self.selected_file.as_ref() {
+            if discarded_paths.contains(&sel.path) {
+                self.selected_file = None;
+                self.diff_content = None;
+            }
         }
         self.refresh_status();
         self.load_diff();
+    }
+
+    fn apply_discard_target(&mut self, target: &DiscardTarget) -> HashSet<String> {
+        let mut touched: HashSet<String> = HashSet::new();
+        let Some(repo) = self.repo.as_ref() else {
+            return touched;
+        };
+        match target {
+            DiscardTarget::File(path) => {
+                let _ = repo.restore_file(path);
+                touched.insert(path.clone());
+            }
+            DiscardTarget::Folder { is_staged, path } => {
+                let source: Vec<String> = if *is_staged {
+                    self.staged_files.iter().map(|f| f.path.clone()).collect()
+                } else {
+                    self.unstaged_files.iter().map(|f| f.path.clone()).collect()
+                };
+                for p in source {
+                    if folder_contains(path, &p) {
+                        revert_path(repo, &p, *is_staged);
+                        touched.insert(p);
+                    }
+                }
+            }
+            DiscardTarget::Section { is_staged } => {
+                let source: Vec<String> = if *is_staged {
+                    self.staged_files.iter().map(|f| f.path.clone()).collect()
+                } else {
+                    self.unstaged_files.iter().map(|f| f.path.clone()).collect()
+                };
+                for p in source {
+                    revert_path(repo, &p, *is_staged);
+                    touched.insert(p);
+                }
+            }
+        }
+        touched
     }
 
     /// Rebuild the commit graph iff HEAD or any ref moved since the last build.
@@ -2127,6 +2181,28 @@ impl App {
     }
 }
 
+// ─── Discard helpers ──────────────────────────────────────────────────────────
+
+/// Revert a single workdir path under the rules used by the "discard all"
+/// and "discard folder" flows. Staged paths are reset to HEAD (unstage +
+/// restore workdir); unstaged paths keep the existing single-file semantics.
+fn revert_path(repo: &GitRepo, path: &str, is_staged: bool) {
+    if is_staged {
+        let _ = repo.unstage_file(path);
+    }
+    let _ = repo.restore_file(path);
+}
+
+/// True when `file_path` lives under the directory at `folder_path` (direct
+/// child or deeper). Tolerates a trailing slash on `folder_path` and handles
+/// the edge case where `file_path` *is* `folder_path` — that should never
+/// happen from UI-driven targets but keeps the Folder discard flow safe if
+/// a caller constructs one programmatically.
+fn folder_contains(folder_path: &str, file_path: &str) -> bool {
+    let prefix = format!("{}/", folder_path.trim_end_matches('/'));
+    file_path == folder_path || file_path.starts_with(&prefix)
+}
+
 // ─── Prefs persistence ────────────────────────────────────────────────────────
 
 /// Load the Git tab's diff layout + mode from the unified prefs file.
@@ -2161,4 +2237,54 @@ fn save_prefs(layout: DiffLayout, mode: DiffMode) {
             DiffMode::FullFile => "full_file",
         },
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::folder_contains;
+
+    #[test]
+    fn folder_contains_direct_child() {
+        assert!(folder_contains("src/ui", "src/ui/a.rs"));
+    }
+
+    #[test]
+    fn folder_contains_nested_child() {
+        assert!(folder_contains("src", "src/ui/panels/git.rs"));
+    }
+
+    #[test]
+    fn folder_contains_does_not_eat_sibling_prefix() {
+        // The classic "src/ui" vs "src/ui-helper.rs" bug — naive prefix
+        // match without the trailing slash would misfire here.
+        assert!(!folder_contains("src/ui", "src/ui-helper.rs"));
+    }
+
+    #[test]
+    fn folder_contains_exact_path_match() {
+        // Defensive: DiscardTarget::Folder with a file path still reverts
+        // that one file instead of silently doing nothing.
+        assert!(folder_contains("src/main.rs", "src/main.rs"));
+    }
+
+    #[test]
+    fn folder_contains_rejects_unrelated_path() {
+        assert!(!folder_contains("src/ui", "tests/foo.rs"));
+    }
+
+    #[test]
+    fn folder_contains_tolerates_trailing_slash() {
+        assert!(folder_contains("src/ui/", "src/ui/a.rs"));
+    }
+
+    #[test]
+    fn folder_contains_empty_path_is_noop() {
+        // The sidebar never builds a `Folder { path: "" }` target — the
+        // tree walk always starts inside a named section — so we don't
+        // need empty-prefix semantics. Document the actual behavior:
+        // the synthetic "/" prefix won't match any normal file path,
+        // which makes an empty target a safe no-op rather than a
+        // "revert everything" footgun.
+        assert!(!folder_contains("", "anything.rs"));
+    }
 }

--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -327,6 +327,8 @@ mod tests {
         FileEntry {
             path: path.to_string(),
             status,
+            additions: 0,
+            deletions: 0,
         }
     }
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -252,7 +252,11 @@ impl GitRepo {
                 let (file_status, path) = if status.contains(git2::Status::INDEX_RENAMED) {
                     let new_path = entry
                         .head_to_index()
-                        .and_then(|d| d.new_file().path().map(|p| p.to_string_lossy().into_owned()))
+                        .and_then(|d| {
+                            d.new_file()
+                                .path()
+                                .map(|p| p.to_string_lossy().into_owned())
+                        })
                         .or_else(|| fallback_path.clone());
                     (FileStatus::Renamed, new_path)
                 } else if status.contains(git2::Status::INDEX_NEW) {
@@ -263,8 +267,7 @@ impl GitRepo {
                     (FileStatus::Deleted, fallback_path.clone())
                 };
                 if let Some(path) = path {
-                    let (additions, deletions) =
-                        staged_stats.get(&path).copied().unwrap_or((0, 0));
+                    let (additions, deletions) = staged_stats.get(&path).copied().unwrap_or((0, 0));
                     staged.push(FileEntry {
                         path,
                         status: file_status,
@@ -286,7 +289,11 @@ impl GitRepo {
                 let (file_status, path) = if status.contains(git2::Status::WT_RENAMED) {
                     let new_path = entry
                         .index_to_workdir()
-                        .and_then(|d| d.new_file().path().map(|p| p.to_string_lossy().into_owned()))
+                        .and_then(|d| {
+                            d.new_file()
+                                .path()
+                                .map(|p| p.to_string_lossy().into_owned())
+                        })
                         .or_else(|| fallback_path.clone());
                     (FileStatus::Renamed, new_path)
                 } else if status.contains(git2::Status::WT_NEW) {
@@ -322,10 +329,7 @@ impl GitRepo {
 
     fn diff_line_counts_staged(&self) -> HashMap<String, (u32, u32)> {
         let head_tree = self.repo.head().ok().and_then(|h| h.peel_to_tree().ok());
-        let mut diff = match self
-            .repo
-            .diff_tree_to_index(head_tree.as_ref(), None, None)
-        {
+        let mut diff = match self.repo.diff_tree_to_index(head_tree.as_ref(), None, None) {
             Ok(d) => d,
             Err(_) => return HashMap::new(),
         };

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -9,6 +9,11 @@ use std::path::{Path, PathBuf};
 pub struct FileEntry {
     pub path: String,
     pub status: FileStatus,
+    /// Lines added in this file for the relevant diff (HEAD→index for staged,
+    /// index→workdir for unstaged; whole-file line count for untracked).
+    /// Populated by [`GitRepo::get_status`]; `commit_files` leaves this at 0.
+    pub additions: u32,
+    pub deletions: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -34,7 +39,8 @@ impl FileStatus {
 
 #[cfg(test)]
 mod tests {
-    use super::FileStatus;
+    use super::{FileStatus, count_workdir_lines};
+    use std::io::Write;
 
     #[test]
     fn file_status_label_all_variants() {
@@ -43,6 +49,62 @@ mod tests {
         assert_eq!(FileStatus::Deleted.label(), "D");
         assert_eq!(FileStatus::Renamed.label(), "R");
         assert_eq!(FileStatus::Untracked.label(), "U");
+    }
+
+    fn write_tmp(bytes: &[u8]) -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let name = "f.txt";
+        let mut f = std::fs::File::create(dir.path().join(name)).expect("create");
+        f.write_all(bytes).expect("write");
+        (dir, name.to_string())
+    }
+
+    #[test]
+    fn count_workdir_lines_empty_file() {
+        let (dir, name) = write_tmp(b"");
+        assert_eq!(count_workdir_lines(Some(dir.path()), &name), 0);
+    }
+
+    #[test]
+    fn count_workdir_lines_single_line_no_trailing_newline() {
+        let (dir, name) = write_tmp(b"hello");
+        assert_eq!(count_workdir_lines(Some(dir.path()), &name), 1);
+    }
+
+    #[test]
+    fn count_workdir_lines_single_line_with_trailing_newline() {
+        let (dir, name) = write_tmp(b"hello\n");
+        assert_eq!(count_workdir_lines(Some(dir.path()), &name), 1);
+    }
+
+    #[test]
+    fn count_workdir_lines_multi_line() {
+        let (dir, name) = write_tmp(b"a\nb\nc\n");
+        assert_eq!(count_workdir_lines(Some(dir.path()), &name), 3);
+    }
+
+    #[test]
+    fn count_workdir_lines_just_newline() {
+        // "\n" is a single blank line — matches `str::lines()` ("" has 0, "\n" has 1).
+        let (dir, name) = write_tmp(b"\n");
+        assert_eq!(count_workdir_lines(Some(dir.path()), &name), 1);
+    }
+
+    #[test]
+    fn count_workdir_lines_binary_nul_short_circuits() {
+        let (dir, name) = write_tmp(b"abc\x00def\n");
+        assert_eq!(count_workdir_lines(Some(dir.path()), &name), 0);
+    }
+
+    #[test]
+    fn count_workdir_lines_missing_file_is_zero() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(count_workdir_lines(Some(dir.path()), "nope.txt"), 0);
+    }
+
+    #[test]
+    fn count_workdir_lines_no_workdir_is_zero() {
+        assert_eq!(count_workdir_lines(None, "whatever.txt"), 0);
     }
 }
 
@@ -165,55 +227,90 @@ impl GitRepo {
             Err(_) => return (staged, unstaged),
         };
 
-        for entry in statuses.iter() {
-            let path = match entry.path() {
-                Some(p) => p.to_string(),
-                None => continue,
-            };
-            let status = entry.status();
+        // Per-file line add/remove counts. Two diffs cover staged and
+        // unstaged separately so each section can show its own numbers
+        // (e.g. a file modified in index then re-edited in workdir has a
+        // distinct +/- on each side).
+        let staged_stats = self.diff_line_counts_staged();
+        let unstaged_stats = self.diff_line_counts_unstaged();
 
-            // Staged changes (index vs HEAD)
+        for entry in statuses.iter() {
+            let status = entry.status();
+            let fallback_path = entry.path().map(str::to_string);
+
+            // Staged changes (index vs HEAD). Check RENAMED before MODIFIED
+            // because libgit2 surfaces renamed+edited files with both flags
+            // set and `entry.path()` keyed on the *old* path — only the
+            // `head_to_index` delta carries the new (post-rename) path,
+            // which is what the index and our diffstat key on.
             if status.intersects(
                 git2::Status::INDEX_NEW
                     | git2::Status::INDEX_MODIFIED
                     | git2::Status::INDEX_DELETED
                     | git2::Status::INDEX_RENAMED,
             ) {
-                let file_status = if status.contains(git2::Status::INDEX_NEW) {
-                    FileStatus::Added
+                let (file_status, path) = if status.contains(git2::Status::INDEX_RENAMED) {
+                    let new_path = entry
+                        .head_to_index()
+                        .and_then(|d| d.new_file().path().map(|p| p.to_string_lossy().into_owned()))
+                        .or_else(|| fallback_path.clone());
+                    (FileStatus::Renamed, new_path)
+                } else if status.contains(git2::Status::INDEX_NEW) {
+                    (FileStatus::Added, fallback_path.clone())
                 } else if status.contains(git2::Status::INDEX_MODIFIED) {
-                    FileStatus::Modified
-                } else if status.contains(git2::Status::INDEX_DELETED) {
-                    FileStatus::Deleted
+                    (FileStatus::Modified, fallback_path.clone())
                 } else {
-                    FileStatus::Renamed
+                    (FileStatus::Deleted, fallback_path.clone())
                 };
-                staged.push(FileEntry {
-                    path: path.clone(),
-                    status: file_status,
-                });
+                if let Some(path) = path {
+                    let (additions, deletions) =
+                        staged_stats.get(&path).copied().unwrap_or((0, 0));
+                    staged.push(FileEntry {
+                        path,
+                        status: file_status,
+                        additions,
+                        deletions,
+                    });
+                }
             }
 
-            // Unstaged changes (workdir vs index)
+            // Unstaged changes (workdir vs index). Same ordering rationale
+            // as above — renamed files in the workdir show WT_RENAMED
+            // alongside WT_MODIFIED.
             if status.intersects(
                 git2::Status::WT_MODIFIED
                     | git2::Status::WT_DELETED
                     | git2::Status::WT_NEW
                     | git2::Status::WT_RENAMED,
             ) {
-                let file_status = if status.contains(git2::Status::WT_NEW) {
-                    FileStatus::Untracked
+                let (file_status, path) = if status.contains(git2::Status::WT_RENAMED) {
+                    let new_path = entry
+                        .index_to_workdir()
+                        .and_then(|d| d.new_file().path().map(|p| p.to_string_lossy().into_owned()))
+                        .or_else(|| fallback_path.clone());
+                    (FileStatus::Renamed, new_path)
+                } else if status.contains(git2::Status::WT_NEW) {
+                    (FileStatus::Untracked, fallback_path.clone())
                 } else if status.contains(git2::Status::WT_MODIFIED) {
-                    FileStatus::Modified
-                } else if status.contains(git2::Status::WT_DELETED) {
-                    FileStatus::Deleted
+                    (FileStatus::Modified, fallback_path.clone())
                 } else {
-                    FileStatus::Renamed
+                    (FileStatus::Deleted, fallback_path.clone())
                 };
-                unstaged.push(FileEntry {
-                    path,
-                    status: file_status,
-                });
+                if let Some(path) = path {
+                    // Untracked paths don't appear in the index→workdir diff;
+                    // count their lines directly so the +N column is still useful.
+                    let (additions, deletions) = if matches!(file_status, FileStatus::Untracked) {
+                        (count_workdir_lines(self.repo.workdir(), &path), 0)
+                    } else {
+                        unstaged_stats.get(&path).copied().unwrap_or((0, 0))
+                    };
+                    unstaged.push(FileEntry {
+                        path,
+                        status: file_status,
+                        additions,
+                        deletions,
+                    });
+                }
             }
         }
 
@@ -221,6 +318,28 @@ impl GitRepo {
         unstaged.sort_by(|a, b| a.path.cmp(&b.path));
 
         (staged, unstaged)
+    }
+
+    fn diff_line_counts_staged(&self) -> HashMap<String, (u32, u32)> {
+        let head_tree = self.repo.head().ok().and_then(|h| h.peel_to_tree().ok());
+        let mut diff = match self
+            .repo
+            .diff_tree_to_index(head_tree.as_ref(), None, None)
+        {
+            Ok(d) => d,
+            Err(_) => return HashMap::new(),
+        };
+        merge_renames(&mut diff);
+        collect_diff_line_counts(&diff)
+    }
+
+    fn diff_line_counts_unstaged(&self) -> HashMap<String, (u32, u32)> {
+        let mut diff = match self.repo.diff_index_to_workdir(None, None) {
+            Ok(d) => d,
+            Err(_) => return HashMap::new(),
+        };
+        merge_renames(&mut diff);
+        collect_diff_line_counts(&diff)
     }
 
     pub fn get_diff(&self, path: &str, staged: bool, context_lines: u32) -> Option<DiffContent> {
@@ -466,6 +585,84 @@ impl GitRepo {
     }
 }
 
+/// Ask libgit2 to collapse `(delete old, add new)` pairs whose contents are
+/// similar into a single `Renamed` delta. Matches `StatusOptions.renames_*`
+/// so the line counts keyed by `new_file().path()` line up with the
+/// `FileStatus::Renamed` entry the sidebar shows. Copy detection is
+/// intentionally off — it's O(n²) over unchanged files and `git status`
+/// itself doesn't enable it. Failure (e.g. the diff holds no renameable
+/// pairs) is ignored; the unmerged diff still yields correct `+N -M` for
+/// non-rename files.
+fn merge_renames(diff: &mut git2::Diff) {
+    let mut opts = git2::DiffFindOptions::new();
+    opts.renames(true);
+    let _ = diff.find_similar(Some(&mut opts));
+}
+
+/// Walk the patch text of `diff` and tally `+` / `-` lines per file path.
+/// Used by [`GitRepo::get_status`] to show `+N -M` next to each file row.
+/// Binary files produce zero counts here (libgit2 emits no line callbacks
+/// for them) — the same behavior you'd see from `git diff --numstat`.
+fn collect_diff_line_counts(diff: &git2::Diff) -> HashMap<String, (u32, u32)> {
+    let mut out: HashMap<String, (u32, u32)> = HashMap::new();
+    let _ = diff.foreach(
+        &mut |_, _| true,
+        None,
+        None,
+        Some(&mut |delta, _hunk, line| {
+            let path = delta
+                .new_file()
+                .path()
+                .or_else(|| delta.old_file().path())
+                .and_then(|p| p.to_str())
+                .unwrap_or("");
+            if path.is_empty() {
+                return true;
+            }
+            let entry = out.entry(path.to_string()).or_insert((0, 0));
+            match line.origin() {
+                '+' => entry.0 += 1,
+                '-' => entry.1 += 1,
+                _ => {}
+            }
+            true
+        }),
+    );
+    out
+}
+
+/// Count newline-delimited lines in an untracked workdir file. Streams via
+/// `BufReader::read_until` so a large untracked log doesn't get slurped into
+/// memory. Bails early with 0 on a NUL byte (binary file — mirrors how
+/// `git diff` suppresses numstat for binaries). Unreadable / missing files
+/// also return 0 instead of propagating. Counting semantics follow
+/// `str::lines()`: an unterminated trailing line still counts once.
+fn count_workdir_lines(workdir: Option<&Path>, path: &str) -> u32 {
+    use std::io::{BufRead, BufReader};
+    let Some(root) = workdir else {
+        return 0;
+    };
+    let Ok(file) = std::fs::File::open(root.join(path)) else {
+        return 0;
+    };
+    let mut reader = BufReader::new(file);
+    let mut buf: Vec<u8> = Vec::with_capacity(8192);
+    let mut count: u32 = 0;
+    loop {
+        buf.clear();
+        match reader.read_until(b'\n', &mut buf) {
+            Ok(0) => return count,
+            Ok(_) => {
+                if buf.contains(&0) {
+                    return 0;
+                }
+                count = count.saturating_add(1);
+            }
+            Err(_) => return 0,
+        }
+    }
+}
+
 /// Push the branch at `workdir` to its upstream. When `force` is true, uses
 /// `--force-with-lease` (safer than `--force`: rejects the push if the
 /// remote advanced since our last fetch, preventing accidental overwrites
@@ -653,7 +850,12 @@ impl GitRepo {
                         git2::Delta::Untracked => FileStatus::Untracked,
                         _ => FileStatus::Modified,
                     };
-                    files.push(FileEntry { path, status });
+                    files.push(FileEntry {
+                        path,
+                        status,
+                        additions: 0,
+                        deletions: 0,
+                    });
                 }
                 true
             },

--- a/src/git/tree.rs
+++ b/src/git/tree.rs
@@ -73,6 +73,8 @@ mod tests {
         FileEntry {
             path: path.to_string(),
             status: FileStatus::Modified,
+            additions: 0,
+            deletions: 0,
         }
     }
 

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -402,8 +402,14 @@ pub fn discard_folder_prefix(is_staged: bool) -> String {
 /// otherwise render as an awkward `）？（` double-bracket.
 pub fn discard_section_prefix_and_count(is_staged: bool, count: usize) -> (String, String) {
     match (lang(), is_staged) {
-        (Lang::Zh, true) => ("  ⚠ 撤回全部已暂存的 ".to_string(), format!("{count} 个文件")),
-        (Lang::Zh, false) => ("  ⚠ 撤回全部未暂存的 ".to_string(), format!("{count} 个文件")),
+        (Lang::Zh, true) => (
+            "  ⚠ 撤回全部已暂存的 ".to_string(),
+            format!("{count} 个文件"),
+        ),
+        (Lang::Zh, false) => (
+            "  ⚠ 撤回全部未暂存的 ".to_string(),
+            format!("{count} 个文件"),
+        ),
         (Lang::En, true) => (
             "  ⚠ Discard all staged changes ".to_string(),
             format!("({count} files)"),

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -88,6 +88,7 @@ pub enum Msg {
     Changes,
     StageAll,
     UnstageAll,
+    DiscardAll,
     NoFiles,
 
     // Diff panel
@@ -193,6 +194,7 @@ fn t_zh(m: Msg) -> &'static str {
         Changes => "更改",
         StageAll => "暂存全部",
         UnstageAll => "取消全部",
+        DiscardAll => "全部撤回",
         NoFiles => "  无文件",
         DiffEmpty => "选择一个文件查看 diff",
         PreviewEmpty => "选择一个文件预览内容",
@@ -281,6 +283,7 @@ fn t_en(m: Msg) -> &'static str {
         Changes => "Changes",
         StageAll => "Stage all",
         UnstageAll => "Unstage all",
+        DiscardAll => "Discard all",
         NoFiles => "  (no files)",
         DiffEmpty => "Select a file to view diff",
         PreviewEmpty => "Select a file to preview",
@@ -376,6 +379,39 @@ pub fn diverged_force_push(ahead: usize, behind: usize) -> String {
     match lang() {
         Lang::Zh => format!(" ⚠ 已分叉 ↑{ahead} ↓{behind} — 强制推送 "),
         Lang::En => format!(" ⚠ Diverged ↑{ahead} ↓{behind} — force push "),
+    }
+}
+
+/// Yellow prefix on the discard-folder confirm banner. Mirrors the
+/// `DiscardPromptPrefix` wording but signals that the target is a whole
+/// directory — staged / unstaged wording distinguishes "reset to HEAD"
+/// from "restore from index".
+pub fn discard_folder_prefix(is_staged: bool) -> String {
+    match (lang(), is_staged) {
+        (Lang::Zh, true) => "  ⚠ 撤回已暂存文件夹 ".to_string(),
+        (Lang::En, true) => "  ⚠ Discard staged folder ".to_string(),
+        (Lang::Zh, false) => "  ⚠ 撤回文件夹 ".to_string(),
+        (Lang::En, false) => "  ⚠ Discard folder ".to_string(),
+    }
+}
+
+/// Banner parts for the "全部撤回" confirmation — returns the yellow prefix
+/// and the white-bold count highlight separately. Keeping them split lets
+/// the panel bold the file count for emphasis. Chinese avoids the
+/// `（N 个文件）` bracketing because the following `？（不可撤销）` would
+/// otherwise render as an awkward `）？（` double-bracket.
+pub fn discard_section_prefix_and_count(is_staged: bool, count: usize) -> (String, String) {
+    match (lang(), is_staged) {
+        (Lang::Zh, true) => ("  ⚠ 撤回全部已暂存的 ".to_string(), format!("{count} 个文件")),
+        (Lang::Zh, false) => ("  ⚠ 撤回全部未暂存的 ".to_string(), format!("{count} 个文件")),
+        (Lang::En, true) => (
+            "  ⚠ Discard all staged changes ".to_string(),
+            format!("({count} files)"),
+        ),
+        (Lang::En, false) => (
+            "  ⚠ Discard all changes ".to_string(),
+            format!("({count} files)"),
+        ),
     }
 }
 

--- a/src/ui/git_status_panel.rs
+++ b/src/ui/git_status_panel.rs
@@ -316,8 +316,7 @@ pub fn handle_command(app: &mut App, id: &str, args: &Value) -> bool {
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
             if !path.is_empty() {
-                app.git_status.confirm_discard =
-                    Some(DiscardTarget::Folder { is_staged, path });
+                app.git_status.confirm_discard = Some(DiscardTarget::Folder { is_staged, path });
             }
             true
         }
@@ -776,8 +775,7 @@ fn render_files(
         for (i, file) in files.iter().enumerate() {
             let is_sel = sel_path.as_deref() == Some(file.path.as_str());
             rows.push(
-                file_row(file, &file.path, "  ", is_sel, &ctx)
-                    .with_search_row(search_base + i),
+                file_row(file, &file.path, "  ", is_sel, &ctx).with_search_row(search_base + i),
             );
         }
     }
@@ -1173,7 +1171,11 @@ fn build_spans_with_path_overlay(
 /// Compute the three banner parts (yellow prefix, white-bold highlight,
 /// yellow suffix) for the discard confirmation. `max_path` trims long paths
 /// so the banner stays inside the sidebar width.
-fn discard_banner_parts(target: &DiscardTarget, app: &App, max_path: usize) -> (String, String, String) {
+fn discard_banner_parts(
+    target: &DiscardTarget,
+    app: &App,
+    max_path: usize,
+) -> (String, String, String) {
     match target {
         DiscardTarget::File(path) => {
             let mut display = path.clone();

--- a/src/ui/git_status_panel.rs
+++ b/src/ui/git_status_panel.rs
@@ -6,7 +6,7 @@
 //! go through `App`'s methods (`stage_file`, `confirm_discard`, `run_push`,
 //! …) which keeps host side state coherent.
 
-use crate::app::{App, Panel, SelectedFile};
+use crate::app::{App, DiscardTarget, Panel, SelectedFile};
 use crate::git::tree::{self as gtree, Node};
 use crate::git::{FileEntry, FileStatus};
 use crate::i18n::{Msg, t};
@@ -143,7 +143,7 @@ pub fn handle_key(app: &mut App, key: &str) -> bool {
                         .map(|f| f.path.clone())
                 });
             if let Some(path) = path {
-                app.git_status.confirm_discard = Some(path);
+                app.git_status.confirm_discard = Some(DiscardTarget::File(path));
             }
             true
         }
@@ -298,10 +298,41 @@ pub fn handle_command(app: &mut App, id: &str, args: &Value) -> bool {
                     path: path.clone(),
                     is_staged: false,
                 });
-                app.git_status.confirm_discard = Some(path);
+                app.git_status.confirm_discard = Some(DiscardTarget::File(path));
                 app.diff_scroll = 0;
                 app.diff_h_scroll = 0;
                 app.load_diff();
+            }
+            true
+        }
+        "git.discardFolderPrompt" => {
+            let path = args
+                .get("path")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let is_staged = args
+                .get("staged")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if !path.is_empty() {
+                app.git_status.confirm_discard =
+                    Some(DiscardTarget::Folder { is_staged, path });
+            }
+            true
+        }
+        "git.discardAllPrompt" => {
+            let is_staged = args
+                .get("staged")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let has_any = if is_staged {
+                !app.staged_files.is_empty()
+            } else {
+                !app.unstaged_files.is_empty()
+            };
+            if has_any {
+                app.git_status.confirm_discard = Some(DiscardTarget::Section { is_staged });
             }
             true
         }
@@ -561,26 +592,22 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
     }
 
     // Discard confirmation banner
-    if let Some(ref path) = status.confirm_discard {
-        let mut display = path.clone();
-        truncate_in_place(&mut display, max_path);
+    if let Some(ref target) = status.confirm_discard {
+        let (prefix_msg, highlight, suffix_msg) = discard_banner_parts(target, app, max_path);
         rows.push(Row::new(vec![
             RowSpan::styled(
-                t(Msg::DiscardPromptPrefix),
+                prefix_msg,
                 Style::default()
                     .fg(Color::Yellow)
                     .add_modifier(Modifier::BOLD),
             ),
             RowSpan::styled(
-                display,
+                highlight,
                 Style::default()
                     .fg(Color::White)
                     .add_modifier(Modifier::BOLD),
             ),
-            RowSpan::styled(
-                t(Msg::DiscardPromptSuffix),
-                Style::default().fg(Color::Yellow),
-            ),
+            RowSpan::styled(suffix_msg, Style::default().fg(Color::Yellow)),
         ]));
         rows.push(Row::new(vec![
             RowSpan::plain("  "),
@@ -621,13 +648,27 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
 
     // Staged section
     if !app.staged_files.is_empty() {
+        let staged_actions = vec![
+            HeaderAction {
+                label: t(Msg::UnstageAll).to_string(),
+                cmd: "git.unstageAll".into(),
+                args: Value::Null,
+                color: Color::Red,
+            },
+            HeaderAction {
+                label: t(Msg::DiscardAll).to_string(),
+                cmd: "git.discardAllPrompt".into(),
+                args: serde_json::json!({ "staged": true }),
+                color: Color::Red,
+            },
+        ];
         rows.push(section_header(
             app.staged_collapsed,
             t(Msg::StagedChanges),
             app.staged_files.len(),
             Color::Green,
             "git.toggleStaged",
-            Some((t(Msg::UnstageAll), "git.unstageAll", Color::Red)),
+            &staged_actions,
             width,
             theme,
         ));
@@ -638,10 +679,23 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
     }
 
     // Unstaged section
-    let unstaged_button = if app.unstaged_files.is_empty() {
-        None
+    let unstaged_actions: Vec<HeaderAction> = if app.unstaged_files.is_empty() {
+        Vec::new()
     } else {
-        Some((t(Msg::StageAll), "git.stageAll", Color::Green))
+        vec![
+            HeaderAction {
+                label: t(Msg::StageAll).to_string(),
+                cmd: "git.stageAll".into(),
+                args: Value::Null,
+                color: Color::Green,
+            },
+            HeaderAction {
+                label: t(Msg::DiscardAll).to_string(),
+                cmd: "git.discardAllPrompt".into(),
+                args: serde_json::json!({ "staged": false }),
+                color: Color::Red,
+            },
+        ]
     };
     rows.push(section_header(
         app.unstaged_collapsed,
@@ -649,7 +703,7 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
         app.unstaged_files.len(),
         Color::Blue,
         "git.toggleUnstaged",
-        unstaged_button,
+        &unstaged_actions,
         width,
         theme,
     ));
@@ -714,20 +768,16 @@ fn render_files(
             search_base,
         );
     } else {
+        let ctx = FileRowCtx {
+            is_staged,
+            max_path,
+            theme,
+        };
         for (i, file) in files.iter().enumerate() {
             let is_sel = sel_path.as_deref() == Some(file.path.as_str());
             rows.push(
-                file_row(
-                    &file.path,
-                    &file.path,
-                    file.status,
-                    is_staged,
-                    max_path,
-                    is_sel,
-                    "  ",
-                    theme,
-                )
-                .with_search_row(search_base + i),
+                file_row(file, &file.path, "  ", is_sel, &ctx)
+                    .with_search_row(search_base + i),
             );
         }
     }
@@ -785,16 +835,12 @@ fn walk_tree(
                 let is_sel = selected_path.as_deref() == Some(entry.path.as_str());
                 let basename = entry.path.rsplit('/').next().unwrap_or(&entry.path);
                 let indent = "  ".repeat(depth);
-                let mut row = file_row(
-                    &entry.path,
-                    basename,
-                    entry.status,
+                let ctx = FileRowCtx {
                     is_staged,
                     max_path,
-                    is_sel,
-                    &indent,
                     theme,
-                );
+                };
+                let mut row = file_row(entry, basename, &indent, is_sel, &ctx);
                 if let Some(pos) = flat_files.iter().position(|f| f.path == entry.path) {
                     row = row.with_search_row(search_base + pos);
                 }
@@ -813,7 +859,7 @@ fn dir_row(
     theme: &Theme,
 ) -> Row {
     let arrow = if is_collapsed { "›" } else { "⌄" };
-    Row::new(vec![
+    let spans = vec![
         RowSpan::plain("  ".repeat(depth)),
         RowSpan::styled(
             format!("{} ", arrow),
@@ -825,42 +871,89 @@ fn dir_row(
                 .fg(theme.accent)
                 .add_modifier(Modifier::BOLD),
         ),
-    ])
-    .on_click(
+        // Per-folder revert button. Clicking this stages a Folder discard
+        // target; the root-row click (below) still toggles expand/collapse.
+        RowSpan::plain(" "),
+        RowSpan {
+            text: "↺".into(),
+            style: Style::default().fg(Color::Red),
+            click: Some((
+                "git.discardFolderPrompt".into(),
+                serde_json::json!({ "path": path, "staged": is_staged }),
+            )),
+            dbl: None,
+        },
+    ];
+    Row::new(spans).on_click(
         "git.toggleDir",
         serde_json::json!({ "path": path, "staged": is_staged }),
     )
 }
 
-#[allow(clippy::too_many_arguments)]
-fn file_row(
-    path: &str,
-    display: &str,
-    status: FileStatus,
+/// Per-render constants shared by every file row in a section: the section's
+/// staged-ness, the width budget for the path column, and the theme. Kept
+/// as a borrowed struct so callers don't have to repack args on every row.
+struct FileRowCtx<'a> {
     is_staged: bool,
     max_path: usize,
-    is_selected: bool,
+    theme: &'a Theme,
+}
+
+fn file_row(
+    file: &FileEntry,
+    display: &str,
     indent: &str,
-    theme: &Theme,
+    is_selected: bool,
+    ctx: &FileRowCtx<'_>,
 ) -> Row {
-    let status_color = match status {
+    let status_color = match file.status {
         FileStatus::Modified => Color::Yellow,
         FileStatus::Added => Color::Green,
         FileStatus::Deleted => Color::Red,
         FileStatus::Renamed => Color::Cyan,
         FileStatus::Untracked => Color::Green,
     };
-    let status_label = status.label();
-    let button = if is_staged { "−" } else { "+" };
-    let button_color = if is_staged { Color::Red } else { Color::Green };
-    let button_cmd = if is_staged {
+    let status_label = file.status.label();
+    let button = if ctx.is_staged { "−" } else { "+" };
+    let button_color = if ctx.is_staged {
+        Color::Red
+    } else {
+        Color::Green
+    };
+    let button_cmd = if ctx.is_staged {
         "git.unstage"
     } else {
         "git.stage"
     };
 
-    let display_path = if display.chars().count() > max_path {
-        let kept = max_path.saturating_sub(3);
+    // Tighter path budget here — numstat and status chrome share the row,
+    // so add their widths to the 10-char reservation from `build_rows`.
+    let add_label = if file.additions > 0 {
+        format!("+{}", file.additions)
+    } else {
+        String::new()
+    };
+    let del_label = if file.deletions > 0 {
+        format!("-{}", file.deletions)
+    } else {
+        String::new()
+    };
+    let numstat_w = add_label.width()
+        + del_label.width()
+        + if !add_label.is_empty() && !del_label.is_empty() {
+            1
+        } else {
+            0
+        }
+        + if !add_label.is_empty() || !del_label.is_empty() {
+            1
+        } else {
+            0
+        };
+    let path_budget = ctx.max_path.saturating_sub(numstat_w);
+
+    let display_path = if display.chars().count() > path_budget {
+        let kept = path_budget.saturating_sub(3);
         let start = display.chars().count().saturating_sub(kept);
         let trailing: String = display.chars().skip(start).collect();
         format!("...{}", trailing)
@@ -869,7 +962,7 @@ fn file_row(
     };
 
     let base_bg = if is_selected {
-        Some(theme.selection_bg)
+        Some(ctx.theme.selection_bg)
     } else {
         None
     };
@@ -878,33 +971,53 @@ fn file_row(
         RowSpan::styled(indent.to_string(), apply_bg(Style::default(), base_bg)),
         RowSpan::styled(
             display_path,
-            apply_bg(Style::default().fg(theme.fg_primary), base_bg),
+            apply_bg(Style::default().fg(ctx.theme.fg_primary), base_bg),
         ),
-        RowSpan::styled(
-            format!(" {} ", status_label),
-            apply_bg(Style::default().fg(status_color), base_bg),
-        ),
-        RowSpan {
-            text: button.into(),
-            style: apply_bg(
-                Style::default()
-                    .fg(button_color)
-                    .add_modifier(Modifier::BOLD),
-                base_bg,
-            ),
-            click: Some((button_cmd.to_string(), serde_json::json!({ "path": path }))),
-            dbl: None,
-        },
-        RowSpan::styled(" ".to_string(), apply_bg(Style::default(), base_bg)),
     ];
 
-    if !is_staged {
+    if !add_label.is_empty() {
+        spans.push(RowSpan::styled(
+            format!(" {}", add_label),
+            apply_bg(Style::default().fg(Color::Green), base_bg),
+        ));
+    }
+    if !del_label.is_empty() {
+        spans.push(RowSpan::styled(
+            format!(" {}", del_label),
+            apply_bg(Style::default().fg(Color::Red), base_bg),
+        ));
+    }
+
+    spans.push(RowSpan::styled(
+        format!(" {} ", status_label),
+        apply_bg(Style::default().fg(status_color), base_bg),
+    ));
+    spans.push(RowSpan {
+        text: button.into(),
+        style: apply_bg(
+            Style::default()
+                .fg(button_color)
+                .add_modifier(Modifier::BOLD),
+            base_bg,
+        ),
+        click: Some((
+            button_cmd.to_string(),
+            serde_json::json!({ "path": file.path }),
+        )),
+        dbl: None,
+    });
+    spans.push(RowSpan::styled(
+        " ".to_string(),
+        apply_bg(Style::default(), base_bg),
+    ));
+
+    if !ctx.is_staged {
         spans.push(RowSpan {
             text: "↺".into(),
             style: apply_bg(Style::default().fg(Color::Red), base_bg),
             click: Some((
                 "git.discardPrompt".to_string(),
-                serde_json::json!({ "path": path }),
+                serde_json::json!({ "path": file.path }),
             )),
             dbl: None,
         });
@@ -917,9 +1030,9 @@ fn file_row(
     Row::new(spans)
         .on_click(
             "git.selectFile",
-            serde_json::json!({ "path": path, "staged": is_staged }),
+            serde_json::json!({ "path": file.path, "staged": ctx.is_staged }),
         )
-        .on_dbl_click(button_cmd, serde_json::json!({ "path": path }))
+        .on_dbl_click(button_cmd, serde_json::json!({ "path": file.path }))
 }
 
 fn apply_bg(style: Style, bg: Option<Color>) -> Style {
@@ -929,6 +1042,16 @@ fn apply_bg(style: Style, bg: Option<Color>) -> Style {
     }
 }
 
+/// One header-level button: `(label, command, args, color)`. The args are
+/// owned so callers can stamp in `{ "staged": true }` for the discard-all
+/// variant without extra plumbing.
+struct HeaderAction {
+    label: String,
+    cmd: String,
+    args: Value,
+    color: Color,
+}
+
 #[allow(clippy::too_many_arguments)]
 fn section_header(
     collapsed: bool,
@@ -936,18 +1059,16 @@ fn section_header(
     count: usize,
     count_color: Color,
     toggle_cmd: &str,
-    action: Option<(&str, &str, Color)>,
+    actions: &[HeaderAction],
     width: u16,
     theme: &Theme,
 ) -> Row {
     let arrow = if collapsed { "›" } else { "⌄" };
     let prefix = format!("{} ", arrow);
     let count_str = format!("  {}", count);
-    let button_text = action.as_ref().map(|(t, _, _)| format!(" {} ", t));
-    let used = prefix.width()
-        + label.width()
-        + count_str.width()
-        + button_text.as_deref().map(str::width).unwrap_or(0);
+    let button_texts: Vec<String> = actions.iter().map(|a| format!(" {} ", a.label)).collect();
+    let buttons_w: usize = button_texts.iter().map(|s| s.width()).sum();
+    let used = prefix.width() + label.width() + count_str.width() + buttons_w;
     let padding = (width as usize).saturating_sub(used);
 
     let mut spans = vec![
@@ -963,11 +1084,13 @@ fn section_header(
     if padding > 0 {
         spans.push(RowSpan::plain(" ".repeat(padding)));
     }
-    if let (Some(text), Some((_, cmd, color))) = (button_text, action) {
+    for (text, action) in button_texts.into_iter().zip(actions.iter()) {
         spans.push(RowSpan {
             text,
-            style: Style::default().fg(color).add_modifier(Modifier::BOLD),
-            click: Some((cmd.to_string(), Value::Null)),
+            style: Style::default()
+                .fg(action.color)
+                .add_modifier(Modifier::BOLD),
+            click: Some((action.cmd.clone(), action.args.clone())),
             dbl: None,
         });
     }
@@ -1045,6 +1168,42 @@ fn build_spans_with_path_overlay(
         }
     }
     out
+}
+
+/// Compute the three banner parts (yellow prefix, white-bold highlight,
+/// yellow suffix) for the discard confirmation. `max_path` trims long paths
+/// so the banner stays inside the sidebar width.
+fn discard_banner_parts(target: &DiscardTarget, app: &App, max_path: usize) -> (String, String, String) {
+    match target {
+        DiscardTarget::File(path) => {
+            let mut display = path.clone();
+            truncate_in_place(&mut display, max_path);
+            (
+                t(Msg::DiscardPromptPrefix).to_string(),
+                display,
+                t(Msg::DiscardPromptSuffix).to_string(),
+            )
+        }
+        DiscardTarget::Folder { is_staged, path } => {
+            let mut display = path.clone();
+            truncate_in_place(&mut display, max_path);
+            (
+                crate::i18n::discard_folder_prefix(*is_staged),
+                format!("{}/", display),
+                t(Msg::DiscardPromptSuffix).to_string(),
+            )
+        }
+        DiscardTarget::Section { is_staged } => {
+            let count = if *is_staged {
+                app.staged_files.len()
+            } else {
+                app.unstaged_files.len()
+            };
+            let (prefix, highlight) =
+                crate::i18n::discard_section_prefix_and_count(*is_staged, count);
+            (prefix, highlight, t(Msg::DiscardPromptSuffix).to_string())
+        }
+    }
 }
 
 fn truncate_in_place(s: &mut String, max: usize) {

--- a/tests/git_repo_integration.rs
+++ b/tests/git_repo_integration.rs
@@ -436,6 +436,9 @@ fn get_status_detects_staged_rename_with_line_counts() {
         .find(|f| f.status == FileStatus::Renamed)
         .expect("a renamed entry exists in staged");
     assert_eq!(entry.path, "b.txt", "Renamed entry keys on new path");
-    assert_eq!(entry.additions, 1, "exactly one line added on top of rename");
+    assert_eq!(
+        entry.additions, 1,
+        "exactly one line added on top of rename"
+    );
     assert_eq!(entry.deletions, 0);
 }

--- a/tests/git_repo_integration.rs
+++ b/tests/git_repo_integration.rs
@@ -374,3 +374,68 @@ fn push_without_upstream_returns_error_message() {
         .expect_err("push must fail without a remote");
     assert!(!err.is_empty(), "error message should be non-empty");
 }
+
+// ─── numstat + rename detection ─────────────────────────────────────────────
+
+#[test]
+fn get_status_fills_unstaged_line_counts() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, raw) = tempdir_repo();
+    commit_file(&raw, "a.txt", "line1\nline2\n", "init");
+    // Delete line2, add line3 → 1 addition, 1 deletion.
+    write_file(&raw, "a.txt", "line1\nline3\n");
+
+    let (_g, repo) = open_in(tmp.path());
+    let (_staged, unstaged) = repo.get_status();
+    let entry = unstaged
+        .iter()
+        .find(|f| f.path == "a.txt")
+        .expect("a.txt in unstaged");
+    assert_eq!(entry.additions, 1);
+    assert_eq!(entry.deletions, 1);
+}
+
+#[test]
+fn get_status_counts_untracked_file_lines() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, raw) = tempdir_repo();
+    // Need at least one commit so `get_status` has a valid HEAD.
+    commit_file(&raw, "seed.txt", "seed\n", "init");
+    write_file(&raw, "new.txt", "a\nb\nc\n");
+
+    let (_g, repo) = open_in(tmp.path());
+    let (_staged, unstaged) = repo.get_status();
+    let entry = unstaged
+        .iter()
+        .find(|f| f.path == "new.txt")
+        .expect("new.txt in unstaged");
+    assert_eq!(entry.status, FileStatus::Untracked);
+    assert_eq!(entry.additions, 3);
+    assert_eq!(entry.deletions, 0);
+}
+
+#[test]
+fn get_status_detects_staged_rename_with_line_counts() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, raw) = tempdir_repo();
+    // Commit a.txt then stage a "rename to b.txt, plus one added line".
+    // libgit2's find_similar should collapse (delete a.txt, add b.txt) into
+    // a single Renamed delta keyed on b.txt, and merge_renames carries that
+    // through so the sidebar's FileEntry has the right +1 count.
+    commit_file(&raw, "a.txt", "line1\nline2\nline3\n", "init");
+    fs::remove_file(tmp.path().join("a.txt")).unwrap();
+    write_file(&raw, "b.txt", "line1\nline2\nline3\nline4\n");
+
+    let (_g, repo) = open_in(tmp.path());
+    repo.stage_file("a.txt").expect("stage deletion");
+    repo.stage_file("b.txt").expect("stage addition");
+
+    let (staged, _unstaged) = repo.get_status();
+    let entry = staged
+        .iter()
+        .find(|f| f.status == FileStatus::Renamed)
+        .expect("a renamed entry exists in staged");
+    assert_eq!(entry.path, "b.txt", "Renamed entry keys on new path");
+    assert_eq!(entry.additions, 1, "exactly one line added on top of rename");
+    assert_eq!(entry.deletions, 0);
+}

--- a/tests/snapshots/ui_snapshots__with_staged_and_unstaged.snap
+++ b/tests/snapshots/ui_snapshots__with_staged_and_unstaged.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 134
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
@@ -7,8 +8,8 @@ expression: output
  View: list            │
                        │
  ⌄ Changes  2 Stage all│
-   new.txt U + ↺       │
-   tracked.txt M + ↺   │
+   new.txt +1 U + ↺    │
+   ...txt +1 -1 M + ↺  │
                        │
                        │
                        │

--- a/tests/snapshots/ui_snapshots__with_staged_and_unstaged_light.snap
+++ b/tests/snapshots/ui_snapshots__with_staged_and_unstaged_light.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 281
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
@@ -7,8 +8,8 @@ expression: output
  View: list            │
                        │
  ⌄ Changes  2 Stage all│
-   new.txt U + ↺       │
-   tracked.txt M + ↺   │
+   new.txt +1 U + ↺    │
+   ...txt +1 -1 M + ↺  │
                        │
                        │
                        │


### PR DESCRIPTION
## Summary

- Git 状态面板每行显示 `+N -M`（加减行数），untracked 用流式逐行数
- 区块头部新增「全部撤回」按钮，树形模式下文件夹行末新增 ↺ 整目录撤回
- 顺带修掉一个重命名检测的真 bug：原来的 match 顺序把「重命名+编辑」的文件错认成 Modified

数据结构：`FileEntry` 加 `additions/deletions`；`GitStatusState.confirm_discard` 从 `Option<String>` 升级成 `DiscardTarget` 枚举（`File` / `Folder { is_staged, path }` / `Section { is_staged }`）。`app::confirm_discard` 按 target 分派到 `restore_file` 或 `unstage + restore` 的批量路径。

重命名修复：libgit2 给改名+修改的文件同时置 `INDEX_MODIFIED | INDEX_RENAMED` 且 `entry.path()` 返回**旧**路径。原代码先抓 `MODIFIED` 就把 Renamed 吞了，且路径跟 index/diff 对不上。现在 RENAMED 优先，用 `head_to_index.new_file().path()` 取新路径；`merge_renames` 对 diffstat 做对称处理，`+N -M` 的 key 对齐。

## Test plan

- [x] `cargo build` + `cargo clippy --all-targets` 干净
- [x] `cargo test` 297 通过（+18 新测）：
  - `count_workdir_lines` 8 条：空文件 / 尾换行有无 / 多行 / 仅 `\n` / NUL 短路 / 缺文件 / 无 workdir
  - `folder_contains` 7 条：直接子 / 嵌套子 / sibling-prefix 反例（`src/ui` 不吞 `src/ui-helper.rs`）/ 精确路径 / 无关路径 / 尾斜杠容忍 / 空路径语义
  - 集成测 3 条：unstaged `+N -M` / untracked 行数 / staged rename 检测
- [x] 现有 UI 快照已更新（新列显示 `+1` / `+1 -1`）
- [ ] 手动在实际仓库里跑一下：树形视图 / 列表视图 / 宽窄侧边栏 / 中英文确认 banner

## 已知权衡

- 每次 status 刷新多两次 diff 遍历，大仓库（上千变更文件）会增几十到几百 ms。后续如发现问题，可以挪到后台 worker。
- 窄侧边栏下「全部撤回」按钮会被 ratatui 裁出右边界；主按钮（Stage/Unstage All）优先保留。

🤖 Generated with [Claude Code](https://claude.com/claude-code)