### PR TITLE
feat(graph): visual-mode multi-commit range with merged diff

### DIFF
--- a/skills/developing-reef/SKILL.md
+++ b/skills/developing-reef/SKILL.md
@@ -49,4 +49,23 @@ Read `references/runtime-architecture.md` before changing `src/app.rs`, `src/tas
 - Add unit tests for pure helpers and state transitions when practical.
 - Update snapshot tests only when rendered text/layout intentionally changes.
 - For async UI behavior, tests should wait for `tick` to consume worker results instead of assuming synchronous state.
-- Run at least focused tests for touched areas; for architecture changes prefer `cargo check`, `cargo test --lib`, relevant integration/snapshot tests, `cargo fmt --all -- --check`, and clippy with `-D warnings`.
+
+## Pre-PR Checks
+
+Run these locally before `git push`. CI runs exactly these commands — mirroring them avoids the "commit → push → CI red → fmt fix → force push" round-trip on every PR.
+
+```
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --all-features
+cargo test --workspace --doc
+```
+
+Failure modes that keep catching people:
+
+- **`cargo test --lib` is not enough.** It skips integration tests (`tests/*.rs`), snapshot tests (`tests/ui_snapshots.rs`), and doctests. CI runs `--workspace --all-features` — so must you.
+- **Clippy without `--workspace` misses `test-support`.** The scope flag is load-bearing; drop it and a broken lint in a helper crate sails through locally then trips CI.
+- **`cargo fmt` edits in place; `--check` only verifies.** Run the first to fix, the second to gate. Omit the first and every stylebot nit becomes a second commit on your PR.
+
+Coverage (`cargo llvm-cov`) is advisory and doesn't block PRs; no need to run it locally unless you're inspecting coverage deltas.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 use crate::file_tree::{FileTree, PreviewContent};
 use crate::fs_watcher;
 use crate::git::graph::GraphRow;
-use crate::git::{CommitDetail, DiffContent, FileEntry, GitRepo, RefLabel};
+use crate::git::{CommitDetail, CommitInfo, DiffContent, FileEntry, GitRepo, RefLabel};
 use crate::tasks::{AsyncState, TaskCoordinator, WorkerResult};
 use crate::ui::highlight::StyledToken;
 use crate::ui::mouse::{ClickAction, HitTestRegistry};
@@ -98,6 +98,11 @@ pub struct GitGraphState {
     pub cache_key: Option<(String, u64)>,
     pub selected_idx: usize,
     pub selected_commit: Option<String>,
+    /// Anchor index for Shift-extended range selection. `None` = single-select
+    /// mode; `Some(i)` pairs with `selected_idx` as cursor. `i == selected_idx`
+    /// is normalised to single-select by `selected_range` / `is_range`.
+    /// Cleared on plain nav, refresh, tab-internal search jump, and Esc.
+    pub selection_anchor: Option<usize>,
     pub scroll: usize,
     /// `selected_idx` observed on the previous render. Used to distinguish
     /// selection-change follow (bring the selected commit into view) from
@@ -105,6 +110,43 @@ pub struct GitGraphState {
     /// for the Files tab — without this, mouse-wheel scroll snapped back to
     /// the selected commit on the next tick.
     pub last_rendered_selected: Option<usize>,
+}
+
+impl GitGraphState {
+    /// Inclusive `(lo, hi)` bounds of the current selection. Returns
+    /// `(selected_idx, selected_idx)` when there's no anchor or the anchor
+    /// has collapsed onto the cursor (= single-select).
+    pub fn selected_range(&self) -> (usize, usize) {
+        match self.selection_anchor {
+            Some(a) if a != self.selected_idx => {
+                (a.min(self.selected_idx), a.max(self.selected_idx))
+            }
+            _ => (self.selected_idx, self.selected_idx),
+        }
+    }
+
+    pub fn is_range(&self) -> bool {
+        matches!(self.selection_anchor, Some(a) if a != self.selected_idx)
+    }
+
+    /// Visual mode is armed iff the anchor is set, regardless of whether
+    /// the cursor has actually moved away from it. Used for UI affordances
+    /// (status bar badge, input dispatch, mouse click semantics) where
+    /// "armed but collapsed" and "armed + extended" behave identically;
+    /// use `is_range` when a real range of ≥2 commits is required (e.g.
+    /// the data loader needs oldest ≠ newest to make `diff_tree_to_tree`
+    /// meaningful).
+    pub fn in_visual_mode(&self) -> bool {
+        self.selection_anchor.is_some()
+    }
+
+    /// Linear scan for the row holding `oid`. Hot enough (status bar clicks,
+    /// worker-result merges, focus commands all go through here) to warrant
+    /// a named helper — without it, `rows.iter().position(|r| r.commit.oid == oid)`
+    /// spread across six sites and drifted on `&str` vs `&String` match.
+    pub fn find_row_by_oid(&self, oid: &str) -> Option<usize> {
+        self.rows.iter().position(|r| r.commit.oid == oid)
+    }
 }
 
 /// Syntect tokens for one line of a diff. `Arc` so the render pipeline can
@@ -138,10 +180,28 @@ pub struct CommitFileDiff {
     pub highlighted: Option<DiffHighlighted>,
 }
 
+/// Range-mode summary for the Graph tab's right panel. Shown instead of
+/// `CommitDetail` when the user has a Shift-extended range. Files are the
+/// net `parent(oldest).tree → newest.tree` delta (matches IntelliJ); the
+/// per-commit list is a snapshot of `rows[lo..=hi]` taken on the main
+/// thread, so the worker only needs to compute `files`.
+#[derive(Debug, Clone)]
+pub struct RangeDetail {
+    pub oldest_oid: String,
+    pub newest_oid: String,
+    pub commit_count: usize,
+    pub commits: Vec<CommitInfo>,
+    pub files: Vec<FileEntry>,
+}
+
 /// State for the inline commit-detail editor panel (Tab::Graph right side).
 #[derive(Debug)]
 pub struct CommitDetailState {
     pub detail: Option<CommitDetail>,
+    /// Range-mode payload. Mutually exclusive with `detail` in practice —
+    /// `reload_graph_selection` flips the panel into exactly one of the two
+    /// modes and clears the other.
+    pub range_detail: Option<RangeDetail>,
     pub file_diff: Option<CommitFileDiff>,
     /// Intentionally independent of `App.diff_layout` — the Git tab and the
     /// Graph tab track their diff layout separately (see plan pitfall #1).
@@ -170,6 +230,7 @@ impl Default for CommitDetailState {
     fn default() -> Self {
         Self {
             detail: None,
+            range_detail: None,
             file_diff: None,
             diff_layout: DiffLayout::Unified,
             diff_mode: DiffMode::Compact,
@@ -1250,15 +1311,82 @@ impl App {
             .load_commit_detail(generation, self.file_tree.root.clone(), oid);
     }
 
-    /// Load the inline diff for a file inside the currently-selected commit.
+    /// (Re)load the range-mode payload for the current Shift-extended
+    /// selection. Fills per-commit metadata synchronously from the cached
+    /// `rows` slice (no git walk needed) and dispatches the file-list
+    /// computation — `parent(oldest).tree → newest.tree` — to the graph
+    /// worker. No-ops when the selection is actually a single row.
+    pub fn load_commit_range_detail(&mut self) {
+        self.commit_detail.file_diff = None;
+        self.commit_detail.diff_h_scroll = 0;
+        self.commit_detail.sbs_left_h_scroll = 0;
+        self.commit_detail.sbs_right_h_scroll = 0;
+        if !self.git_graph.is_range() {
+            self.commit_detail.range_detail = None;
+            return;
+        }
+        let (lo, hi) = self.git_graph.selected_range();
+        let Some(oldest_row) = self.git_graph.rows.get(hi) else {
+            self.commit_detail.range_detail = None;
+            return;
+        };
+        let Some(newest_row) = self.git_graph.rows.get(lo) else {
+            self.commit_detail.range_detail = None;
+            return;
+        };
+        // `rows` is newest-first (revwalk order), so the higher index is the
+        // chronologically older commit; `parent(oldest)` is the baseline.
+        let oldest_oid = oldest_row.commit.oid.clone();
+        let newest_oid = newest_row.commit.oid.clone();
+        let commits: Vec<CommitInfo> = self.git_graph.rows[lo..=hi]
+            .iter()
+            .map(|r| r.commit.clone())
+            .collect();
+        let commit_count = commits.len();
+        // Seed with empty files so the panel has something to render while
+        // the worker computes the union list. Worker result replaces it on
+        // arrival via generation match.
+        self.commit_detail.range_detail = Some(RangeDetail {
+            oldest_oid: oldest_oid.clone(),
+            newest_oid: newest_oid.clone(),
+            commit_count,
+            commits,
+            files: Vec::new(),
+        });
+        if self.repo.is_none() {
+            return;
+        }
+        let generation = self.commit_detail_load.begin();
+        self.tasks.load_commit_range_detail(
+            generation,
+            self.file_tree.root.clone(),
+            oldest_oid,
+            newest_oid,
+        );
+    }
+
+    /// Dispatch the correct loader based on the current selection shape.
+    /// Single-commit selection → `load_commit_detail`; range selection →
+    /// `load_commit_range_detail`. Callers who previously called
+    /// `load_commit_detail` directly on selection change should switch to
+    /// this so range mode is exercised automatically.
+    pub fn reload_graph_selection(&mut self) {
+        if self.git_graph.is_range() {
+            self.commit_detail.detail = None;
+            self.load_commit_range_detail();
+        } else {
+            self.commit_detail.range_detail = None;
+            self.load_commit_detail();
+        }
+    }
+
+    /// Load the inline diff for a file inside the currently-selected commit
+    /// or commit range. Routes to range-file-diff plumbing when a range is
+    /// active so the diff baseline matches the file list.
     pub fn load_commit_file_diff(&mut self, path: &str) {
         let context = match self.commit_detail.diff_mode {
             DiffMode::Compact => 3,
             DiffMode::FullFile => 9999,
-        };
-        let Some(oid) = self.git_graph.selected_commit.clone() else {
-            self.commit_detail.file_diff = None;
-            return;
         };
         if self.repo.is_none() {
             self.commit_detail.file_diff = None;
@@ -1278,6 +1406,28 @@ impl App {
             self.commit_detail.sbs_left_h_scroll = 0;
             self.commit_detail.sbs_right_h_scroll = 0;
         }
+        if self.git_graph.is_range() {
+            let Some(range) = self.commit_detail.range_detail.as_ref() else {
+                self.commit_detail.file_diff = None;
+                return;
+            };
+            let (oldest, newest) = (range.oldest_oid.clone(), range.newest_oid.clone());
+            let generation = self.commit_file_diff_load.begin();
+            self.tasks.load_range_file_diff(
+                generation,
+                self.file_tree.root.clone(),
+                oldest,
+                newest,
+                path.to_string(),
+                context,
+                self.theme.is_dark,
+            );
+            return;
+        }
+        let Some(oid) = self.git_graph.selected_commit.clone() else {
+            self.commit_detail.file_diff = None;
+            return;
+        };
         let generation = self.commit_file_diff_load.begin();
         self.tasks.load_commit_file_diff(
             generation,
@@ -1302,11 +1452,49 @@ impl App {
         }
     }
 
-    /// Move the graph selection by `delta` rows (clamped). Updates
-    /// selected_commit and reloads commit detail.
+    /// Move the graph selection by `delta` rows (clamped). Clears any
+    /// Shift-anchor (plain nav drops range mode) and reloads the single
+    /// commit detail.
     pub fn move_graph_selection(&mut self, delta: i32) {
         if self.git_graph.rows.is_empty() {
             return;
+        }
+        // Plain navigation always collapses to single-select. `anchor=None`
+        // means `reload_graph_selection()` below (and the cursor-didn't-move
+        // branch) always take the single-commit path — we call
+        // `load_commit_detail()` directly to skip that dispatch hop.
+        self.git_graph.selection_anchor = None;
+        let last = self.git_graph.rows.len() - 1;
+        let current = self.git_graph.selected_idx as i32;
+        let next = (current + delta).clamp(0, last as i32) as usize;
+        if next == self.git_graph.selected_idx {
+            // Edge-clamp with a stale range still visible (user was in
+            // visual mode, pressed plain ↓ at the bottom). Clear the
+            // range payload so the panel snaps back to single-commit.
+            if self.commit_detail.range_detail.is_some() {
+                self.commit_detail.range_detail = None;
+                self.load_commit_detail();
+            }
+            return;
+        }
+        self.git_graph.selected_idx = next;
+        self.git_graph.selected_commit =
+            self.git_graph.rows.get(next).map(|r| r.commit.oid.clone());
+        self.commit_detail.scroll = 0;
+        self.commit_detail.range_detail = None;
+        self.load_commit_detail();
+    }
+
+    /// Shift-extend the selection by `delta` rows. Sets the anchor to the
+    /// current cursor on first call, then moves the cursor; the range always
+    /// spans `[min(anchor, cursor), max(anchor, cursor)]`. When the cursor
+    /// collapses back onto the anchor the selection normalises to single.
+    pub fn extend_graph_selection(&mut self, delta: i32) {
+        if self.git_graph.rows.is_empty() {
+            return;
+        }
+        if self.git_graph.selection_anchor.is_none() {
+            self.git_graph.selection_anchor = Some(self.git_graph.selected_idx);
         }
         let last = self.git_graph.rows.len() - 1;
         let current = self.git_graph.selected_idx as i32;
@@ -1317,9 +1505,18 @@ impl App {
         self.git_graph.selected_idx = next;
         self.git_graph.selected_commit =
             self.git_graph.rows.get(next).map(|r| r.commit.oid.clone());
-        // Reset commit-detail scroll so the new commit starts at the top.
         self.commit_detail.scroll = 0;
-        self.load_commit_detail();
+        self.reload_graph_selection();
+    }
+
+    /// Drop any Shift-anchor, collapsing to single-select on the current
+    /// cursor. No-op when not in range mode.
+    pub fn clear_graph_range(&mut self) {
+        if self.git_graph.selection_anchor.take().is_some() {
+            self.commit_detail.scroll = 0;
+            self.commit_detail.range_detail = None;
+            self.reload_graph_selection();
+        }
     }
 
     /// Kick off a `git push` in the background. Returns immediately; the
@@ -1566,19 +1763,37 @@ impl App {
                 Ok(payload) => {
                     if self.graph_load.complete_ok(generation) {
                         let previous_commit = self.git_graph.selected_commit.clone();
+                        // Snapshot the anchor's OID before the re-walk
+                        // overwrites `rows`. The graph is revalidated every
+                        // ~5s on a timer (`next_graph_revalidate_at`), so
+                        // dropping the anchor here would silently exit the
+                        // user's visual mode every few seconds — the
+                        // "range disappears" symptom. We relocate by OID
+                        // instead, same as `selected_commit` below.
+                        let previous_anchor_oid = self
+                            .git_graph
+                            .selection_anchor
+                            .and_then(|idx| self.git_graph.rows.get(idx))
+                            .map(|r| r.commit.oid.clone());
+                        // Detect whether the incoming payload is a no-op
+                        // (HEAD + ref-hash unchanged). The worker always
+                        // re-walks; this cheap comparison on the main
+                        // thread lets us skip a range-detail reload — and
+                        // the `file_diff = None` reset that comes with it
+                        // — when nothing actually changed. Without this,
+                        // visual-mode users watching a file diff saw it
+                        // blink every 5s.
+                        let cache_key_changed =
+                            self.git_graph.cache_key.as_ref() != Some(&payload.cache_key);
+
                         self.git_graph.rows = payload.rows;
                         self.git_graph.ref_map = payload.ref_map;
                         self.git_graph.cache_key = Some(payload.cache_key);
 
-                        if let Some(ref oid) = previous_commit {
-                            if let Some(idx) = self
-                                .git_graph
-                                .rows
-                                .iter()
-                                .position(|r| r.commit.oid == *oid)
-                            {
-                                self.git_graph.selected_idx = idx;
-                            }
+                        if let Some(ref oid) = previous_commit
+                            && let Some(idx) = self.git_graph.find_row_by_oid(oid)
+                        {
+                            self.git_graph.selected_idx = idx;
                         }
                         if self.git_graph.selected_idx >= self.git_graph.rows.len() {
                             self.git_graph.selected_idx =
@@ -1590,7 +1805,29 @@ impl App {
                             .get(self.git_graph.selected_idx)
                             .map(|r| r.commit.oid.clone());
 
-                        if self.git_graph.selected_commit != previous_commit
+                        // Relocate the anchor by OID. Only clear when the
+                        // anchor commit genuinely vanished from history
+                        // (rebase / amend / prune rewrote it away).
+                        let anchor_survived = previous_anchor_oid
+                            .as_ref()
+                            .and_then(|oid| self.git_graph.find_row_by_oid(oid));
+                        self.git_graph.selection_anchor = anchor_survived;
+                        if anchor_survived.is_none() {
+                            self.commit_detail.range_detail = None;
+                        }
+
+                        // Reload the right panel only when something
+                        // actually shifted. In visual mode we skip the
+                        // range rebuild when cache_key matched — rows
+                        // are byte-identical so the cached range_detail
+                        // still describes the same slice. Single-select
+                        // keeps its pre-existing short-circuit on
+                        // selected_commit identity.
+                        if self.git_graph.selection_anchor.is_some() {
+                            if cache_key_changed {
+                                self.reload_graph_selection();
+                            }
+                        } else if self.git_graph.selected_commit != previous_commit
                             || self.commit_detail.detail.is_none()
                         {
                             self.load_commit_detail();
@@ -1612,6 +1849,28 @@ impl App {
                 }
             },
             WorkerResult::CommitFileDiff { generation, result } => match result {
+                Ok(file_diff) => {
+                    if self.commit_file_diff_load.complete_ok(generation) {
+                        self.commit_detail.file_diff = file_diff;
+                    }
+                }
+                Err(error) => {
+                    self.commit_file_diff_load.complete_err(generation, error);
+                }
+            },
+            WorkerResult::RangeDetail { generation, result } => match result {
+                Ok(files) => {
+                    if self.commit_detail_load.complete_ok(generation) {
+                        if let Some(rd) = self.commit_detail.range_detail.as_mut() {
+                            rd.files = files;
+                        }
+                    }
+                }
+                Err(error) => {
+                    self.commit_detail_load.complete_err(generation, error);
+                }
+            },
+            WorkerResult::RangeFileDiff { generation, result } => match result {
                 Ok(file_diff) => {
                     if self.commit_file_diff_load.complete_ok(generation) {
                         self.commit_detail.file_diff = file_diff;
@@ -2344,7 +2603,52 @@ fn save_prefs(layout: DiffLayout, mode: DiffMode) {
 
 #[cfg(test)]
 mod tests {
-    use super::folder_contains;
+    use super::{GitGraphState, folder_contains};
+
+    #[test]
+    fn graph_state_selected_range_single_without_anchor() {
+        let g = GitGraphState {
+            selected_idx: 5,
+            ..Default::default()
+        };
+        assert_eq!(g.selected_range(), (5, 5));
+        assert!(!g.is_range());
+    }
+
+    #[test]
+    fn graph_state_selected_range_collapsed_anchor_is_single() {
+        // `V` just entered visual mode — anchor sits on the cursor.
+        let g = GitGraphState {
+            selected_idx: 3,
+            selection_anchor: Some(3),
+            ..Default::default()
+        };
+        assert_eq!(g.selected_range(), (3, 3));
+        assert!(!g.is_range());
+    }
+
+    #[test]
+    fn graph_state_selected_range_anchor_above_cursor() {
+        // (lo, hi) is always sorted — cursor can be above or below anchor.
+        let g = GitGraphState {
+            selected_idx: 2,
+            selection_anchor: Some(7),
+            ..Default::default()
+        };
+        assert_eq!(g.selected_range(), (2, 7));
+        assert!(g.is_range());
+    }
+
+    #[test]
+    fn graph_state_selected_range_anchor_below_cursor() {
+        let g = GitGraphState {
+            selected_idx: 9,
+            selection_anchor: Some(4),
+            ..Default::default()
+        };
+        assert_eq!(g.selected_range(), (4, 9));
+        assert!(g.is_range());
+    }
 
     #[test]
     fn folder_contains_direct_child() {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -837,41 +837,114 @@ impl GitRepo {
             Err(_) => return Vec::new(),
         };
 
-        let mut files = Vec::new();
-        diff.foreach(
-            &mut |delta, _progress| {
-                let path = delta
-                    .new_file()
-                    .path()
-                    .or_else(|| delta.old_file().path())
-                    .and_then(|p| p.to_str())
-                    .map(String::from);
-                if let Some(path) = path {
-                    let status = match delta.status() {
-                        git2::Delta::Added => FileStatus::Added,
-                        git2::Delta::Deleted => FileStatus::Deleted,
-                        git2::Delta::Renamed | git2::Delta::Copied => FileStatus::Renamed,
-                        git2::Delta::Untracked => FileStatus::Untracked,
-                        _ => FileStatus::Modified,
-                    };
-                    files.push(FileEntry {
-                        path,
-                        status,
-                        additions: 0,
-                        deletions: 0,
-                    });
-                }
-                true
-            },
-            None,
-            None,
-            None,
-        )
-        .ok();
-
-        files.sort_by(|a, b| a.path.cmp(&b.path));
-        files
+        collect_files_from_diff(&diff)
     }
+
+    /// Files changed by the range [oldest, newest] (inclusive) — computed as
+    /// the net tree delta `parent(oldest).tree → newest.tree`. Merge commits
+    /// (either endpoint or anywhere inside the range) follow first-parent, the
+    /// same convention as single-commit diffs.
+    pub fn get_range_files(&self, oldest_oid: &str, newest_oid: &str) -> Vec<FileEntry> {
+        let Some(oldest) = git2::Oid::from_str(oldest_oid)
+            .ok()
+            .and_then(|o| self.repo.find_commit(o).ok())
+        else {
+            return Vec::new();
+        };
+        let Some(newest) = git2::Oid::from_str(newest_oid)
+            .ok()
+            .and_then(|o| self.repo.find_commit(o).ok())
+        else {
+            return Vec::new();
+        };
+        let Ok(new_tree) = newest.tree() else {
+            return Vec::new();
+        };
+        // None = oldest is a root commit; diff against empty tree.
+        let parent_tree = oldest.parents().next().and_then(|p| p.tree().ok());
+
+        let diff = match self
+            .repo
+            .diff_tree_to_tree(parent_tree.as_ref(), Some(&new_tree), None)
+        {
+            Ok(d) => d,
+            Err(_) => return Vec::new(),
+        };
+
+        collect_files_from_diff(&diff)
+    }
+
+    /// Single-file diff for a commit range: same semantics as
+    /// `get_range_files` — `parent(oldest).tree → newest.tree`, first-parent
+    /// on merges, empty-tree baseline if `oldest` has no parent.
+    pub fn get_range_file_diff(
+        &self,
+        oldest_oid: &str,
+        newest_oid: &str,
+        path: &str,
+        context_lines: u32,
+    ) -> Option<DiffContent> {
+        let oldest = self
+            .repo
+            .find_commit(git2::Oid::from_str(oldest_oid).ok()?)
+            .ok()?;
+        let newest = self
+            .repo
+            .find_commit(git2::Oid::from_str(newest_oid).ok()?)
+            .ok()?;
+        let new_tree = newest.tree().ok()?;
+        let parent_tree = oldest.parents().next().and_then(|p| p.tree().ok());
+
+        let mut opts = DiffOptions::new();
+        opts.pathspec(path).context_lines(context_lines);
+
+        let diff = self
+            .repo
+            .diff_tree_to_tree(parent_tree.as_ref(), Some(&new_tree), Some(&mut opts))
+            .ok()?;
+
+        self.parse_git2_diff(&diff, path)
+    }
+}
+
+/// Shared `git2::Diff → Vec<FileEntry>` reducer. Keeps the delta→status map
+/// and the trailing sort in one place so `commit_files` and `get_range_files`
+/// stay structurally identical.
+fn collect_files_from_diff(diff: &git2::Diff) -> Vec<FileEntry> {
+    let mut files = Vec::new();
+    diff.foreach(
+        &mut |delta, _progress| {
+            let path = delta
+                .new_file()
+                .path()
+                .or_else(|| delta.old_file().path())
+                .and_then(|p| p.to_str())
+                .map(String::from);
+            if let Some(path) = path {
+                let status = match delta.status() {
+                    git2::Delta::Added => FileStatus::Added,
+                    git2::Delta::Deleted => FileStatus::Deleted,
+                    git2::Delta::Renamed | git2::Delta::Copied => FileStatus::Renamed,
+                    git2::Delta::Untracked => FileStatus::Untracked,
+                    _ => FileStatus::Modified,
+                };
+                files.push(FileEntry {
+                    path,
+                    status,
+                    additions: 0,
+                    deletions: 0,
+                });
+            }
+            true
+        },
+        None,
+        None,
+        None,
+    )
+    .ok();
+
+    files.sort_by(|a, b| a.path.cmp(&b.path));
+    files
 }
 
 fn commit_to_info(commit: &git2::Commit) -> CommitInfo {

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -133,6 +133,15 @@ pub enum Msg {
     HelpPageDown,
     HelpHScroll,
     HelpHScrollFast,
+    HelpGraphRangeExtend,
+    HelpGraphRangeExtendFast,
+    HelpGraphRangeClear,
+    HelpGraphShiftExtend,
+    HelpGraphShiftClick,
+    HelpGraphVisualMode,
+    HelpGraphVisualClick,
+    RangeHint,
+    StatusBarRangeHint,
     HelpHomeEnd,
     HelpMouseHScroll,
     HelpStageUnstage,
@@ -230,6 +239,15 @@ fn t_zh(m: Msg) -> &'static str {
         HelpPageDown => "快速向下翻页",
         HelpHScroll => "横向滚动（Diff/预览 面板聚焦时）",
         HelpHScrollFast => "横向快速滚动（10 列）",
+        HelpGraphRangeExtend => "扩选一行提交（Graph 标签页）",
+        HelpGraphRangeExtendFast => "扩选 10 行提交（Graph 标签页）",
+        HelpGraphRangeClear => "退出可视模式 / 清除范围选择",
+        HelpGraphShiftExtend => "扩选（在支持 Shift 透传的终端，否则按 V 进入可视模式）",
+        HelpGraphShiftClick => "Shift+点击：扩选到该提交（同上，否则用可视模式）",
+        HelpGraphVisualMode => "进入/退出可视模式（Graph 标签页）",
+        HelpGraphVisualClick => "可视模式下点击提交 = 改变终点",
+        RangeHint => "点击下方任一提交即可折叠范围回到单选",
+        StatusBarRangeHint => "↑↓/点击 扩选 · V/Esc 退出",
         HelpHomeEnd => "回到行首 / 跳到行尾",
         HelpMouseHScroll => "鼠标横向滚动",
         HelpStageUnstage => "暂存 / 取消暂存（Git tab）",
@@ -321,6 +339,15 @@ fn t_en(m: Msg) -> &'static str {
         HelpPageDown => "Page down",
         HelpHScroll => "Horizontal scroll (when Diff/Preview focused)",
         HelpHScrollFast => "Horizontal fast scroll (10 cols)",
+        HelpGraphRangeExtend => "Extend commit range by 1 (Graph tab)",
+        HelpGraphRangeExtendFast => "Extend commit range by 10 (Graph tab)",
+        HelpGraphRangeClear => "Exit visual mode / clear range",
+        HelpGraphShiftExtend => "Extend range (terminals that forward Shift; else use V)",
+        HelpGraphShiftClick => "Shift+Click: extend range (same; else use visual mode)",
+        HelpGraphVisualMode => "Enter/exit visual mode (Graph tab)",
+        HelpGraphVisualClick => "In visual mode: click = move endpoint",
+        RangeHint => "Click any commit below to collapse back to single-select",
+        StatusBarRangeHint => "↑↓/click extend · V/Esc exit",
         HelpHomeEnd => "Jump to line start / end",
         HelpMouseHScroll => "Mouse horizontal scroll",
         HelpStageUnstage => "Stage / unstage (Git tab)",
@@ -429,6 +456,19 @@ pub fn discard_section_prefix_and_count(is_staged: bool, count: usize) -> (Strin
 
 pub fn changed_files_header(n: usize) -> String {
     format!("{} ({})", t(Msg::ChangedFiles), n)
+}
+
+pub fn range_header_count(n: usize) -> String {
+    match lang() {
+        Lang::Zh => format!("范围 · {} 个提交", n),
+        Lang::En => format!("Range · {} commits", n),
+    }
+}
+
+pub fn range_badge(n: usize) -> String {
+    // "RANGE" is a fixed UI token (matches SELECT/PLACE/TRASH badge style),
+    // not a translatable word; keep it language-agnostic.
+    format!(" RANGE {} ", n)
 }
 
 /// Trailing "  [label]  t 切换" / "  [label]  t toggle" hint on the commit

--- a/src/input.rs
+++ b/src/input.rs
@@ -639,16 +639,31 @@ fn handle_key_search_input_mode(key: KeyEvent, app: &mut App, ctrl: bool, alt: b
 fn handle_key_graph(key: KeyEvent, app: &mut App) {
     use ui::{commit_detail_panel, git_graph_panel};
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+    // While in visual mode every direction key extends (no Shift needed —
+    // works in terminals that intercept Shift+Click / Shift+Arrow for text
+    // selection), a mouse click on a commit moves the endpoint, and `V` /
+    // `Esc` exits. This is the primary path; Shift+Arrow below is kept as
+    // a convenience for terminals that *do* forward the modifier.
+    let in_visual = app.git_graph.in_visual_mode() && app.active_panel == Panel::Files;
     match key.code {
         KeyCode::Up | KeyCode::Char('k') if !ctrl => match app.active_panel {
             Panel::Files => {
-                git_graph_panel::handle_key(app, "k");
+                if shift || in_visual {
+                    app.extend_graph_selection(-1);
+                } else {
+                    git_graph_panel::handle_key(app, "k");
+                }
             }
             Panel::Diff => commit_detail_panel::scroll(app, -1),
         },
         KeyCode::Down | KeyCode::Char('j') if !ctrl => match app.active_panel {
             Panel::Files => {
-                git_graph_panel::handle_key(app, "j");
+                if shift || in_visual {
+                    app.extend_graph_selection(1);
+                } else {
+                    git_graph_panel::handle_key(app, "j");
+                }
             }
             Panel::Diff => commit_detail_panel::scroll(app, 1),
         },
@@ -656,32 +671,65 @@ fn handle_key_graph(key: KeyEvent, app: &mut App) {
         // Files/Git tabs bind).
         KeyCode::Char('p' | 'k') if ctrl => match app.active_panel {
             Panel::Files => {
-                git_graph_panel::handle_key(app, "k");
+                if shift || in_visual {
+                    app.extend_graph_selection(-1);
+                } else {
+                    git_graph_panel::handle_key(app, "k");
+                }
             }
             Panel::Diff => commit_detail_panel::scroll(app, -1),
         },
         KeyCode::Char('n' | 'j') if ctrl => match app.active_panel {
             Panel::Files => {
-                git_graph_panel::handle_key(app, "j");
+                if shift || in_visual {
+                    app.extend_graph_selection(1);
+                } else {
+                    git_graph_panel::handle_key(app, "j");
+                }
             }
             Panel::Diff => commit_detail_panel::scroll(app, 1),
         },
         KeyCode::PageUp => match app.active_panel {
             Panel::Files => {
-                for _ in 0..10 {
-                    git_graph_panel::handle_key(app, "k");
+                if shift || in_visual {
+                    app.extend_graph_selection(-10);
+                } else {
+                    for _ in 0..10 {
+                        git_graph_panel::handle_key(app, "k");
+                    }
                 }
             }
             Panel::Diff => commit_detail_panel::scroll(app, -20),
         },
         KeyCode::PageDown => match app.active_panel {
             Panel::Files => {
-                for _ in 0..10 {
-                    git_graph_panel::handle_key(app, "j");
+                if shift || in_visual {
+                    app.extend_graph_selection(10);
+                } else {
+                    for _ in 0..10 {
+                        git_graph_panel::handle_key(app, "j");
+                    }
                 }
             }
             Panel::Diff => commit_detail_panel::scroll(app, 20),
         },
+        // `V` (uppercase = Shift+v) toggles visual mode. Entering: anchor
+        // collapses onto the cursor (is_range() stays false until the user
+        // actually extends), so the status bar can distinguish "armed but
+        // empty" from an active range if it wants to.
+        KeyCode::Char('V') if app.active_panel == Panel::Files => {
+            if app.git_graph.in_visual_mode() {
+                app.clear_graph_range();
+            } else if !app.git_graph.rows.is_empty() {
+                app.git_graph.selection_anchor = Some(app.git_graph.selected_idx);
+            }
+        }
+        // Esc exits visual mode / collapses any range back to single-select.
+        // Only consumed when actually armed on the Files panel so higher
+        // priority Esc handlers (overlays etc.) aren't shadowed elsewhere.
+        KeyCode::Esc if app.active_panel == Panel::Files && app.git_graph.in_visual_mode() => {
+            app.clear_graph_range();
+        }
         KeyCode::Char('r') => {
             // `r` on the graph sidebar = force a graph cache refresh
             app.git_graph.cache_key = None;
@@ -1189,6 +1237,27 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
                 } else {
                     action
                 };
+                // Shift+Click on a graph row = extend the range, for
+                // terminals that actually forward Shift+Click to the app.
+                // Most macOS terminals intercept this for text selection;
+                // those users should press `V` to enter visual mode and
+                // click normally instead — the in-visual-mode click path
+                // lives in `git_graph_panel::handle_command`.
+                if mouse.modifiers.contains(KeyModifiers::SHIFT)
+                    && let ui::mouse::ClickAction::GitCommand { command, args, .. } = &effective
+                    && command == "git.selectCommit"
+                    && let Some(oid) = args.get("oid").and_then(|v| v.as_str())
+                    && let Some(target_idx) = app.git_graph.find_row_by_oid(oid)
+                {
+                    let delta = target_idx as i32 - app.git_graph.selected_idx as i32;
+                    app.extend_graph_selection(delta);
+                    app.last_click = if is_double {
+                        None
+                    } else {
+                        Some((now, mouse.column, mouse.row))
+                    };
+                    return;
+                }
                 app.handle_action(effective);
             }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -536,6 +536,10 @@ fn restore_snapshot(app: &mut App, snap: &Snapshot) {
             .rows
             .get(snap.git_graph_selected_idx)
             .map(|r| r.commit.oid.clone());
+        // Snapshot restore doesn't carry the anchor, so any in-flight range
+        // would be stale relative to the restored cursor. Drop it cleanly.
+        app.git_graph.selection_anchor = None;
+        app.commit_detail.range_detail = None;
         app.commit_detail.scroll = snap.commit_detail_scroll;
         app.load_commit_detail();
     }
@@ -578,6 +582,12 @@ fn jump_to_current(app: &mut App) {
                 app.git_graph.selected_idx = m.row;
                 app.git_graph.selected_commit =
                     app.git_graph.rows.get(m.row).map(|r| r.commit.oid.clone());
+                // Search jumps always collapse any active range back to
+                // single-select: the anchor points at the commit the user was
+                // looking at before they searched, which is rarely relevant
+                // once they've jumped to a match.
+                app.git_graph.selection_anchor = None;
+                app.commit_detail.range_detail = None;
                 app.commit_detail.scroll = 0;
                 app.load_commit_detail();
             }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -115,6 +115,19 @@ pub enum WorkerResult {
         generation: u64,
         result: Result<Option<CommitFileDiff>, String>,
     },
+    /// Merged-file list for a commit range — `parent(oldest).tree → newest.tree`.
+    /// Consumed by the Graph tab's range-select mode. Per-commit subject
+    /// metadata is filled in on the main thread from cached `rows`.
+    RangeDetail {
+        generation: u64,
+        result: Result<Vec<FileEntry>, String>,
+    },
+    /// Single-file diff for a commit range, same semantics as `CommitFileDiff`
+    /// but sourced from `GitRepo::get_range_file_diff`.
+    RangeFileDiff {
+        generation: u64,
+        result: Result<Option<CommitFileDiff>, String>,
+    },
     /// A batch of global-search hits. Streamed from the worker so the UI
     /// stays responsive on big workdirs; can fire multiple times per search
     /// before the matching `GlobalSearchDone`. Consumers drop the payload
@@ -270,6 +283,21 @@ enum GraphTask {
         /// read correctly against the active UI theme — same as `load_preview`.
         dark: bool,
     },
+    LoadCommitRangeDetail {
+        generation: u64,
+        workdir: PathBuf,
+        oldest_oid: String,
+        newest_oid: String,
+    },
+    LoadRangeFileDiff {
+        generation: u64,
+        workdir: PathBuf,
+        oldest_oid: String,
+        newest_oid: String,
+        path: String,
+        context_lines: u32,
+        dark: bool,
+    },
 }
 
 pub struct TaskCoordinator {
@@ -419,6 +447,43 @@ impl TaskCoordinator {
             generation,
             workdir,
             oid,
+            path,
+            context_lines,
+            dark,
+        });
+    }
+
+    pub fn load_commit_range_detail(
+        &self,
+        generation: u64,
+        workdir: PathBuf,
+        oldest_oid: String,
+        newest_oid: String,
+    ) {
+        let _ = self.graph_tx.send(GraphTask::LoadCommitRangeDetail {
+            generation,
+            workdir,
+            oldest_oid,
+            newest_oid,
+        });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn load_range_file_diff(
+        &self,
+        generation: u64,
+        workdir: PathBuf,
+        oldest_oid: String,
+        newest_oid: String,
+        path: String,
+        context_lines: u32,
+        dark: bool,
+    ) {
+        let _ = self.graph_tx.send(GraphTask::LoadRangeFileDiff {
+            generation,
+            workdir,
+            oldest_oid,
+            newest_oid,
             path,
             context_lines,
             dark,
@@ -848,6 +913,31 @@ fn spawn_graph_worker(result_tx: mpsc::Sender<WorkerResult>) -> mpsc::Sender<Gra
                                 .map(|diff| build_commit_file_diff(path, diff, dark))
                         });
                         let _ = result_tx.send(WorkerResult::CommitFileDiff { generation, result });
+                    }
+                    GraphTask::LoadCommitRangeDetail {
+                        generation,
+                        workdir,
+                        oldest_oid,
+                        newest_oid,
+                    } => {
+                        let result = open_repo(&workdir)
+                            .map(|repo| repo.get_range_files(&oldest_oid, &newest_oid));
+                        let _ = result_tx.send(WorkerResult::RangeDetail { generation, result });
+                    }
+                    GraphTask::LoadRangeFileDiff {
+                        generation,
+                        workdir,
+                        oldest_oid,
+                        newest_oid,
+                        path,
+                        context_lines,
+                        dark,
+                    } => {
+                        let result = open_repo(&workdir).map(|repo| {
+                            repo.get_range_file_diff(&oldest_oid, &newest_oid, &path, context_lines)
+                                .map(|diff| build_commit_file_diff(path, diff, dark))
+                        });
+                        let _ = result_tx.send(WorkerResult::RangeFileDiff { generation, result });
                     }
                 }
             }

--- a/src/ui/commit_detail_panel.rs
+++ b/src/ui/commit_detail_panel.rs
@@ -793,7 +793,9 @@ fn append_range_header(
     rows.push(Row::new(vec![
         RowSpan::styled(
             crate::i18n::range_header_count(range.commit_count),
-            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD),
         ),
         RowSpan::styled(
             format!(" {}..{}", oldest_short, newest_short),

--- a/src/ui/commit_detail_panel.rs
+++ b/src/ui/commit_detail_panel.rs
@@ -457,15 +457,25 @@ pub fn handle_command(app: &mut App, id: &str, args: &Value) -> bool {
         "git.selectCommitFile" => {
             let oid = args.get("oid").and_then(|v| v.as_str()).unwrap_or("");
             let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
-            if oid.is_empty() || path.is_empty() {
+            if path.is_empty() {
                 return true;
             }
-            if app.git_graph.selected_commit.as_deref() != Some(oid) {
-                if let Some(idx) = app.git_graph.rows.iter().position(|r| r.commit.oid == oid) {
-                    app.git_graph.selected_idx = idx;
+            // In range mode, keep the range intact — file clicks load the
+            // range diff (routed inside `load_commit_file_diff`). The `oid`
+            // arg on range rows is just the "newest" marker; we deliberately
+            // don't compare it against `selected_commit` because that would
+            // spuriously flip us into single-select.
+            if !app.git_graph.is_range() {
+                if oid.is_empty() {
+                    return true;
                 }
-                app.git_graph.selected_commit = Some(oid.to_string());
-                app.load_commit_detail();
+                if app.git_graph.selected_commit.as_deref() != Some(oid) {
+                    if let Some(idx) = app.git_graph.find_row_by_oid(oid) {
+                        app.git_graph.selected_idx = idx;
+                    }
+                    app.git_graph.selected_commit = Some(oid.to_string());
+                    app.load_commit_detail();
+                }
             }
             app.load_commit_file_diff(path);
             true
@@ -608,18 +618,103 @@ fn from_ratatui_span(span: Span<'static>) -> RowSpan {
 fn build_rows(app: &App, width: u16, display_w: u16, theme: &Theme) -> Vec<Row> {
     let mut rows: Vec<Row> = Vec::new();
     let cd = &app.commit_detail;
-
-    let Some(detail) = &cd.detail else {
-        rows.push(Row::new(vec![RowSpan::styled(
-            t(Msg::CommitDetailEmpty),
-            Style::default().fg(theme.fg_secondary),
-        )]));
-        return rows;
-    };
-
-    let info = &detail.info;
     let max_msg = (width as usize).saturating_sub(4);
     let max_path = (width as usize).saturating_sub(6);
+
+    // Range mode and single mode share the bottom half (files list + inline
+    // diff) but have different headers. Collect the common data — (files
+    // slice, stable oid for selectCommitFile clicks) — then emit the
+    // appropriate header, and hand off to the shared tail.
+    let (files_source, stable_oid): (&[FileEntry], &str) = match (&cd.range_detail, &cd.detail) {
+        (Some(range), _) => {
+            append_range_header(&mut rows, range, max_msg, theme);
+            (range.files.as_slice(), range.newest_oid.as_str())
+        }
+        (None, Some(detail)) => {
+            append_commit_header(&mut rows, app, detail, max_msg, theme);
+            (detail.files.as_slice(), detail.info.oid.as_str())
+        }
+        (None, None) => {
+            rows.push(Row::new(vec![RowSpan::styled(
+                t(Msg::CommitDetailEmpty),
+                Style::default().fg(theme.fg_secondary),
+            )]));
+            return rows;
+        }
+    };
+
+    let view_label = if cd.files_tree_mode {
+        t(Msg::ViewTree)
+    } else {
+        t(Msg::ViewList)
+    };
+    rows.push(Row::new(vec![
+        RowSpan::styled(
+            crate::i18n::changed_files_header(files_source.len()),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ),
+        RowSpan::styled(
+            crate::i18n::view_toggle_hint(view_label),
+            Style::default().fg(theme.fg_secondary),
+        )
+        .on_click("git.toggleCommitFilesView", Value::Null),
+    ]));
+
+    let ctx = CommitFilesCtx {
+        selected_file: cd.file_diff.as_ref().map(|d| d.path.as_str()),
+        sel_bg: theme.selection_bg,
+        max_path,
+        commit_oid: stable_oid,
+        collapsed: &cd.files_collapsed,
+        fg: theme.fg_primary,
+    };
+
+    if cd.files_tree_mode {
+        let nodes = gtree::build(files_source);
+        render_commit_file_tree(&nodes, 1, &ctx, &mut rows, theme);
+    } else {
+        for file in files_source {
+            rows.push(commit_file_row(file, &file.path, "  ", &ctx));
+        }
+    }
+
+    if let Some(file_diff) = &cd.file_diff {
+        rows.push(Row::blank());
+        rows.push(diff_header_row(
+            &file_diff.path,
+            cd.diff_layout,
+            cd.diff_mode,
+            width,
+            theme,
+        ));
+        rows.push(diff_separator_row(width, theme));
+        append_diff_rows(
+            &mut rows,
+            &file_diff.diff,
+            file_diff.highlighted.as_ref(),
+            cd.diff_layout,
+            width,
+            display_w,
+            theme,
+        );
+    }
+
+    rows
+}
+
+/// Single-commit header: oid/author/date/refs + message body. Unchanged from
+/// the original inline version — just extracted so range-mode can substitute
+/// `append_range_header`.
+fn append_commit_header(
+    rows: &mut Vec<Row>,
+    app: &App,
+    detail: &crate::git::CommitDetail,
+    max_msg: usize,
+    theme: &Theme,
+) {
+    let info = &detail.info;
 
     rows.push(Row::new(vec![
         RowSpan::styled(t(Msg::CommitLabel), Style::default().fg(theme.fg_secondary)),
@@ -678,66 +773,72 @@ fn build_rows(app: &App, width: u16, display_w: u16, theme: &Theme) -> Vec<Row> 
     }
 
     rows.push(Row::blank());
+}
 
-    let view_label = if cd.files_tree_mode {
-        t(Msg::ViewTree)
-    } else {
-        t(Msg::ViewList)
-    };
+/// Range-mode header: "N commits: oldest..newest" plus a clickable list of
+/// subjects. Each commit row emits `git.graph.focusCommit` — a zoom-in
+/// command that always collapses the range back to single-select on the
+/// target commit regardless of visual mode. Plain `git.selectCommit`
+/// behaves differently inside visual mode (it extends the endpoint), which
+/// is the wrong semantic for this list.
+fn append_range_header(
+    rows: &mut Vec<Row>,
+    range: &crate::app::RangeDetail,
+    max_msg: usize,
+    theme: &Theme,
+) {
+    let oldest_short: String = range.oldest_oid.chars().take(7).collect();
+    let newest_short: String = range.newest_oid.chars().take(7).collect();
+
     rows.push(Row::new(vec![
         RowSpan::styled(
-            crate::i18n::changed_files_header(detail.files.len()),
-            Style::default()
-                .fg(Color::Green)
-                .add_modifier(Modifier::BOLD),
+            crate::i18n::range_header_count(range.commit_count),
+            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
         ),
         RowSpan::styled(
-            crate::i18n::view_toggle_hint(view_label),
-            Style::default().fg(theme.fg_secondary),
-        )
-        .on_click("git.toggleCommitFilesView", Value::Null),
+            format!(" {}..{}", oldest_short, newest_short),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::DIM),
+        ),
     ]));
+    rows.push(Row::new(vec![RowSpan::styled(
+        t(Msg::RangeHint),
+        Style::default().fg(theme.fg_secondary),
+    )]));
+    rows.push(Row::blank());
 
-    let ctx = CommitFilesCtx {
-        selected_file: cd.file_diff.as_ref().map(|d| d.path.as_str()),
-        sel_bg: theme.selection_bg,
-        max_path,
-        commit_oid: &info.oid,
-        collapsed: &cd.files_collapsed,
-        fg: theme.fg_primary,
-    };
+    // Commit list: newest first (matches the graph panel's order). Click
+    // any row → collapse range to single on that commit.
+    for commit in &range.commits {
+        let short: String = commit.short_oid.clone();
+        let mut subject = commit.subject.clone();
+        // Reserve room for the short oid + separator + author column.
+        let subject_budget = max_msg.saturating_sub(short.len() + 16);
+        truncate_in_place(&mut subject, subject_budget);
+        let raw_w = UnicodeWidthStr::width(subject.as_str()) + short.len() + 3;
 
-    if cd.files_tree_mode {
-        let nodes = gtree::build(&detail.files);
-        render_commit_file_tree(&nodes, 1, &ctx, &mut rows, theme);
-    } else {
-        for file in &detail.files {
-            rows.push(commit_file_row(file, &file.path, "  ", &ctx));
-        }
-    }
-
-    if let Some(file_diff) = &cd.file_diff {
-        rows.push(Row::blank());
-        rows.push(diff_header_row(
-            &file_diff.path,
-            cd.diff_layout,
-            cd.diff_mode,
-            width,
-            theme,
-        ));
-        rows.push(diff_separator_row(width, theme));
-        append_diff_rows(
-            &mut rows,
-            &file_diff.diff,
-            file_diff.highlighted.as_ref(),
-            cd.diff_layout,
-            width,
-            display_w,
-            theme,
+        rows.push(
+            Row::new(vec![
+                RowSpan::plain("  "),
+                RowSpan::styled(
+                    short,
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::DIM),
+                ),
+                RowSpan::plain(" "),
+                RowSpan::styled(subject, Style::default().fg(theme.fg_primary)),
+            ])
+            .on_click(
+                "git.graph.focusCommit",
+                serde_json::json!({ "oid": commit.oid }),
+            )
+            .with_content_width(raw_w),
         );
     }
 
-    rows
+    rows.push(Row::blank());
 }
 
 struct CommitFilesCtx<'a> {

--- a/src/ui/git_graph_panel.rs
+++ b/src/ui/git_graph_panel.rs
@@ -58,14 +58,23 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
 
     let rows: Vec<&GraphRow> = app.git_graph.rows.iter().collect();
     let theme = app.theme;
+    // Range highlight bounds. Collapsed range (lo == hi) = single-select;
+    // `in_range` check below only fires when the user actually Shift-extended.
+    let (range_lo, range_hi) = app.git_graph.selected_range();
+    let is_range = app.git_graph.is_range();
+    let anchor_idx = app.git_graph.selection_anchor;
     for (i, row) in rows.iter().skip(scroll).take(height).enumerate() {
         let idx = scroll + i;
         let y = area.y + i as u16;
         let hover = crate::ui::hover::is_hover(app, area, y);
         let (search_ranges, search_cur) = app.search.ranges_on_row(SearchTarget::CommitGraph, idx);
+        let in_range = is_range && idx >= range_lo && idx <= range_hi;
+        let is_anchor = is_range && Some(idx) == anchor_idx;
         let (line, click_x_w) = build_row_line(
             row,
             idx == app.git_graph.selected_idx,
+            in_range,
+            is_anchor,
             show_meta,
             max_subject,
             head_oid,
@@ -117,14 +126,41 @@ pub fn handle_command(app: &mut App, id: &str, args: &Value) -> bool {
             true
         }
         "git.selectCommit" => {
+            // Click on a graph row. In visual mode (anchor set) it moves
+            // the endpoint, keeping the anchor — this is the primary way
+            // to build a range in terminals that intercept Shift+Click.
+            // Out of visual mode, single-select behaviour as before.
             let oid = args.get("oid").and_then(|v| v.as_str()).unwrap_or("");
-            if !oid.is_empty() {
-                if let Some(idx) = app.git_graph.rows.iter().position(|r| r.commit.oid == oid) {
+            if !oid.is_empty()
+                && let Some(idx) = app.git_graph.find_row_by_oid(oid)
+            {
+                if app.git_graph.in_visual_mode() {
+                    let delta = idx as i32 - app.git_graph.selected_idx as i32;
+                    app.extend_graph_selection(delta);
+                } else {
                     app.git_graph.selected_idx = idx;
                     app.git_graph.selected_commit = Some(oid.to_string());
+                    app.commit_detail.range_detail = None;
                     app.commit_detail.scroll = 0;
                     app.load_commit_detail();
                 }
+            }
+            true
+        }
+        "git.graph.focusCommit" => {
+            // Range-list "zoom-in" click: always collapse to single-select
+            // on the target commit, regardless of visual mode. Emitted by
+            // the commit_detail_panel range-header commit list.
+            let oid = args.get("oid").and_then(|v| v.as_str()).unwrap_or("");
+            if !oid.is_empty()
+                && let Some(idx) = app.git_graph.find_row_by_oid(oid)
+            {
+                app.git_graph.selected_idx = idx;
+                app.git_graph.selected_commit = Some(oid.to_string());
+                app.git_graph.selection_anchor = None;
+                app.commit_detail.range_detail = None;
+                app.commit_detail.scroll = 0;
+                app.load_commit_detail();
             }
             true
         }
@@ -152,6 +188,8 @@ pub fn scroll(app: &mut App, delta: i32) {
 fn build_row_line(
     row: &GraphRow,
     selected: bool,
+    in_range: bool,
+    is_anchor: bool,
     show_meta: bool,
     max_subject: usize,
     head_oid: Option<&str>,
@@ -166,6 +204,16 @@ fn build_row_line(
     let is_head = head_oid == Some(oid.as_str());
 
     let mut spans: Vec<Span<'static>> = Vec::new();
+
+    // Anchor indicator: a slim accent bar at the very left, so the user can
+    // always see where the range started even when the cursor has drifted
+    // far away. Costs one cell of horizontal space on the anchor row only.
+    if is_anchor && !selected {
+        spans.push(Span::styled(
+            "▌".to_string(),
+            Style::default().fg(theme.accent),
+        ));
+    }
 
     let glyphs = render_lane_chars(row);
     for (col, ch) in glyphs.iter().enumerate() {
@@ -237,6 +285,28 @@ fn build_row_line(
     }
 
     if selected {
+        // All selected rows wear `selection_bg`; when the selection is
+        // part of an active range the cursor additionally picks up BOLD
+        // so it reads as the focused commit within its peers. BOLD alone
+        // isn't applied outside range mode to keep single-select look
+        // unchanged from pre-visual-mode versions.
+        spans = spans
+            .into_iter()
+            .map(|s| {
+                let mut style = s.style.bg(sel_bg);
+                if in_range {
+                    style = style.add_modifier(Modifier::BOLD);
+                }
+                Span::styled(s.content.into_owned(), style)
+            })
+            .collect();
+    } else if in_range {
+        // Range peers share the cursor's `selection_bg` so the whole bundle
+        // reads as one highlighted block. Earlier we tried `hover_bg` here
+        // to dim non-cursor rows, but on dark themes that's Rgb(40,40,50) —
+        // visually indistinguishable from the default background. Using the
+        // same `selection_bg` with a bold cursor gives stronger affordance
+        // for "these are the commits being merged".
         spans = spans
             .into_iter()
             .map(|s| Span::styled(s.content.into_owned(), s.style.bg(sel_bg)))

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -408,6 +408,35 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
         return;
     }
 
+    // Graph-tab visual-mode indicator. Shows whenever `selection_anchor`
+    // is set — even when the range has collapsed to a single commit (user
+    // just pressed V but hasn't moved yet) — so the user always knows why
+    // arrows/clicks behave differently. Takes priority over the generic
+    // status line so the exit hint (`Esc`) is always visible.
+    if app.active_tab == crate::app::Tab::Graph && app.git_graph.in_visual_mode() {
+        let (lo, hi) = app.git_graph.selected_range();
+        let count = hi - lo + 1;
+        let hint = Line::from(vec![
+            Span::styled(
+                crate::i18n::range_badge(count),
+                Style::default()
+                    .fg(th.chrome_bg)
+                    .bg(th.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!(" {}", t(Msg::StatusBarRangeHint)),
+                Style::default().fg(th.accent).bg(th.chrome_bg),
+            ),
+            Span::styled(
+                " ".repeat(area.width.saturating_sub(80) as usize),
+                Style::default().bg(th.chrome_bg),
+            ),
+        ]);
+        f.render_widget(hint, area);
+        return;
+    }
+
     // Show the most recent toast (push success/failure etc.) inline.
     let (notif, notif_color) = match app.toasts.last() {
         Some(t) => (
@@ -534,6 +563,13 @@ fn render_help(f: &mut Frame, app: &App, screen: Rect) {
         ("PageDown", t(Msg::HelpPageDown)),
         ("← / →", t(Msg::HelpHScroll)),
         ("Shift+← / Shift+→", t(Msg::HelpHScrollFast)),
+        ("V", t(Msg::HelpGraphVisualMode)),
+        ("↑ / ↓ (visual)", t(Msg::HelpGraphRangeExtend)),
+        ("PgUp / PgDn (visual)", t(Msg::HelpGraphRangeExtendFast)),
+        ("Click (visual)", t(Msg::HelpGraphVisualClick)),
+        ("Esc", t(Msg::HelpGraphRangeClear)),
+        ("Shift+↑ / Shift+↓", t(Msg::HelpGraphShiftExtend)),
+        ("Shift+Click", t(Msg::HelpGraphShiftClick)),
         ("Home / End", t(Msg::HelpHomeEnd)),
         (t(Msg::HelpKeyMouseHScroll), t(Msg::HelpMouseHScroll)),
         ("s / u", t(Msg::HelpStageUnstage)),

--- a/tests/git_repo_integration.rs
+++ b/tests/git_repo_integration.rs
@@ -257,6 +257,80 @@ fn get_commit_file_diff_shows_additions() {
     assert!(added);
 }
 
+#[test]
+fn get_range_files_degenerate_range_matches_single_commit() {
+    // Degenerate range (oldest == newest) should be indistinguishable from
+    // single-commit `commit_files` — protects the v1 claim that range mode
+    // reuses the same first-parent diff semantics as single-commit mode.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, raw) = tempdir_repo();
+    commit_file(&raw, "a.txt", "v1\n", "first");
+    let oid = commit_file(&raw, "b.txt", "v1\n", "second");
+
+    let (_g, repo) = open_in(tmp.path());
+    let files = repo.get_range_files(&oid.to_string(), &oid.to_string());
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].path, "b.txt");
+    assert!(matches!(files[0].status, FileStatus::Added));
+}
+
+#[test]
+fn get_range_files_multi_commit_is_union() {
+    // Range spanning 3 commits should list every file touched by any of
+    // them (net `parent(oldest).tree → newest.tree` delta). Confirms the
+    // IntelliJ-style semantics: 3 distinct files added across 3 commits
+    // all show up, not just the newest one. Also exercises root-commit
+    // handling — `a.txt` was added in the initial commit, and we diff
+    // from `parent(c1)` (empty tree), so it's still `Added` in the range.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, raw) = tempdir_repo();
+    let _c1 = commit_file(&raw, "a.txt", "v1\n", "first");
+    let _c2 = commit_file(&raw, "b.txt", "v1\n", "second");
+    let _c3 = commit_file(&raw, "c.txt", "v1\n", "third");
+
+    let (_g, repo) = open_in(tmp.path());
+    // list_commits is newest-first, so oldest = first commit, newest = third.
+    let commits = repo.list_commits(10);
+    let oldest = &commits[2].oid;
+    let newest = &commits[0].oid;
+    let files = repo.get_range_files(oldest, newest);
+    let paths: Vec<_> = files.iter().map(|f| f.path.as_str()).collect();
+    assert_eq!(paths, vec!["a.txt", "b.txt", "c.txt"]);
+}
+
+#[test]
+fn get_range_file_diff_collapses_multiple_edits() {
+    // A single file edited across three commits, then diffed over the
+    // whole range, should show the *net* change from baseline → final —
+    // intermediate "v1→v2" and "v2→v3" don't appear as separate hunks.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, raw) = tempdir_repo();
+    let _c1 = commit_file(&raw, "a.txt", "v1\n", "first");
+    let _c2 = commit_file(&raw, "a.txt", "v2\n", "second");
+    let _c3 = commit_file(&raw, "a.txt", "v3\n", "third");
+
+    let (_g, repo) = open_in(tmp.path());
+    let commits = repo.list_commits(10);
+    let oldest = &commits[2].oid;
+    let newest = &commits[0].oid;
+    let diff = repo
+        .get_range_file_diff(oldest, newest, "a.txt", 3)
+        .expect("diff available");
+    // Net delta: `a.txt` didn't exist at parent(c1) (root) → now contains
+    // "v3\n". Intermediate v1/v2 content should NOT appear.
+    let all_content: String = diff
+        .hunks
+        .iter()
+        .flat_map(|h| h.lines.iter())
+        .filter(|l| matches!(l.tag, LineTag::Added))
+        .map(|l| l.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(all_content.contains("v3"));
+    assert!(!all_content.contains("v1"));
+    assert!(!all_content.contains("v2"));
+}
+
 // ── Remote sync state (ahead_behind / push) ─────────────────────────────────
 
 /// Seeds a local repo, registers a fake `origin` remote (bogus URL — we never

--- a/tests/snapshots/ui_snapshots__graph_range_mode.snap
+++ b/tests/snapshots/ui_snapshots__graph_range_mode.snap
@@ -1,0 +1,29 @@
+---
+source: tests/ui_snapshots.rs
+assertion_line: 325
+expression: output
+---
+ reef  [TMPDIR]  ⎇ master
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph           1:Files 2:Search 3:Git 4:Graph
+ ▌● [OID]  HEAD   mas│ Range · 3 commits [OID]..[OID]
+ ● [OID] second      │ Click any commit below to collapse back to single-selec
+ ● [OID] first       │
+                       │   [OID] third
+                       │   [OID] second
+                       │   [OID] first
+                       │
+                       │ Changed files (3)  [list]  t toggle
+                       │   A a.txt
+                       │   A b.txt
+                       │   A c.txt
+                       │
+                       │
+                       │
+                       │
+                       │
+                       │
+                       │
+                       │
+                       │
+                       │
+ RANGE 3  ↑↓/click extend · V/Esc exit

--- a/tests/ui_snapshots.rs
+++ b/tests/ui_snapshots.rs
@@ -139,7 +139,9 @@ fn snapshot_with_staged_and_unstaged() {
     app.refresh_status();
     wait_for_git_status(&mut app);
     let output = render_app(&mut app, 80, 20);
-    with_filters(&[], || insta::assert_snapshot!("with_staged_and_unstaged", output));
+    with_filters(&[], || {
+        insta::assert_snapshot!("with_staged_and_unstaged", output)
+    });
 }
 
 #[test]
@@ -225,7 +227,9 @@ fn snapshot_tree_edit_row_new_file() {
     );
 
     let output = render_app(&mut app, 80, 20);
-    with_filters(&[], || insta::assert_snapshot!("tree_edit_row_new_file", output));
+    with_filters(&[], || {
+        insta::assert_snapshot!("tree_edit_row_new_file", output)
+    });
 }
 
 #[test]
@@ -353,5 +357,7 @@ fn snapshot_with_staged_and_unstaged_light_theme() {
     app.refresh_status();
     wait_for_git_status(&mut app);
     let output = render_app(&mut app, 80, 20);
-    with_filters(&[], || insta::assert_snapshot!("with_staged_and_unstaged_light", output));
+    with_filters(&[], || {
+        insta::assert_snapshot!("with_staged_and_unstaged_light", output)
+    });
 }

--- a/tests/ui_snapshots.rs
+++ b/tests/ui_snapshots.rs
@@ -88,12 +88,20 @@ fn wait_for_git_status(app: &mut App) {
     panic!("timed out waiting for background git status");
 }
 
-/// Apply filters to mask nondeterministic tokens (tempdir name, path segments).
-fn with_filters<F: FnOnce()>(body: F) {
+/// Apply the shared TMPDIR masks plus any per-test `extra` filters, then
+/// run `body` under the resulting insta settings. `extra` is a slice of
+/// `(regex, replacement)` pairs — pass `&[]` when no extras are needed.
+/// Keeps the two TMPDIR regex defaults in exactly one place so tests that
+/// need to mask additional nondeterministic tokens (e.g. short OIDs for the
+/// graph-range snapshot) don't drift out of sync.
+fn with_filters<F: FnOnce()>(extra: &[(&str, &str)], body: F) {
     let mut settings = insta::Settings::clone_current();
     // TempDir names are `.tmpXXXXXX` on most platforms.
     settings.add_filter(r"\.tmp[A-Za-z0-9]{6,}", "[TMPDIR]");
     settings.add_filter(r"tmp[A-Za-z0-9]{6,}", "[TMPDIR]");
+    for (pat, replacement) in extra {
+        settings.add_filter(pat, *replacement);
+    }
     settings.bind(body);
 }
 
@@ -110,7 +118,7 @@ fn snapshot_empty_repo() {
 
     let mut app = App::new(Theme::dark());
     let output = render_app(&mut app, 80, 20);
-    with_filters(|| insta::assert_snapshot!("empty_repo", output));
+    with_filters(&[], || insta::assert_snapshot!("empty_repo", output));
 }
 
 #[test]
@@ -131,7 +139,7 @@ fn snapshot_with_staged_and_unstaged() {
     app.refresh_status();
     wait_for_git_status(&mut app);
     let output = render_app(&mut app, 80, 20);
-    with_filters(|| insta::assert_snapshot!("with_staged_and_unstaged", output));
+    with_filters(&[], || insta::assert_snapshot!("with_staged_and_unstaged", output));
 }
 
 #[test]
@@ -175,7 +183,7 @@ fn snapshot_place_mode_renders_banner_and_border() {
     app.enter_place_mode(vec![source]);
 
     let output = render_app(&mut app, 80, 20);
-    with_filters(|| insta::assert_snapshot!("place_mode", output));
+    with_filters(&[], || insta::assert_snapshot!("place_mode", output));
 }
 
 #[test]
@@ -217,7 +225,7 @@ fn snapshot_tree_edit_row_new_file() {
     );
 
     let output = render_app(&mut app, 80, 20);
-    with_filters(|| insta::assert_snapshot!("tree_edit_row_new_file", output));
+    with_filters(&[], || insta::assert_snapshot!("tree_edit_row_new_file", output));
 }
 
 #[test]
@@ -253,7 +261,74 @@ fn snapshot_tree_context_menu() {
     app.open_tree_context_menu(Some(0), (4, 5));
 
     let output = render_app(&mut app, 80, 20);
-    with_filters(|| insta::assert_snapshot!("tree_context_menu", output));
+    with_filters(&[], || insta::assert_snapshot!("tree_context_menu", output));
+}
+
+/// Wait for the graph worker to populate `rows` and then for the initial
+/// commit-detail / range-detail load to finish. Polls `tick` with a 2s
+/// deadline — matches the `wait_for_git_status` pattern above.
+fn wait_for_graph_ready(app: &mut App) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        app.tick();
+        let graph_ready = !app.graph_load.loading && !app.git_graph.rows.is_empty();
+        let detail_ready = !app.commit_detail_load.loading;
+        if graph_ready && detail_ready {
+            return;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    panic!("timed out waiting for graph / commit detail to load");
+}
+
+#[test]
+fn snapshot_graph_range_mode() {
+    // Lock in the Graph tab's range-mode visuals: three contiguous commits
+    // selected via `extend_graph_selection`, right panel showing the
+    // "Range · N commits" header, the commit list, and the union of files
+    // changed. Regressions here would indicate either the range payload
+    // plumbing (app.rs → tasks.rs → git/mod.rs) or the commit_detail_panel
+    // range-mode render path drifted. 80×24 is tall enough to show the
+    // full header + all commits + the 3-file list without truncation.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    force_en_lang();
+    let (tmp, raw) = tempdir_repo();
+    commit_file(&raw, "a.txt", "v1\n", "first");
+    commit_file(&raw, "b.txt", "v1\n", "second");
+    commit_file(&raw, "c.txt", "v1\n", "third");
+    let home = tempfile::TempDir::new().expect("home tempdir");
+    let _h = HomeGuard::enter(home.path());
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark());
+    app.set_active_tab(reef::app::Tab::Graph);
+    wait_for_graph_ready(&mut app);
+    // Extend by 2 → range of 3 (newest + 2 older). `rows` is newest-first,
+    // so `selected_idx=0` starts on "third"; extending downward (+delta)
+    // grows the range toward older commits.
+    app.extend_graph_selection(2);
+    // Wait for the range-detail worker (files union) to land.
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        app.tick();
+        let has_files = app
+            .commit_detail
+            .range_detail
+            .as_ref()
+            .map(|r| !r.files.is_empty())
+            .unwrap_or(false);
+        if has_files && !app.commit_detail_load.loading {
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let output = render_app(&mut app, 80, 24);
+    // Short OIDs (7-hex prefix) are fresh per run; mask them so the
+    // snapshot captures layout/text, not the non-deterministic SHAs.
+    with_filters(&[(r"\b[0-9a-f]{7}\b", "[OID]")], || {
+        insta::assert_snapshot!("graph_range_mode", output)
+    });
 }
 
 #[test]
@@ -278,5 +353,5 @@ fn snapshot_with_staged_and_unstaged_light_theme() {
     app.refresh_status();
     wait_for_git_status(&mut app);
     let output = render_app(&mut app, 80, 20);
-    with_filters(|| insta::assert_snapshot!("with_staged_and_unstaged_light", output));
+    with_filters(&[], || insta::assert_snapshot!("with_staged_and_unstaged_light", output));
 }


### PR DESCRIPTION
## Summary
- Graph tab gains a "visual mode" (`V`) for selecting a contiguous range of commits; the right panel then shows the combined `parent(oldest).tree → newest.tree` diff — IntelliJ's "show diff for N commits" ported to the TUI
- Primary interaction path works in terminals that intercept Shift+Click / Shift+Arrow (press `V`, arrows/click extend without needing Shift); Shift variants kept as a convenience where supported
- Net delta semantics via `git2::diff_tree_to_tree` — merge commits follow first-parent, root commits diff against empty tree, same conventions as the existing single-commit path

## Interaction
- `V` enters visual mode (anchor at cursor). `V` / `Esc` exits
- `↑ ↓ j k PgUp PgDn` extend the range while in visual mode
- Clicking any graph row moves the endpoint (anchor stays)
- Clicking a commit in the right-panel commit list collapses back to single-select on that commit
- Status bar shows `RANGE N` badge with exit hint

## Implementation notes
- `src/git/mod.rs`: `get_range_files` / `get_range_file_diff` — reuse a new shared `collect_files_from_diff` reducer (single-commit path refactored to call it; zero behaviour change there)
- `src/tasks.rs`: `LoadCommitRangeDetail` / `LoadRangeFileDiff` GraphTasks + matching WorkerResult variants; reuses `AsyncState` generation-based cancellation
- `src/app.rs`: `GitGraphState.selection_anchor` + helpers (`is_range`, `in_visual_mode`, `find_row_by_oid`, `selected_range`); `CommitDetailState.range_detail` mutually exclusive with `detail` per mode
- 5s graph revalidate preserves anchor by OID; `cache_key` short-circuit avoids re-firing the range worker (and resetting `file_diff`) when rows are byte-identical, so the file-diff view doesn't blink

## Test plan
- [x] `cargo test --lib` — 288 tests (4 new `GitGraphState` range-math unit tests)
- [x] `cargo test --test git_repo_integration` — 26 tests (3 new: degenerate range = single commit, multi-commit union, net-delta collapsing intermediate edits)
- [x] `cargo test --test ui_snapshots` — 7 tests (new `snapshot_graph_range_mode` at 80×24, OIDs masked)
- [x] `cargo clippy --all-targets -- -D warnings` — 0 warnings
- [ ] Manual: open a repo with ≥5 commits, Graph tab, press `V`, `↓↓`, verify right panel shows `Range · 3 commits`, file list is union of changed files, clicking a file shows merged diff; press `V` again to exit
- [ ] Manual: sit in visual mode for ≥30s with a file diff open — verify nothing blinks on the 5s revalidate tick
- [ ] Manual: range including a merge commit renders without panic; range starting at the initial commit (no parent) shows all files as Added

🤖 Generated with [Claude Code](https://claude.com/claude-code)