### PR TITLE
feat(cli): `reef shell-integration <shell>` + startup sweep + hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ reef --ssh user@host:/path      # open /path on host
 - One ControlMaster SSH session powers the whole thing: JSON-RPC over stdio for data, `scp` over the existing socket for drag-drop upload, `ssh -t` for `$EDITOR`.
 - Content search, diff, graph, stage/unstage, file-tree create/rename/delete — all work identically remote.
 
+### Auto-SSH on terminal split
+
+Once you're `--ssh`'d into a host, the terminal's native split (Ghostty <kbd>Cmd</kbd>+<kbd>D</kbd>, iTerm2 <kbd>Cmd</kbd>+<kbd>D</kbd>, Terminal.app <kbd>Cmd</kbd>+<kbd>D</kbd>, …) drops you straight into an `ssh` shell on the same host + same workdir — reusing the ControlMaster socket so there's no second password prompt.
+
+One-time setup (pick your shell):
+
+```bash
+reef shell-integration zsh  >> ~/.zshrc
+reef shell-integration bash >> ~/.bashrc
+reef shell-integration fish >> ~/.config/fish/config.fish
+```
+
+Reef emits an OSC 7 `cwd` pointing at `~/.reef/sessions/<pid>/` while the SSH session is live; the snippet above recognises that anchor dir and execs `ssh` into the same host. `cd ~` inside a reef pane before splitting (or open a new window instead of a split) to skip the auto-SSH and get a plain local shell. Works in every terminal that honours OSC 7 — no terminal-specific CLI integration.
+
 ### File operations
 
 - Create, rename, move-to-trash, and hard-delete from the file tree — via toolbar, right-click context menu, or keyboard (`F2`, `d` / `Del`, `Shift+D` / `Shift+Del`).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,6 +45,20 @@ reef --ssh user@host:/path      # 打开远端的 /path
 - 一条 SSH ControlMaster 会话包办全部：JSON-RPC over stdio 走数据，`scp` 走拖拽上传，`ssh -t` 走 `$EDITOR` 透传。
 - 内容搜索、diff、graph、暂存/取消暂存、文件树增删改名——远程全部等效于本地。
 
+### 分屏自动 SSH
+
+`--ssh` 连上远端后，终端原生的分屏快捷键（Ghostty <kbd>Cmd</kbd>+<kbd>D</kbd>、iTerm2 <kbd>Cmd</kbd>+<kbd>D</kbd>、Terminal.app <kbd>Cmd</kbd>+<kbd>D</kbd>……）会直接开一个 `ssh` shell 进到同一台主机的同一 workdir——复用 ControlMaster socket，**不会再问密码**。
+
+一次性配置（按你的 shell 选一条）：
+
+```bash
+reef shell-integration zsh  >> ~/.zshrc
+reef shell-integration bash >> ~/.bashrc
+reef shell-integration fish >> ~/.config/fish/config.fish
+```
+
+Reef 在 SSH session 期间对终端发 OSC 7 `cwd` 指向 `~/.reef/sessions/<pid>/`；上面的片段识别到这个锚点目录就 `exec ssh` 接管。想在 reef pane 里开本地 shell：分屏前 `cd ~` 跳出锚点目录，或者新开窗口而不是分屏即可。所有支持 OSC 7 的终端都能用——不依赖特定终端的 CLI API。
+
 ### 文件操作
 
 - 在文件树里创建、改名、移到回收站、硬删除——工具栏、右键菜单、键盘（`F2`、`d` / `Del`、`Shift+D` / `Shift+Del`）都走得通。

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -408,6 +408,24 @@ pub fn ssh_connect_failed(target: &str, e: &str) -> String {
     }
 }
 
