### PR TITLE
feat(preview): in-app drag-select with OSC 52 clipboard copy

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -217,6 +217,22 @@ pub struct App {
     pub preview_scroll: usize,
     pub preview_h_scroll: usize,
 
+    /// 应用级文字选中状态(preview 面板)。Some = 正在拖 / 刚松开但仍要
+    /// 显示高亮;None = 无选中。坐标在文件空间(line_index, byte_offset),
+    /// 与滚动无关。
+    pub preview_selection: Option<crate::ui::selection::PreviewSelection>,
+    /// 上一帧 preview 面板(含头部与分隔线)的整体 Rect,mouse handler 用于
+    /// hit test 判断鼠标是否在 preview 区域内。None = 尚未渲染过或者不在
+    /// 当前 tab。
+    pub last_preview_rect: Option<ratatui::layout::Rect>,
+    /// 上一帧 preview 内容行的起点(content_x, content_y)与 gutter 宽度。
+    /// mouse handler 据此把终端列行坐标映射回文件行/列。
+    pub last_preview_content_origin: Option<(u16, u16, u16)>,
+    /// 连击计数器:记录上一次 preview 区 Down(Left) 的时间/位置/次数,用于
+    /// 检测双击(选词)和三击(选行)。与全局 `last_click` 独立,不干扰
+    /// hit_registry 的 double-click 逻辑。
+    pub preview_click_state: Option<(Instant, u16, u16, u8)>,
+
     // Layout
     pub split_percent: u16,
     pub dragging_split: bool,
@@ -432,6 +448,10 @@ impl App {
             last_rendered_tree_selected: None,
             preview_scroll: 0,
             preview_h_scroll: 0,
+            preview_selection: None,
+            last_preview_rect: None,
+            last_preview_content_origin: None,
+            preview_click_state: None,
             split_percent: 30,
             dragging_split: false,
             hit_registry: HitTestRegistry::new(),
@@ -1432,6 +1452,8 @@ impl App {
                         if !same_file {
                             self.preview_scroll = 0;
                             self.preview_h_scroll = 0;
+                            self.preview_selection = None;
+                            self.preview_click_state = None;
                         }
                         // If `global_search::accept` stashed a highlight for
                         // this file, re-center once the preview actually
@@ -1693,6 +1715,11 @@ impl App {
             self.tree_context_menu.close();
             self.tree_delete_confirm = None;
         }
+        // Preview selection is scoped to the Files/Search tabs that render
+        // the preview panel. Switching away clears it so no stale highlight
+        // appears on return and the click-count resets cleanly.
+        self.preview_selection = None;
+        self.preview_click_state = None;
         match tab {
             Tab::Git => self.git_status_load.mark_stale(),
             Tab::Graph => self.graph_load.mark_stale(),

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,103 @@
+//! OSC 52 剪贴板写入。终端托管在 iTerm2 / Kitty / WezTerm / Alacritty /
+//! Ghostty / foot / 新版 tmux(需 `set -g set-clipboard on`)等里时,
+//! OSC 52 转义序列能让应用直接写系统剪贴板,不需要 arboard/copypasta 这种
+//! 跨平台依赖。macOS Terminal.app 不支持——选中仍然会高亮但剪贴板无变化。
+//!
+//! 格式: `ESC ] 52 ; c ; <base64(payload)> BEL`
+//!
+//! base64 编码手写(20 行),避免拉新依赖。
+
+use std::io::{self, Write};
+
+const BASE64_ALPHABET: &[u8; 64] =
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+pub fn base64_encode(input: &[u8]) -> String {
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    let mut chunks = input.chunks_exact(3);
+    for chunk in &mut chunks {
+        let n = (u32::from(chunk[0]) << 16) | (u32::from(chunk[1]) << 8) | u32::from(chunk[2]);
+        out.push(BASE64_ALPHABET[((n >> 18) & 0x3f) as usize] as char);
+        out.push(BASE64_ALPHABET[((n >> 12) & 0x3f) as usize] as char);
+        out.push(BASE64_ALPHABET[((n >> 6) & 0x3f) as usize] as char);
+        out.push(BASE64_ALPHABET[(n & 0x3f) as usize] as char);
+    }
+    let rem = chunks.remainder();
+    match rem.len() {
+        0 => {}
+        1 => {
+            let n = u32::from(rem[0]) << 16;
+            out.push(BASE64_ALPHABET[((n >> 18) & 0x3f) as usize] as char);
+            out.push(BASE64_ALPHABET[((n >> 12) & 0x3f) as usize] as char);
+            out.push('=');
+            out.push('=');
+        }
+        2 => {
+            let n = (u32::from(rem[0]) << 16) | (u32::from(rem[1]) << 8);
+            out.push(BASE64_ALPHABET[((n >> 18) & 0x3f) as usize] as char);
+            out.push(BASE64_ALPHABET[((n >> 12) & 0x3f) as usize] as char);
+            out.push(BASE64_ALPHABET[((n >> 6) & 0x3f) as usize] as char);
+            out.push('=');
+        }
+        _ => unreachable!(),
+    }
+    out
+}
+
+/// 向 stdout 写 OSC 52 序列把 `text` 放进系统剪贴板。写失败的情况(stdout
+/// 异常)极罕见,此时返回 IoError 供上层做降级提示;OSC 52 被目标终端忽略
+/// 时本函数仍然会成功返回——终端那头没有回复的协议。
+pub fn copy_to_clipboard(text: &str) -> io::Result<()> {
+    let payload = base64_encode(text.as_bytes());
+    let mut stdout = io::stdout().lock();
+    write!(stdout, "\x1b]52;c;{payload}\x07")?;
+    stdout.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_empty() {
+        assert_eq!(base64_encode(b""), "");
+    }
+
+    #[test]
+    fn base64_one_byte_two_pad() {
+        assert_eq!(base64_encode(b"f"), "Zg==");
+    }
+
+    #[test]
+    fn base64_two_bytes_one_pad() {
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+    }
+
+    #[test]
+    fn base64_three_bytes_no_pad() {
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+    }
+
+    #[test]
+    fn base64_rfc4648_vectors() {
+        assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
+        assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
+        assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn base64_utf8_cjk() {
+        // "你" = E4 BD A0 — 3 字节,正好对齐无填充。
+        assert_eq!(base64_encode("你".as_bytes()), "5L2g");
+    }
+
+    #[test]
+    fn base64_binary_full_range() {
+        let data: Vec<u8> = (0..=255u8).collect();
+        let encoded = base64_encode(&data);
+        // 长度 = ceil(256/3)*4 = 344
+        assert_eq!(encoded.len(), 344);
+        // 末尾应只有 '=' 填充(256 mod 3 == 1 → "=="),倒数两个是 '='。
+        assert!(encoded.ends_with("=="));
+    }
+}

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -67,6 +67,8 @@ pub enum Msg {
     PushSuccess,
     ForcePushSuccess,
     PushThreadCrashed,
+    ClipboardCopied,
+    ClipboardCopyFailed,
 
     // Git status panel
     PushingHint,
@@ -175,6 +177,8 @@ fn t_zh(m: Msg) -> &'static str {
         PushSuccess => "推送成功",
         ForcePushSuccess => "强制推送成功",
         PushThreadCrashed => "推送线程异常退出，请重试",
+        ClipboardCopied => "已复制到剪贴板",
+        ClipboardCopyFailed => "复制到剪贴板失败",
         PushingHint => "  ⋯ 推送中…",
         PushFailedPrefix => "  ✖ 推送失败: ",
         DismissClose => "  [关闭]",
@@ -264,6 +268,8 @@ fn t_en(m: Msg) -> &'static str {
         PushSuccess => "Push succeeded",
         ForcePushSuccess => "Force push succeeded",
         PushThreadCrashed => "Push worker crashed, please retry",
+        ClipboardCopied => "Copied to clipboard",
+        ClipboardCopyFailed => "Clipboard copy failed",
         PushingHint => "  ⋯ Pushing…",
         PushFailedPrefix => "  ✖ Push failed: ",
         DismissClose => "  [dismiss]",

--- a/src/input.rs
+++ b/src/input.rs
@@ -9,13 +9,20 @@
 //! just add indirection.
 
 use crate::app::{App, Panel, Tab};
+use crate::clipboard;
 use crate::global_search;
+use crate::i18n::{Msg, t};
 use crate::quick_open;
 use crate::search;
 use crate::ui;
+use crate::ui::selection::{
+    PreviewSelection, col_to_byte_offset, collect_selected_text, word_at_byte,
+};
+use crate::ui::toast::Toast;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::Terminal;
 use ratatui::backend::Backend;
+use ratatui::layout::Rect;
 use std::time::{Duration, Instant};
 
 pub const DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(400);
@@ -1125,6 +1132,17 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
     // (The fallthrough-close region is registered by the menu renderer
     // underneath the menu panel, so it goes through handle_action.)
 
+    // Preview drag-selection fast-path. Owns Down/Drag/Up(Left) when the
+    // gesture starts inside the preview panel. Scroll wheel, right-click,
+    // and Down outside the panel fall through to the normal match below.
+    //
+    // Once a drag has begun, subsequent Drag and Up events are captured
+    // unconditionally (even if the cursor leaves the panel) — otherwise
+    // selection would silently drop whenever the user pulls past the edge.
+    if handle_preview_selection(&mouse, app) {
+        return;
+    }
+
     match mouse.kind {
         MouseEventKind::Down(MouseButton::Left) => {
             let now = Instant::now();
@@ -1289,6 +1307,161 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
         }
         _ => {}
     }
+}
+
+/// Drive in-panel text selection on the preview panel. Returns `true` when
+/// the mouse event was consumed so the caller stops further dispatch.
+///
+/// Click levels (same position within `DOUBLE_CLICK_WINDOW`):
+/// - 1× (single drag) → anchor-to-cursor drag selection
+/// - 2× (double-click) → select word under cursor
+/// - 3× (triple-click) → select entire line
+///
+/// For levels 2 and 3 the initial selection is committed immediately on
+/// `Down`, but `dragging = true` so the `Up` handler still triggers the
+/// clipboard copy. A `Drag` after a double/triple click extends the active
+/// endpoint normally (VS Code-style word-range extension).
+fn handle_preview_selection(mouse: &MouseEvent, app: &mut App) -> bool {
+    let content_origin = app.last_preview_content_origin;
+    match mouse.kind {
+        MouseEventKind::Down(MouseButton::Left) => {
+            let Some(rect) = app.last_preview_rect else {
+                return false;
+            };
+            if !point_in_rect(rect, mouse.column, mouse.row) {
+                return false;
+            }
+            let Some(origin) = content_origin else {
+                return false;
+            };
+            let Some((file_line, byte_offset)) =
+                mouse_to_file_coord(app, mouse.column, mouse.row, origin)
+            else {
+                return false;
+            };
+
+            // Advance (or reset) the click counter.
+            let now = Instant::now();
+            let click_count = if let Some((t, c, r, n)) = app.preview_click_state {
+                if c == mouse.column
+                    && r == mouse.row
+                    && now.duration_since(t) < DOUBLE_CLICK_WINDOW
+                {
+                    (n + 1).min(3)
+                } else {
+                    1
+                }
+            } else {
+                1
+            };
+            app.preview_click_state = Some((now, mouse.column, mouse.row, click_count));
+
+            let preview_lines = app
+                .preview_content
+                .as_ref()
+                .map(|p| p.lines.as_slice())
+                .unwrap_or_default();
+            let line_len = preview_lines.get(file_line).map(|l| l.len()).unwrap_or(0);
+
+            let sel = match click_count {
+                2 => {
+                    // Double-click → select word
+                    let word = preview_lines
+                        .get(file_line)
+                        .map(|l| word_at_byte(l, byte_offset))
+                        .unwrap_or(byte_offset..byte_offset);
+                    PreviewSelection {
+                        anchor: (file_line, word.start),
+                        active: (file_line, word.end),
+                        dragging: true,
+                    }
+                }
+                3 => {
+                    // Triple-click → select entire line
+                    PreviewSelection {
+                        anchor: (file_line, 0),
+                        active: (file_line, line_len),
+                        dragging: true,
+                    }
+                }
+                _ => PreviewSelection::new((file_line, byte_offset)),
+            };
+            app.preview_selection = Some(sel);
+            true
+        }
+        MouseEventKind::Drag(MouseButton::Left) => {
+            let dragging = app.preview_selection.is_some_and(|s| s.dragging);
+            if !dragging {
+                return false;
+            }
+            let Some(origin) = content_origin else {
+                return true; // swallow even without update — the drag is ours
+            };
+            if let Some(pos) = mouse_to_file_coord(app, mouse.column, mouse.row, origin) {
+                if let Some(s) = app.preview_selection.as_mut() {
+                    s.active = pos;
+                }
+            }
+            true
+        }
+        MouseEventKind::Up(MouseButton::Left) => {
+            let Some(sel) = app.preview_selection.as_mut() else {
+                return false;
+            };
+            if !sel.dragging {
+                return false;
+            }
+            sel.dragging = false;
+            let sel_snapshot = *sel;
+            if !sel_snapshot.is_empty() {
+                if let Some(preview) = app.preview_content.as_ref() {
+                    let text = collect_selected_text(&preview.lines, &sel_snapshot);
+                    if !text.is_empty() {
+                        match clipboard::copy_to_clipboard(&text) {
+                            Ok(()) => app.toasts.push(Toast::info(t(Msg::ClipboardCopied))),
+                            Err(_) => app.toasts.push(Toast::error(t(Msg::ClipboardCopyFailed))),
+                        }
+                    }
+                }
+            }
+            true
+        }
+        _ => false,
+    }
+}
+
+fn point_in_rect(rect: Rect, col: u16, row: u16) -> bool {
+    col >= rect.x && col < rect.x + rect.width && row >= rect.y && row < rect.y + rect.height
+}
+
+/// Translate a terminal `(column, row)` hit into `(file_line_index,
+/// byte_offset_in_line)` using the cached content-area origin + current
+/// scroll state. Returns `None` when the preview is empty / unloaded.
+///
+/// Columns left of the gutter collapse to byte 0; rows above the content area
+/// collapse to file line `preview_scroll` (first visible line). Rows past the
+/// last line clamp to the last line's terminator (so "drag past end" selects
+/// through the final line cleanly).
+fn mouse_to_file_coord(
+    app: &App,
+    col: u16,
+    row: u16,
+    origin: (u16, u16, u16),
+) -> Option<(usize, usize)> {
+    let preview = app.preview_content.as_ref()?;
+    if preview.lines.is_empty() {
+        return None;
+    }
+    let (content_x, content_y, _) = origin;
+
+    let visible_row = row.saturating_sub(content_y) as usize;
+    let file_line = (app.preview_scroll + visible_row).min(preview.lines.len() - 1);
+    let line = &preview.lines[file_line];
+
+    let visible_col = (col.saturating_sub(content_x) as usize) + app.preview_h_scroll;
+    let byte_offset = col_to_byte_offset(line, visible_col);
+
+    Some((file_line, byte_offset))
 }
 
 /// Apply a horizontal-scroll delta (in display columns) to whichever panel

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! (src/main.rs) is a thin wrapper that consumes this library.
 
 pub mod app;
+pub mod clipboard;
 pub mod editor;
 pub mod file_tree;
 pub mod fs_watcher;

--- a/src/ui/file_preview_panel.rs
+++ b/src/ui/file_preview_panel.rs
@@ -2,7 +2,7 @@ use crate::app::App;
 use crate::file_tree::PreviewContent;
 use crate::i18n::{Msg, t};
 use crate::search::SearchTarget;
-use crate::ui::text::{clip_spans, overlay_match_highlight};
+use crate::ui::text::{clip_spans, overlay_match_highlight, overlay_selection_highlight};
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
@@ -14,6 +14,10 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default().padding(Padding::new(1, 1, 0, 0));
     let inner = block.inner(area);
     f.render_widget(block, area);
+    // Cache the preview-panel rect so the mouse handler can hit-test
+    // drag-to-select events. Reset to None at the top of `ui::render` on
+    // tabs that don't render this panel.
+    app.last_preview_rect = Some(inner);
 
     let preview = match app.preview_content.take() {
         None => {
@@ -116,6 +120,11 @@ fn render_content(f: &mut Frame, app: &mut App, area: Rect, preview: &PreviewCon
     app.preview_h_scroll = app.preview_h_scroll.min(max_h);
     let h = app.preview_h_scroll;
 
+    // Cache the content-area origin so the mouse handler can translate a
+    // `(column, row)` hit into `(file_line, byte_offset)`.
+    app.last_preview_content_origin = Some((area.x + gutter_w as u16, y, gutter_w as u16));
+    let selection = app.preview_selection;
+
     for (i, line) in preview.lines.iter().skip(app.preview_scroll).enumerate() {
         let cy = y + i as u16;
         if cy >= max_y {
@@ -164,6 +173,15 @@ fn render_content(f: &mut Frame, app: &mut App, area: Rect, preview: &PreviewCon
                 th.search_match,
                 th.search_current,
             )
+        };
+        // Drag-selection highlight layered on top — `Modifier::REVERSED`
+        // so it composes cleanly with any theme / search background.
+        let tokens = match selection
+            .as_ref()
+            .and_then(|s| s.line_byte_range(real_idx, line))
+        {
+            Some(r) if r.start < r.end => overlay_selection_highlight(tokens, r),
+            _ => tokens,
         };
 
         let mut spans = vec![gutter];

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -11,6 +11,7 @@ pub mod hover;
 pub mod mouse;
 pub mod quick_open_panel;
 pub mod search_tab;
+pub mod selection;
 pub mod text;
 pub mod theme;
 pub mod toast;
@@ -30,6 +31,13 @@ use unicode_width::UnicodeWidthStr;
 pub fn render(f: &mut Frame, app: &mut App) {
     let size = f.area();
     app.hit_registry.clear();
+    // Clear the preview hit cache each frame; the preview panel's own
+    // `render` will repopulate it when the active tab renders the preview.
+    // Without this, switching away from a preview-bearing tab would leave
+    // `last_preview_rect` pointing at a now-hidden region and the mouse
+    // handler would treat clicks on other panels as selection gestures.
+    app.last_preview_rect = None;
+    app.last_preview_content_origin = None;
 
     let main_layout = Layout::default()
         .direction(Direction::Vertical)

--- a/src/ui/selection.rs
+++ b/src/ui/selection.rs
@@ -1,0 +1,402 @@
+//! 应用级文本选中模型:记录 preview 面板里拖拽选中的范围,供渲染反色、
+//! 复制到剪贴板时使用。
+//!
+//! 坐标系:`(line_index, byte_offset_in_line)`,其中 `line_index` 是 preview
+//! 文件中的行号(0 起),`byte_offset_in_line` 是该行 UTF-8 字节偏移(不是
+//! 显示列)。这样选中与 `preview_scroll` / `preview_h_scroll` 解耦——
+//! 滚动后选中范围仍然指向文件里原来的同一段文本。
+
+use std::ops::Range;
+use unicode_width::UnicodeWidthChar;
+
+#[derive(Debug, Clone, Copy)]
+pub struct PreviewSelection {
+    pub anchor: (usize, usize),
+    pub active: (usize, usize),
+    /// 鼠标当前是否仍按住左键在拖。Up(Left) 时置为 false。选中仍可渲染,
+    /// 只是新的 Down 会开启一个新的锚点。
+    pub dragging: bool,
+}
+
+impl PreviewSelection {
+    pub fn new(anchor: (usize, usize)) -> Self {
+        Self {
+            anchor,
+            active: anchor,
+            dragging: true,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.anchor == self.active
+    }
+
+    /// 按文档顺序归一化成 `(start, end)`,`start <= end`。
+    pub fn normalized(&self) -> ((usize, usize), (usize, usize)) {
+        if self.anchor <= self.active {
+            (self.anchor, self.active)
+        } else {
+            (self.active, self.anchor)
+        }
+    }
+
+    pub fn contains_line(&self, row: usize) -> bool {
+        let (start, end) = self.normalized();
+        row >= start.0 && row <= end.0
+    }
+
+    /// 给定某一行的原始文本,返回该行内被选中的字节区间(开闭区间,end
+    /// 可能等于 `line.len()`,即"选中到行尾包括换行")。
+    ///
+    /// 不在选中范围内的行返回 `None`。
+    pub fn line_byte_range(&self, row: usize, line: &str) -> Option<Range<usize>> {
+        let (start, end) = self.normalized();
+        if row < start.0 || row > end.0 {
+            return None;
+        }
+        let line_len = line.len();
+        let s = if row == start.0 {
+            start.1.min(line_len)
+        } else {
+            0
+        };
+        let e = if row == end.0 {
+            end.1.min(line_len)
+        } else {
+            line_len
+        };
+        if s >= e {
+            // 单行同位置 / 反转后为空,仍返回一个空区间,让渲染端自己判断。
+            return Some(s..s);
+        }
+        Some(s..e)
+    }
+}
+
+/// 字符分类:用于双击选词时确定扩展边界。
+#[derive(PartialEq, Eq)]
+enum CharClass {
+    AlphaNum, // [a-zA-Z0-9_] — 标识符字符
+    Space,    // 空白
+    Other,    // 标点 / 运算符等
+}
+
+fn char_class(c: char) -> CharClass {
+    if c.is_alphanumeric() || c == '_' {
+        CharClass::AlphaNum
+    } else if c.is_whitespace() {
+        CharClass::Space
+    } else {
+        CharClass::Other
+    }
+}
+
+/// 双击选词:以 `byte_offset`(必须是 UTF-8 字符起点或 `line.len()`)为基础,
+/// 向两端扩展到同一字符分类的边界,返回字节区间。
+///
+/// - 标识符字符(`[a-zA-Z0-9_]`)向两边扩展整个单词。
+/// - 空白向两边扩展连续空白。
+/// - 其他字符(标点/运算符)同样向两边扩展相同分类的连续片段(如 `->`, `::`)。
+/// - `byte_offset >= line.len()` 时返回空区间 `line.len()..line.len()`。
+pub fn word_at_byte(line: &str, byte_offset: usize) -> Range<usize> {
+    if line.is_empty() || byte_offset >= line.len() {
+        return line.len()..line.len();
+    }
+    let anchor_char = line[byte_offset..].chars().next().unwrap();
+    let class = char_class(anchor_char);
+
+    // 向左扩展
+    let mut start = byte_offset;
+    let before: Vec<(usize, char)> = line[..byte_offset].char_indices().collect();
+    for &(i, c) in before.iter().rev() {
+        if char_class(c) == class {
+            start = i;
+        } else {
+            break;
+        }
+    }
+
+    // 向右扩展
+    let mut end = byte_offset + anchor_char.len_utf8();
+    for (off, c) in line[byte_offset..].char_indices().skip(1) {
+        if char_class(c) == class {
+            end = byte_offset + off + c.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    start..end
+}
+
+/// 把可见列坐标(`UnicodeWidthChar` 计的显示列,0 起)翻译成该行的字节
+/// 偏移。落在宽字符后半格时返回那个字符起点(选到它);超过行宽时返回
+/// 行长度——这让"拖到行尾空白"的体验自然:选中一直延伸到换行符。
+pub fn col_to_byte_offset(line: &str, col: usize) -> usize {
+    let mut acc = 0usize;
+    for (i, c) in line.char_indices() {
+        if acc >= col {
+            return i;
+        }
+        let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+        if acc + cw > col {
+            // col 落在宽字符内部,取字符起点(含这个字符)。
+            return i;
+        }
+        acc += cw;
+    }
+    line.len()
+}
+
+/// 把选中范围从 `lines` 提取成一段纯文本。多行之间用 `\n` 连接。
+pub fn collect_selected_text(lines: &[String], sel: &PreviewSelection) -> String {
+    if sel.is_empty() {
+        return String::new();
+    }
+    let (start, end) = sel.normalized();
+    let last = end.0.min(lines.len().saturating_sub(1));
+    let mut out = String::new();
+    for row in start.0..=last {
+        let line = &lines[row];
+        let range = match sel.line_byte_range(row, line) {
+            Some(r) => r,
+            None => continue,
+        };
+        if range.start < line.len() {
+            let end_clamped = range.end.min(line.len());
+            out.push_str(&line[range.start..end_clamped]);
+        }
+        if row < last {
+            out.push('\n');
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── col_to_byte_offset ──────────────────────────────────────────────
+
+    #[test]
+    fn col_to_byte_offset_ascii_mid() {
+        assert_eq!(col_to_byte_offset("hello", 3), 3);
+    }
+
+    #[test]
+    fn col_to_byte_offset_ascii_zero() {
+        assert_eq!(col_to_byte_offset("hello", 0), 0);
+    }
+
+    #[test]
+    fn col_to_byte_offset_ascii_past_end_returns_len() {
+        assert_eq!(col_to_byte_offset("hello", 99), 5);
+    }
+
+    #[test]
+    fn col_to_byte_offset_cjk_boundary() {
+        // "你好" — 每个字符 2 列、3 字节。col=2 正好落在第二个字符起点。
+        assert_eq!(col_to_byte_offset("你好", 2), 3);
+    }
+
+    #[test]
+    fn col_to_byte_offset_cjk_inside_wide_char() {
+        // col=1 落在"你"内部,取"你"的起点(0)。
+        assert_eq!(col_to_byte_offset("你好", 1), 0);
+    }
+
+    #[test]
+    fn col_to_byte_offset_mixed() {
+        // "a你b" — a(1 列) 你(2 列) b(1 列),总 4 列。col=3 → b 起点。
+        assert_eq!(col_to_byte_offset("a你b", 3), 4);
+    }
+
+    // ── PreviewSelection ────────────────────────────────────────────────
+
+    #[test]
+    fn normalized_orders_anchor_before_active() {
+        let s = PreviewSelection {
+            anchor: (5, 3),
+            active: (2, 0),
+            dragging: false,
+        };
+        let (a, b) = s.normalized();
+        assert_eq!(a, (2, 0));
+        assert_eq!(b, (5, 3));
+    }
+
+    #[test]
+    fn is_empty_when_anchor_equals_active() {
+        let s = PreviewSelection::new((1, 1));
+        assert!(s.is_empty());
+    }
+
+    #[test]
+    fn line_byte_range_single_line() {
+        let s = PreviewSelection {
+            anchor: (0, 2),
+            active: (0, 5),
+            dragging: false,
+        };
+        assert_eq!(s.line_byte_range(0, "abcdef"), Some(2..5));
+    }
+
+    #[test]
+    fn line_byte_range_multi_line_middle_full() {
+        let s = PreviewSelection {
+            anchor: (0, 2),
+            active: (2, 3),
+            dragging: false,
+        };
+        assert_eq!(s.line_byte_range(0, "abcdef"), Some(2..6));
+        assert_eq!(s.line_byte_range(1, "middle"), Some(0..6));
+        assert_eq!(s.line_byte_range(2, "tailxyz"), Some(0..3));
+    }
+
+    #[test]
+    fn line_byte_range_out_of_range_returns_none() {
+        let s = PreviewSelection {
+            anchor: (0, 0),
+            active: (1, 0),
+            dragging: false,
+        };
+        assert_eq!(s.line_byte_range(5, "anything"), None);
+    }
+
+    #[test]
+    fn line_byte_range_clamps_past_end() {
+        let s = PreviewSelection {
+            anchor: (0, 0),
+            active: (0, 999),
+            dragging: false,
+        };
+        // 请求字节 0..999,实际行长度 3,钳到 0..3。
+        assert_eq!(s.line_byte_range(0, "abc"), Some(0..3));
+    }
+
+    // ── collect_selected_text ───────────────────────────────────────────
+
+    #[test]
+    fn collect_empty_returns_empty_string() {
+        let lines = vec!["hello".to_string()];
+        let s = PreviewSelection::new((0, 0));
+        assert_eq!(collect_selected_text(&lines, &s), "");
+    }
+
+    #[test]
+    fn collect_single_line_partial() {
+        let lines = vec!["hello world".to_string()];
+        let s = PreviewSelection {
+            anchor: (0, 6),
+            active: (0, 11),
+            dragging: false,
+        };
+        assert_eq!(collect_selected_text(&lines, &s), "world");
+    }
+
+    #[test]
+    fn collect_multi_line_joins_with_newlines() {
+        let lines = vec![
+            "first".to_string(),
+            "second".to_string(),
+            "third".to_string(),
+        ];
+        let s = PreviewSelection {
+            anchor: (0, 2),
+            active: (2, 3),
+            dragging: false,
+        };
+        assert_eq!(collect_selected_text(&lines, &s), "rst\nsecond\nthi");
+    }
+
+    #[test]
+    fn collect_reverse_direction_still_in_document_order() {
+        let lines = vec!["abc".to_string(), "def".to_string()];
+        let s = PreviewSelection {
+            anchor: (1, 2),
+            active: (0, 1),
+            dragging: false,
+        };
+        assert_eq!(collect_selected_text(&lines, &s), "bc\nde");
+    }
+
+    #[test]
+    fn collect_cjk_preserves_full_chars() {
+        let lines = vec!["你好世界".to_string()];
+        // 字节偏移 3..9 = "好世"
+        let s = PreviewSelection {
+            anchor: (0, 3),
+            active: (0, 9),
+            dragging: false,
+        };
+        assert_eq!(collect_selected_text(&lines, &s), "好世");
+    }
+
+    // ── word_at_byte ────────────────────────────────────────────────────
+
+    #[test]
+    fn word_empty_line_returns_empty() {
+        assert_eq!(word_at_byte("", 0), 0..0);
+    }
+
+    #[test]
+    fn word_past_end_returns_end() {
+        assert_eq!(word_at_byte("abc", 99), 3..3);
+    }
+
+    #[test]
+    fn word_ascii_identifier_mid() {
+        // "fn hello_world()" — click on 'l' at byte 5
+        let line = "fn hello_world()";
+        assert_eq!(word_at_byte(line, 5), 3..14); // "hello_world"
+    }
+
+    #[test]
+    fn word_ascii_identifier_start() {
+        let line = "fn hello()";
+        assert_eq!(word_at_byte(line, 3), 3..8); // "hello"
+    }
+
+    #[test]
+    fn word_ascii_identifier_end() {
+        let line = "fn hello()";
+        // click on 'o' = last char of "hello", byte 7
+        assert_eq!(word_at_byte(line, 7), 3..8); // "hello"
+    }
+
+    #[test]
+    fn word_space_expands_whitespace_run() {
+        let line = "foo   bar";
+        // click on middle space (byte 4)
+        assert_eq!(word_at_byte(line, 4), 3..6); // "   "
+    }
+
+    #[test]
+    fn word_operator_expands_to_run() {
+        let line = "a -> b";
+        // click on '-' at byte 2
+        assert_eq!(word_at_byte(line, 2), 2..4); // "->"
+    }
+
+    #[test]
+    fn word_single_punct() {
+        let line = "a(b)";
+        // click on '(' at byte 1
+        assert_eq!(word_at_byte(line, 1), 1..2); // "("
+    }
+
+    #[test]
+    fn word_cjk_identifier_class() {
+        // CJK chars are alphanumeric in Rust (is_alphanumeric)
+        let line = "let 变量 = 1";
+        // "变量" — "变" at byte 4, "量" at byte 7
+        assert_eq!(word_at_byte(line, 4), 4..10); // "变量"
+    }
+
+    #[test]
+    fn word_underscore_is_alnum() {
+        let line = "_foo_bar";
+        assert_eq!(word_at_byte(line, 0), 0..8); // whole "_foo_bar"
+    }
+}

--- a/src/ui/text.rs
+++ b/src/ui/text.rs
@@ -191,6 +191,72 @@ fn apply_search_bg(base: Style, bg: Color) -> Style {
     }
 }
 
+/// Overlay a visual-selection range onto already-styled tokens. The range is
+/// byte offsets into the concatenated plain text of `tokens`. Segments inside
+/// the range get `Modifier::REVERSED` (fg/bg swap), which is theme-agnostic
+/// and also works on rows that already carry a background (diff added/removed).
+///
+/// Empty ranges round-trip the tokens unchanged. Mirrors the split-at-boundary
+/// pattern in [`overlay_match_highlight`].
+pub fn overlay_selection_highlight(
+    tokens: Vec<(Style, String)>,
+    range: Range<usize>,
+) -> Vec<(Style, String)> {
+    if range.start >= range.end {
+        return tokens;
+    }
+    let mut out: Vec<(Style, String)> = Vec::with_capacity(tokens.len());
+    let mut abs = 0usize;
+    for (style, text) in tokens {
+        if text.is_empty() {
+            out.push((style, text));
+            continue;
+        }
+        let base_abs = abs;
+        let len = text.len();
+        abs += len;
+
+        let mut seg_start = 0usize;
+        let mut run_selected = byte_in_range(base_abs, &range);
+        for (i, _) in text.char_indices() {
+            if i == 0 {
+                continue;
+            }
+            let next_selected = byte_in_range(base_abs + i, &range);
+            if next_selected != run_selected {
+                out.push(styled_selection_segment(
+                    style,
+                    &text[seg_start..i],
+                    run_selected,
+                ));
+                seg_start = i;
+                run_selected = next_selected;
+            }
+        }
+        if seg_start < len {
+            out.push(styled_selection_segment(
+                style,
+                &text[seg_start..len],
+                run_selected,
+            ));
+        }
+    }
+    out
+}
+
+fn byte_in_range(abs: usize, range: &Range<usize>) -> bool {
+    abs >= range.start && abs < range.end
+}
+
+fn styled_selection_segment(base: Style, text: &str, selected: bool) -> (Style, String) {
+    let style = if selected {
+        base.add_modifier(Modifier::REVERSED)
+    } else {
+        base
+    };
+    (style, text.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -420,5 +486,57 @@ mod tests {
             ratatui::style::Color::Red,
         );
         assert_eq!(collect_text(&out), "hello world");
+    }
+
+    // ── overlay_selection_highlight ──────────────────────────────────────────
+
+    #[test]
+    fn selection_overlay_empty_range_is_identity() {
+        let tokens = vec![(Style::default(), "hello".to_string())];
+        let out = overlay_selection_highlight(tokens.clone(), 3..3);
+        assert_eq!(out, tokens);
+    }
+
+    #[test]
+    fn selection_overlay_reverses_range() {
+        let tokens = vec![(Style::default(), "abcdef".to_string())];
+        let out = overlay_selection_highlight(tokens, 2..4);
+        assert_eq!(collect_text(&out), "abcdef");
+        assert_eq!(out.len(), 3);
+        assert!(!out[0].0.add_modifier.contains(Modifier::REVERSED));
+        assert!(out[1].0.add_modifier.contains(Modifier::REVERSED));
+        assert_eq!(out[1].1, "cd");
+        assert!(!out[2].0.add_modifier.contains(Modifier::REVERSED));
+    }
+
+    #[test]
+    fn selection_overlay_spans_token_boundary() {
+        let tokens = vec![
+            (Style::default(), "abc".to_string()),
+            (
+                Style::default().fg(ratatui::style::Color::Red),
+                "def".to_string(),
+            ),
+        ];
+        let out = overlay_selection_highlight(tokens, 1..5);
+        assert_eq!(collect_text(&out), "abcdef");
+        // Segments: a | bc | de | f
+        assert_eq!(out.len(), 4);
+        assert!(!out[0].0.add_modifier.contains(Modifier::REVERSED));
+        assert!(out[1].0.add_modifier.contains(Modifier::REVERSED));
+        assert_eq!(out[1].1, "bc");
+        assert!(out[2].0.add_modifier.contains(Modifier::REVERSED));
+        assert_eq!(out[2].1, "de");
+        // 2nd segment preserves fg.
+        assert_eq!(out[2].0.fg, Some(ratatui::style::Color::Red));
+        assert!(!out[3].0.add_modifier.contains(Modifier::REVERSED));
+    }
+
+    #[test]
+    fn selection_overlay_full_token_range() {
+        let tokens = vec![(Style::default(), "abc".to_string())];
+        let out = overlay_selection_highlight(tokens, 0..3);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].0.add_modifier.contains(Modifier::REVERSED));
     }
 }


### PR DESCRIPTION
## Summary

- **拖拽选中**:在 preview 面板按左键拖拽即可高亮选区(反色),松手后通过 OSC 52 转义序列写入系统剪贴板并弹 toast 提示
- **双击选词**:双击选中光标处的词(`[a-zA-Z0-9_]` / 空白 / 标点各自扩展到同类边界,如 `->` 会选整个运算符)
- **三击选行**:三击选中整行内容
- 不再依赖 `v` select-mode;mouse capture 保持开启,点击/滚轮/分割条拖动全部正常

## 实现要点

| 文件 | 改动 |
|------|------|
| `src/ui/selection.rs` (新) | `PreviewSelection` 数据模型、`col_to_byte_offset`(unicode-aware)、`collect_selected_text`、`word_at_byte`;24 个单元测试 |
| `src/clipboard.rs` (新) | 手写 base64 + OSC 52 stdout 写入,零新依赖;7 个单元测试 |
| `src/ui/text.rs` | 新增 `overlay_selection_highlight`(token 分割 + `Modifier::REVERSED`);4 个单元测试 |
| `src/app.rs` | 4 个新字段(`preview_selection` / `last_preview_rect` / `last_preview_content_origin` / `preview_click_state`);tab 切换 & 换文件时清空 |
| `src/ui/mod.rs` | render 顶部每帧清理 rect 缓存 |
| `src/ui/file_preview_panel.rs` | 写入 rect/origin 缓存,每行应用选中反色 |
| `src/input.rs` | `handle_preview_selection` fast-path;三级点击计数 |
| `src/i18n.rs` | `ClipboardCopied` / `ClipboardCopyFailed` 中英文案 |

## 终端兼容性

支持 OSC 52 的终端(选中后真正写剪贴板):iTerm2、Kitty、WezTerm、Alacritty、Ghostty、foot、tmux(`set -g set-clipboard on`)。
macOS Terminal.app 不支持 OSC 52 —— 选中高亮仍然显示,但剪贴板无变化。

## Test plan

- [ ] `cargo test` 通过(284 个单元测试,0 失败)
- [ ] `cargo clippy` 零告警
- [ ] 手动:Files tab 选文件 → preview 内拖拽 → 反色高亮 → 松手 → toast + Cmd+V 粘贴成功
- [ ] 手动:双击标识符 → 整词选中复制
- [ ] 手动:三击 → 整行选中复制
- [ ] 手动:切换 tab / 切换文件 → 选中消失
- [ ] 手动:滚轮滚动 preview → 选中随文件坐标保留
- [ ] 手动:`v` select-mode 旧路径不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)