+/// First-time SSH-connect hint: points users at the one-liner that
+/// enables auto-SSH on terminal split. Shown once per install; after
+/// they run `reef shell-integration …` the marker file silences it.
+pub fn shell_integration_hint(shell: crate::shell_integration::Shell) -> String {
+    let name = shell.name();
+    let rc = shell.rc_path_suffix();
+    match lang() {
+        Lang::Zh => {
+            format!("提示：运行 `reef shell-integration {name} >> ~/{rc}` 启用分屏自动 SSH")
+        }
+        Lang::En => {
+            format!(
+                "Tip: run `reef shell-integration {name} >> ~/{rc}` to enable auto-SSH on split"
+            )
+        }
+    }
+}
+
 pub fn push_failed_toast(e: &str) -> String {
     match lang() {
         Lang::Zh => format!("推送失败: {e}"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,8 +35,31 @@ use std::time::Duration;
 ///                                 version lives on the remote, and
 ///                             (c) connect to it.
 ///   --help / -h               Print usage and exit.
-fn parse_args() -> Result<AppArgs, String> {
-    let mut args = std::env::args().skip(1);
+///
+/// Subcommands (first positional arg):
+///   shell-integration <zsh|bash|fish>    Print the shell snippet that
+///                             enables auto-SSH on terminal split. Pipe
+///                             into your rc: `reef shell-integration zsh
+///                             >> ~/.zshrc`.
+fn parse_args() -> Result<ParsedArgs, String> {
+    let mut args = std::env::args().skip(1).peekable();
+    // Peek the first arg: if it's a known subcommand, route early.
+    if let Some(first) = args.peek() {
+        if first == "shell-integration" {
+            args.next();
+            let raw = args.next().ok_or_else(|| {
+                "shell-integration requires a shell name (zsh|bash|fish)".to_string()
+            })?;
+            let shell = reef::shell_integration::Shell::parse(&raw).ok_or_else(|| {
+                format!("unknown shell '{raw}'; expected one of: zsh, bash, fish")
+            })?;
+            if args.next().is_some() {
+                return Err("shell-integration accepts exactly one argument".into());
+            }
+            return Ok(ParsedArgs::ShellIntegration(shell));
+        }
+    }
+
     let mut agent_exec: Option<String> = None;
     let mut ssh_target: Option<String> = None;
     while let Some(arg) = args.next() {
@@ -63,10 +86,15 @@ fn parse_args() -> Result<AppArgs, String> {
     if agent_exec.is_some() && ssh_target.is_some() {
         return Err("--agent-exec and --ssh are mutually exclusive".into());
     }
-    Ok(AppArgs {
+    Ok(ParsedArgs::App(AppArgs {
         agent_exec,
         ssh_target,
-    })
+    }))
+}
+
+enum ParsedArgs {
+    App(AppArgs),
+    ShellIntegration(reef::shell_integration::Shell),
 }
 
 fn print_usage() {
@@ -84,6 +112,11 @@ fn print_usage() {
     eprintln!();
     eprintln!("The --agent-exec value is whitespace-split into argv. Typical remote:");
     eprintln!("    reef --agent-exec \"ssh user@host reef-agent --stdio --workdir /path\"");
+    eprintln!();
+    eprintln!("SUBCOMMANDS:");
+    eprintln!("    reef shell-integration zsh    # print shell snippet enabling auto-SSH on split");
+    eprintln!("    reef shell-integration bash   # pipe into your rc: `… >> ~/.zshrc`/`~/.bashrc`");
+    eprintln!("    reef shell-integration fish");
 }
 
 struct AppArgs {
@@ -106,7 +139,15 @@ fn split_ssh_target(target: &str) -> (String, String) {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let parsed = parse_args()?;
+    let parsed = match parse_args()? {
+        ParsedArgs::App(args) => args,
+        ParsedArgs::ShellIntegration(shell) => return run_shell_integration(shell),
+    };
+
+    // One-shot housekeeping: drop leftover anchor dirs from reef instances
+    // that died without running their Drop (e.g. killed with SIGKILL or
+    // lost power). Safe to run unconditionally — live sessions survive.
+    reef::shell_integration::sweep_stale_sessions();
 
     // Set up panic hook to restore terminal
     let original_hook = panic::take_hook();
@@ -192,6 +233,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // invisible while the alt-screen is up, so we route through the toast
     // queue instead.
     let mut pending_connect_error: Option<String> = None;
+    // `pending_hint` carries the "run shell-integration to enable split
+    // auto-SSH" info toast into the next App. Seeded once per reef
+    // lifetime — after `hint_shown` flips, subsequent session swaps
+    // leave the hint alone so users cycling through Ctrl+O don't see
+    // the same tip repeated on every connection.
+    let mut pending_hint: Option<String> = hint_for_ssh_connect(parsed.ssh_target.as_deref());
+    let mut hint_shown = false;
     'session: loop {
         // App init — clone the picker per session because each App owns
         // it for its preview-protocol lifecycle.
@@ -201,6 +249,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Re-open the picker so the user has a visible recovery path
             // — they came here trying to connect to *something*.
             app.open_hosts_picker();
+        }
+        if let Some(msg) = pending_hint.take() {
+            app.toasts.push(Toast::info(msg));
+            hint_shown = true;
         }
 
         // First-run heuristic: if the user launched reef without `--ssh`
@@ -352,6 +404,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             match build_ssh_backend(&target_arg) {
                 Ok(new_backend) => {
                     backend = Arc::new(new_backend);
+                    if !hint_shown {
+                        pending_hint = hint_for_ssh_connect(Some(&target_arg));
+                    }
                     continue 'session;
                 }
                 Err(e) => {
@@ -366,6 +421,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         break 'session;
     } // end 'session
+
+    // Drop the backend explicitly before LeaveAlternateScreen so the
+    // RemoteBackend's OSC 7 restore (via `shell_session`'s Drop) fires
+    // while the terminal is still in the same pane/mode context as the
+    // original emit. Without this, the restore byte stream arrives
+    // after the terminal has already swapped screens, which works on
+    // modern terminals but is semantically backwards.
+    drop(backend);
 
     // Restore terminal. Pop the keyboard enhancement flags only if the
     // push succeeded earlier — popping on a terminal that never received
@@ -432,4 +495,53 @@ fn remote_path_suffix(path: &str) -> String {
     } else {
         format!(":{path}")
     }
+}
+
+/// Returns the install-shell-integration hint to surface once, when:
+///   (a) the user asked for `--ssh <target>` (so they'll plausibly want
+///       split auto-SSH), and
+///   (b) the `~/.reef/snippet-installed` marker is absent (they haven't
+///       run `reef shell-integration …` yet).
+///
+/// Returns `None` otherwise so the session loop is a no-op. The shell
+/// is detected from `$SHELL` with a zsh fallback — users on exotic
+/// shells get pointed at zsh's instructions but the principle is the
+/// same.
+fn hint_for_ssh_connect(ssh_target: Option<&str>) -> Option<String> {
+    ssh_target?;
+    let marker = reef::shell_integration::snippet_installed_marker()?;
+    if marker.exists() {
+        return None;
+    }
+    Some(i18n::shell_integration_hint(detect_shell()))
+}
+
+/// Best-effort `$SHELL` → `Shell` parse. Users on exotic shells fall
+/// back to zsh instructions — all three shells' snippets follow the
+/// same pattern, so the wrong hint is still directionally useful.
+fn detect_shell() -> reef::shell_integration::Shell {
+    std::env::var_os("SHELL")
+        .as_deref()
+        .and_then(|s| std::path::Path::new(s).file_name())
+        .and_then(|name| reef::shell_integration::Shell::parse(&name.to_string_lossy()))
+        .unwrap_or(reef::shell_integration::Shell::Zsh)
+}
+
+/// Implements `reef shell-integration <shell>`: prints the embedded
+/// snippet to stdout and touches `~/.reef/snippet-installed` so the
+/// first-connect toast stops reminding the user.
+fn run_shell_integration(
+    shell: reef::shell_integration::Shell,
+) -> Result<(), Box<dyn std::error::Error>> {
+    print!("{}", shell.snippet());
+    // Touch the marker. Ignore errors (HOME-less env, permission etc.) —
+    // the worst case is the user sees the install toast once more per
+    // session, which is not broken.
+    if let Some(marker) = reef::shell_integration::snippet_installed_marker() {
+        if let Some(parent) = marker.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(&marker, b"");
+    }
+    Ok(())
 }


### PR DESCRIPTION
## Summary

Third and final of three stacked PRs. Adds the user-facing entry points for the OSC 7 auto-SSH-on-split feature: a CLI subcommand that prints the shell snippet, a startup sweep that clears crash leftovers, a one-time toast that points new users at the install command, and a Drop-order fix so OSC 7 restore fires while the terminal is still in alt-screen mode. Also updates both READMEs.

## Stack

- #34 — shell_integration module
- #35 — RemoteBackend wiring
- **#this** — CLI + sweep + hint + docs

## Changes

### \`reef shell-integration <shell>\`

\`\`\`bash
reef shell-integration zsh  >> ~/.zshrc
reef shell-integration bash >> ~/.bashrc
reef shell-integration fish >> ~/.config/fish/config.fish
\`\`\`

Prints the matching embedded snippet to stdout and touches \`~/.reef/snippet-installed\` so the first-connect toast stops nagging. Unknown shells error out with a hint.

### First-connect toast

When \`--ssh\` is used AND the marker file is absent, queue a \`Toast::info\` with the install command. Shown **once per reef lifetime** — a \`hint_shown\` flag guards against re-firing on <kbd>Ctrl</kbd>+<kbd>O</kbd> host swaps. \`detect_shell()\` parses \`\$SHELL\` with a zsh fallback.

### Startup sweep

\`sweep_stale_sessions()\` runs before terminal setup. Clears out \`~/.reef/sessions/<pid>/\` dirs whose pid is no longer alive (prior reef killed with \`kill -9\` or lost power). Best-effort — errors silently ignored, ~1ms per stale dir via \`ps -p\`.

### Drop-order fix

Explicit \`drop(backend)\` immediately after the session loop, before \`LeaveAlternateScreen\`. Without this, the RemoteBackend (and its Session) drop last, emitting OSC 7 restore *after* the terminal has already left alt-screen. Modern terminals handle post-alt-screen escapes fine, but the same-mode-context ordering is semantically cleaner and matches the emit-on-connect context.

### Docs

New \"Auto-SSH on terminal split\" / \"分屏自动 SSH\" section in both READMEs, covering the setup one-liner and the \`cd ~\` escape hatch.

## Manual E2E (Ghostty)

Recommended test flow once all three PRs are merged:

\`\`\`bash
reef shell-integration zsh >> ~/.zshrc && exec zsh
reef --ssh user@host:/path
# Press Cmd+D → new pane auto-logs into user@host:/path, no password prompt
# Exit reef → original pane's cwd restored
\`\`\`

## Test plan

- [ ] \`cargo build --workspace\` clean
- [ ] \`cargo test --workspace --lib\` — 364 passing
- [ ] \`cargo test --test backend_osc7_loopback\` — 5 passing
- [ ] \`cargo clippy -- -D warnings\` clean
- [ ] \`cargo fmt --check\` clean
- [ ] \`reef shell-integration zsh\` prints snippet
- [ ] \`reef shell-integration bogus\` errors with hint
- [ ] Manual Ghostty E2E per above

🤖 Generated with [Claude Code](https://claude.com/claude-code)