### PR TITLE
fix(backend): symlink-safe read paths + PendingGuard failure-path test

### DIFF
--- a/crates/reef-agent/src/main.rs
+++ b/crates/reef-agent/src/main.rs
@@ -116,6 +116,10 @@ fn main() -> io::Result<()> {
         None => std::env::current_dir()?,
     };
     std::env::set_current_dir(&workdir)?;
+    // Canonicalise once so the symlink-escape guard on every `ReadFile`
+    // doesn't repeat the syscall. `workdir` is immutable for the
+    // agent's lifetime, so a single call covers every later request.
+    let workdir = std::fs::canonicalize(&workdir)?;
 
     let backend = Arc::new(LocalBackend::open_at(workdir.clone()));
     let stdout = Arc::new(Mutex::new(BufWriter::new(io::stdout())));
@@ -226,44 +230,7 @@ fn dispatch(backend: &dyn Backend, workdir: &Path, env: Envelope) -> Option<Resp
             }
         }
 
-        Request::ReadFile { path, max_bytes } => {
-            // Boundary check: refuse `..` / absolute paths so a malicious
-            // or buggy client can't `ReadFile { path: "../etc/passwd" }`.
-            // Other write ops route through `LocalBackend::resolve_rel`;
-            // this path bypasses the backend (so it can return
-            // `is_file: false` instead of NotFound), so we apply the
-            // same guard inline here.
-            reef::backend::local::resolve_rel_within(workdir, Path::new(&path))
-                .map_err(backend_err)
-                .and_then(|abs| {
-                    if !abs.is_file() {
-                        serde_json::to_value(ReadFileResponse {
-                            is_file: false,
-                            bytes: Vec::new(),
-                            size: 0,
-                        })
-                        .map_err(|e| (ErrorCode::Protocol, format!("encode: {e}")))
-                    } else {
-                        match std::fs::read(&abs) {
-                            Ok(raw) => {
-                                let size = raw.len() as u64;
-                                let bytes = if size > max_bytes {
-                                    raw[..max_bytes as usize].to_vec()
-                                } else {
-                                    raw
-                                };
-                                serde_json::to_value(ReadFileResponse {
-                                    is_file: true,
-                                    bytes,
-                                    size,
-                                })
-                                .map_err(|e| (ErrorCode::Protocol, format!("encode: {e}")))
-                            }
-                            Err(e) => Err((ErrorCode::Io, e.to_string())),
-                        }
-                    }
-                })
-        }
+        Request::ReadFile { path, max_bytes } => read_file_response(workdir, &path, max_bytes),
 
         Request::GitStatus => match backend.git_status() {
             Ok(snap) => serde_json::to_value(StatusSnapshotDto {
@@ -554,20 +521,50 @@ fn dispatch_search_content(
 }
 
 fn backend_err(e: reef::backend::BackendError) -> (ErrorCode, String) {
+    (e.wire_code(), e.to_string())
+}
+
+/// Agent-side `ReadFile` dispatcher. Rejects lexical escapes *and*
+/// symlink escapes — a workdir containing `link → /etc/passwd` would
+/// otherwise let a malicious client exfiltrate any file the agent user
+/// can read. `NotFound` is folded into `is_file: false` so the client
+/// contract stays "no error on missing file"; `PathEscape` and other
+/// filesystem errors surface through the normal error channel.
+fn read_file_response(
+    workdir: &Path,
+    rel: &str,
+    max_bytes: u64,
+) -> Result<serde_json::Value, (ErrorCode, String)> {
     use reef::backend::BackendError;
-    let code = match &e {
-        BackendError::NotFound => ErrorCode::NotFound,
-        BackendError::Io(_) => ErrorCode::Io,
-        BackendError::Git(_) => ErrorCode::Git,
-        BackendError::Rpc(_) => ErrorCode::Other,
-        BackendError::Protocol(_) => ErrorCode::Protocol,
-        BackendError::Unimplemented(_) => ErrorCode::Unimplemented,
-        BackendError::PathExists(_) => ErrorCode::PathExists,
-        BackendError::PathEscape(_) => ErrorCode::PathEscape,
-        BackendError::TrashUnavailable(_) => ErrorCode::TrashUnavailable,
-        BackendError::Other(_) => ErrorCode::Other,
+    let missing = || {
+        serde_json::to_value(ReadFileResponse {
+            is_file: false,
+            bytes: Vec::new(),
+            size: 0,
+        })
+        .map_err(|e| (ErrorCode::Protocol, format!("encode: {e}")))
     };
-    (code, e.to_string())
+    let abs = match reef::backend::local::canonical_child_within(workdir, Path::new(rel)) {
+        Ok(p) => p,
+        Err(BackendError::NotFound) => return missing(),
+        Err(e) => return Err(backend_err(e)),
+    };
+    if !abs.is_file() {
+        return missing();
+    }
+    let raw = std::fs::read(&abs).map_err(|e| (ErrorCode::Io, e.to_string()))?;
+    let size = raw.len() as u64;
+    let bytes = if size > max_bytes {
+        raw[..max_bytes as usize].to_vec()
+    } else {
+        raw
+    };
+    serde_json::to_value(ReadFileResponse {
+        is_file: true,
+        bytes,
+        size,
+    })
+    .map_err(|e| (ErrorCode::Protocol, format!("encode: {e}")))
 }
 
 /// Probe once for `gio` and cache the result. `0` = unknown, `1` =

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -10,7 +10,7 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Component, Path, PathBuf};
-use std::sync::{Mutex, mpsc};
+use std::sync::{Mutex, OnceLock, mpsc};
 
 use super::{
     Backend, BackendError, ContentMatchHit, ContentSearchCompleted, ContentSearchRequest,
@@ -71,6 +71,12 @@ impl PreviewCache {
 /// Local filesystem + libgit2 backend.
 pub struct LocalBackend {
     workdir: PathBuf,
+    /// Cached `fs::canonicalize(workdir)`. Populated lazily on the first
+    /// symlink-safe read because `workdir` is immutable after
+    /// construction — without the cache every `read_file` / preview
+    /// would pay one extra syscall to canonicalise the root before
+    /// resolving the target.
+    canon_workdir: OnceLock<PathBuf>,
     /// Decoded-preview LRU. Re-selecting a file — whether via cursor
     /// bounce, quick-open, or fs-watcher refresh with no actual change
     /// — returns the cached `PreviewContent` (deep-clone, ~ms for the
@@ -88,6 +94,7 @@ impl LocalBackend {
         let workdir = std::env::current_dir()?;
         Ok(Self {
             workdir,
+            canon_workdir: OnceLock::new(),
             preview_cache: Mutex::new(PreviewCache::default()),
         })
     }
@@ -96,6 +103,7 @@ impl LocalBackend {
     pub fn open_at(workdir: PathBuf) -> Self {
         Self {
             workdir,
+            canon_workdir: OnceLock::new(),
             preview_cache: Mutex::new(PreviewCache::default()),
         }
     }
@@ -113,6 +121,18 @@ impl LocalBackend {
     /// traversal. Accepts the root itself (`""` or `.`).
     fn resolve_rel(&self, rel: &Path) -> Result<PathBuf, BackendError> {
         resolve_rel_within(&self.workdir, rel)
+    }
+
+    fn canonical_workdir(&self) -> Result<&Path, BackendError> {
+        if let Some(p) = self.canon_workdir.get() {
+            return Ok(p);
+        }
+        let canon = canonicalize_or_backend_err(&self.workdir, "canonicalize workdir")?;
+        let _ = self.canon_workdir.set(canon);
+        Ok(self
+            .canon_workdir
+            .get()
+            .expect("just populated via OnceLock::set"))
     }
 }
 
@@ -144,6 +164,38 @@ pub fn resolve_rel_within(root: &Path, rel: &Path) -> Result<PathBuf, BackendErr
         }
     }
     Ok(root.join(rel))
+}
+
+/// `fs::canonicalize` lifted into `BackendError`. Missing path → `NotFound`;
+/// anything else → `Io` with the provided `context` prefix.
+fn canonicalize_or_backend_err(path: &Path, context: &str) -> Result<PathBuf, BackendError> {
+    std::fs::canonicalize(path).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => BackendError::NotFound,
+        _ => BackendError::Io(format!("{context}: {e}")),
+    })
+}
+
+/// Canonicalising variant of `resolve_rel_within` for *read* paths.
+/// Follows symlinks and rejects targets outside `canon_root` — without
+/// this, a workdir containing `link → /etc/passwd` would let a caller
+/// read the symlink target. Only matters in remote/agent mode (malicious
+/// workdir threat model); applied uniformly so local and remote behave
+/// the same.
+///
+/// `canon_root` MUST already be canonicalised (callers typically cache
+/// it — see `LocalBackend::canonical_workdir`). TOCTOU: a symlink swap
+/// between this call and the subsequent open is possible; `openat2`
+/// would close it but is Linux-only.
+pub fn canonical_child_within(canon_root: &Path, rel: &Path) -> Result<PathBuf, BackendError> {
+    let joined = resolve_rel_within(canon_root, rel)?;
+    let canon_target = canonicalize_or_backend_err(&joined, "canonicalize target")?;
+    if !canon_target.starts_with(canon_root) {
+        return Err(BackendError::PathEscape(format!(
+            "symlink escapes workdir: {}",
+            rel.display()
+        )));
+    }
+    Ok(canon_target)
 }
 
 impl Backend for LocalBackend {
@@ -220,6 +272,15 @@ impl Backend for LocalBackend {
             }
         }
 
+        // Symlink-escape gate only fires on cache miss — hits return
+        // content we already validated on a prior read, so no fresh
+        // filesystem traversal is about to happen. `file_tree::load_preview`
+        // below does a raw `File::open` that follows symlinks without
+        // any boundary check, so without this gate a workdir-relative
+        // symlink could exfiltrate arbitrary files.
+        let canon_root = self.canonical_workdir().ok()?;
+        canonical_child_within(canon_root, rel_path).ok()?;
+
         let fresh = file_tree::load_preview(&self.workdir, rel_path, dark, wants_decoded_image)?;
 
         if let Ok(mut cache) = self.preview_cache.lock() {
@@ -229,10 +290,12 @@ impl Backend for LocalBackend {
     }
 
     fn read_file(&self, rel_path: &Path, max_bytes: u64) -> Result<Vec<u8>, BackendError> {
-        // Route through `resolve_rel` so the workdir is a hard boundary
-        // even on read paths — every other op honours this; without it a
-        // malicious or buggy client could `ReadFile { path: "../etc/passwd" }`.
-        let full = self.resolve_rel(rel_path)?;
+        // `canonical_child_within` enforces the workdir boundary *after*
+        // symlink resolution. Without it a workdir-relative symlink
+        // would let a caller exfiltrate any file the backend process
+        // can read — critical in remote/agent mode where the caller is
+        // untrusted relative to the host filesystem.
+        let full = canonical_child_within(self.canonical_workdir()?, rel_path)?;
         if !full.is_file() {
             return Err(BackendError::NotFound);
         }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -82,6 +82,47 @@ impl From<io::Error> for BackendError {
     }
 }
 
+impl BackendError {
+    /// Reconstruct a `BackendError` from a wire-level `(ErrorCode, message)`
+    /// pair. Inverse of `wire_code` — keep the two arms in sync; the
+    /// exhaustive `match` below forces an update whenever a new
+    /// `ErrorCode` variant lands.
+    pub fn from_wire(code: reef_proto::ErrorCode, message: String) -> Self {
+        use reef_proto::ErrorCode;
+        match code {
+            ErrorCode::NotFound => BackendError::NotFound,
+            ErrorCode::Io => BackendError::Io(message),
+            ErrorCode::Git => BackendError::Git(message),
+            ErrorCode::Protocol => BackendError::Protocol(message),
+            ErrorCode::Unimplemented => BackendError::Unimplemented(message),
+            ErrorCode::PathExists => BackendError::PathExists(message),
+            ErrorCode::PathEscape => BackendError::PathEscape(message),
+            ErrorCode::TrashUnavailable => BackendError::TrashUnavailable(message),
+            ErrorCode::Other => BackendError::Other(message),
+        }
+    }
+
+    /// Pick the wire-level `ErrorCode` that best represents this error.
+    /// Inverse of `from_wire`. `Rpc` collapses to `Other` because it's a
+    /// client-side condition that never appears on the wire going the
+    /// other direction.
+    pub fn wire_code(&self) -> reef_proto::ErrorCode {
+        use reef_proto::ErrorCode;
+        match self {
+            BackendError::NotFound => ErrorCode::NotFound,
+            BackendError::Io(_) => ErrorCode::Io,
+            BackendError::Git(_) => ErrorCode::Git,
+            BackendError::Rpc(_) => ErrorCode::Other,
+            BackendError::Protocol(_) => ErrorCode::Protocol,
+            BackendError::Unimplemented(_) => ErrorCode::Unimplemented,
+            BackendError::PathExists(_) => ErrorCode::PathExists,
+            BackendError::PathEscape(_) => ErrorCode::PathEscape,
+            BackendError::TrashUnavailable(_) => ErrorCode::TrashUnavailable,
+            BackendError::Other(_) => ErrorCode::Other,
+        }
+    }
+}
+
 /// Snapshot of the repo status returned by `git_status`.
 #[derive(Debug, Clone)]
 pub struct StatusSnapshot {

--- a/src/backend/remote.rs
+++ b/src/backend/remote.rs
@@ -271,6 +271,14 @@ impl RemoteBackend {
     }
 
     fn request<T: serde::de::DeserializeOwned>(&self, req: Request) -> Result<T, BackendError> {
+        self.request_with_timeout(req, DEFAULT_RPC_TIMEOUT)
+    }
+
+    fn request_with_timeout<T: serde::de::DeserializeOwned>(
+        &self,
+        req: Request,
+        timeout: Duration,
+    ) -> Result<T, BackendError> {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let (tx, rx) = mpsc::channel::<Response>();
         // Without this guard, RPC timeouts / send errors leak `pending`
@@ -278,12 +286,12 @@ impl RemoteBackend {
         let _pending = MapGuard::register(&self.pending, id, tx, "pending")?;
         self.send_envelope(Envelope { id, body: req })?;
         let response = rx
-            .recv_timeout(DEFAULT_RPC_TIMEOUT)
+            .recv_timeout(timeout)
             .map_err(|e| BackendError::Rpc(format!("recv: {e}")))?;
         match response {
             Response::Ok { result, .. } => serde_json::from_value::<T>(result)
                 .map_err(|e| BackendError::Protocol(format!("response decode: {e}"))),
-            Response::Err { message, .. } => Err(BackendError::Rpc(message)),
+            Response::Err { code, message, .. } => Err(BackendError::from_wire(code, message)),
         }
     }
 
@@ -293,6 +301,31 @@ impl RemoteBackend {
     #[doc(hidden)]
     pub fn __pending_len_for_tests(&self) -> usize {
         self.pending.lock().map(|m| m.len()).unwrap_or(0)
+    }
+
+    /// Test-only entry to `request_with_timeout`, so the leak regression
+    /// test can drive the failure path (100ms timeout against a killed
+    /// agent) without having to wait the full `DEFAULT_RPC_TIMEOUT`.
+    #[doc(hidden)]
+    pub fn __request_with_timeout_for_tests<T: serde::de::DeserializeOwned>(
+        &self,
+        req: Request,
+        timeout: Duration,
+    ) -> Result<T, BackendError> {
+        self.request_with_timeout(req, timeout)
+    }
+
+    /// Test-only helper that kills the agent subprocess so subsequent
+    /// RPCs are guaranteed to fail (send hits BrokenPipe, or
+    /// recv_timeout never gets a response). Used by the PendingGuard
+    /// failure-path regression test; no production path should call
+    /// this.
+    #[doc(hidden)]
+    pub fn __kill_agent_for_tests(&self) {
+        if let Ok(mut child) = self.child.lock() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
     }
 
     /// Shut the agent down cleanly. Called by Drop; exposed for tests that
@@ -952,8 +985,8 @@ impl Backend for RemoteBackend {
                         truncated: completed.truncated,
                     });
                 }
-                Ok(Response::Err { message, .. }) => {
-                    return Err(BackendError::Rpc(message));
+                Ok(Response::Err { code, message, .. }) => {
+                    return Err(BackendError::from_wire(code, message));
                 }
                 Err(mpsc::RecvTimeoutError::Timeout) => {
                     // Loop back: drain more chunks, then try the

--- a/tests/backend_symlink_escape.rs
+++ b/tests/backend_symlink_escape.rs
@@ -1,0 +1,98 @@
+//! Read-path symlink-escape guard. Regression for #31.
+//!
+//! Without `canonical_child_within`, a workdir containing
+//! `link → /outside/...` would let `read_file` / `Request::ReadFile` /
+//! `load_preview` exfiltrate any file the backend user can read — the
+//! concrete threat is a malicious workdir opened in remote/agent mode,
+//! where the SSH user is trusted to the host filesystem but the
+//! caller is not. All read entry points must reject it.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::symlink;
+use std::path::Path;
+use std::sync::Mutex;
+
+use reef::backend::{Backend, BackendError, LocalBackend, RemoteBackend};
+use tempfile::TempDir;
+use test_support::agent_bin;
+
+static BACKEND_LOCK: Mutex<()> = Mutex::new(());
+
+fn spawn_remote(workdir: &Path) -> RemoteBackend {
+    let argv = vec![
+        agent_bin().display().to_string(),
+        "--stdio".to_string(),
+        "--workdir".to_string(),
+        workdir.display().to_string(),
+    ];
+    RemoteBackend::spawn(&argv).expect("spawn remote")
+}
+
+/// Build a workdir with `link → <secret_dir>/secret.txt`. Both tempdirs
+/// are returned so they stay alive for the test's duration; the secret
+/// dir is intentionally unrelated to the workdir root.
+fn with_escape_layout() -> (TempDir, TempDir) {
+    let secret_dir = TempDir::new().expect("secret tempdir");
+    let secret = secret_dir.path().join("secret.txt");
+    std::fs::write(&secret, b"TOPSECRET").unwrap();
+
+    let workdir = TempDir::new().expect("workdir tempdir");
+    symlink(&secret, workdir.path().join("link")).unwrap();
+    (workdir, secret_dir)
+}
+
+#[test]
+fn local_read_file_rejects_symlink_escape() {
+    let _lock = BACKEND_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (workdir, _secret_dir) = with_escape_layout();
+    let b = LocalBackend::open_at(workdir.path().to_path_buf());
+
+    let err = b.read_file(Path::new("link"), 1024).unwrap_err();
+    assert!(
+        matches!(err, BackendError::PathEscape(_)),
+        "expected PathEscape, got {err:?}"
+    );
+}
+
+#[test]
+fn local_read_file_allows_internal_symlink() {
+    // A symlink that stays inside the workdir (`alias → target.txt`) is
+    // legitimate and must still resolve — the guard only rejects
+    // *escapes*, not all symlinks.
+    let _lock = BACKEND_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let workdir = TempDir::new().unwrap();
+    std::fs::write(workdir.path().join("target.txt"), b"inside").unwrap();
+    symlink("target.txt", workdir.path().join("alias")).unwrap();
+
+    let b = LocalBackend::open_at(workdir.path().to_path_buf());
+    let bytes = b.read_file(Path::new("alias"), 1024).unwrap();
+    assert_eq!(bytes, b"inside");
+}
+
+#[test]
+fn local_load_preview_refuses_symlink_escape() {
+    // `load_preview` returns Option — a symlink escape degrades to
+    // "not previewable" rather than surfacing an error to the UI.
+    let _lock = BACKEND_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (workdir, _secret_dir) = with_escape_layout();
+    let b = LocalBackend::open_at(workdir.path().to_path_buf());
+
+    assert!(b.load_preview(Path::new("link"), false, false).is_none());
+}
+
+#[test]
+fn remote_read_file_rejects_symlink_escape() {
+    // Same guarantee, but over the RPC boundary — an escape on the
+    // agent side must surface as `PathEscape` at the RemoteBackend,
+    // not silently return the symlink target's bytes.
+    let _lock = BACKEND_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (workdir, _secret_dir) = with_escape_layout();
+    let r = spawn_remote(workdir.path());
+
+    let err = r.read_file(Path::new("link"), 1024).unwrap_err();
+    assert!(
+        matches!(err, BackendError::PathEscape(_)),
+        "expected PathEscape over RPC, got {err:?}"
+    );
+}

--- a/tests/backend_writes_loopback.rs
+++ b/tests/backend_writes_loopback.rs
@@ -171,6 +171,39 @@ fn pending_map_does_not_leak_on_repeated_requests() {
 }
 
 #[test]
+fn pending_map_cleaned_on_rpc_failure() {
+    // The whole point of `PendingGuard` is the *failure* path: if the
+    // read loop never delivers a Response (agent died, socket dropped,
+    // RPC timed out), the guard's `Drop` has to remove the in-flight
+    // slot — otherwise the map grows unbounded across transient SSH
+    // blips. The success-path test above wouldn't catch a regression
+    // where the guard only fires on Ok(Response).
+    //
+    // Setup: spawn a real agent, complete the handshake, kill it. The
+    // stdin pipe closes, so `send_envelope` may or may not fail
+    // depending on buffering — either way we get an Err. If the write
+    // buffers, `recv_timeout(100ms)` fires and PendingGuard::Drop
+    // cleans up. We assert both: Err surfaces, and `pending_len == 0`.
+    let _lock = BACKEND_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let r_tmp = TempDir::new().unwrap();
+    let r = spawn_remote(r_tmp.path());
+
+    r.__kill_agent_for_tests();
+
+    let res: Result<reef_proto::HandshakeResponse, _> = r
+        .__request_with_timeout_for_tests(
+            reef_proto::Request::Handshake,
+            std::time::Duration::from_millis(100),
+        );
+    assert!(res.is_err(), "expected failure after agent kill, got Ok");
+    assert_eq!(
+        r.__pending_len_for_tests(),
+        0,
+        "pending map must be empty after failed RPC",
+    );
+}
+
+#[test]
 fn read_file_rejects_path_escape() {
     let _lock = BACKEND_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let l_tmp = TempDir::new().unwrap();

--- a/tests/backend_writes_loopback.rs
+++ b/tests/backend_writes_loopback.rs
@@ -190,11 +190,10 @@ fn pending_map_cleaned_on_rpc_failure() {
 
     r.__kill_agent_for_tests();
 
-    let res: Result<reef_proto::HandshakeResponse, _> = r
-        .__request_with_timeout_for_tests(
-            reef_proto::Request::Handshake,
-            std::time::Duration::from_millis(100),
-        );
+    let res: Result<reef_proto::HandshakeResponse, _> = r.__request_with_timeout_for_tests(
+        reef_proto::Request::Handshake,
+        std::time::Duration::from_millis(100),
+    );
     assert!(res.is_err(), "expected failure after agent kill, got Ok");
     assert_eq!(
         r.__pending_len_for_tests(),


### PR DESCRIPTION
Closes #31. Two follow-ups deferred from review of #30.

## Summary

- **Read-path symlink-escape guard** — new `canonical_child_within(canon_root, rel)` in `src/backend/local.rs`. Applied to `LocalBackend::read_file`, `LocalBackend::load_preview` (as a cache-miss-only gate), and the agent's `Request::ReadFile` handler. Closes the obvious symlink bypass in remote/agent mode where a malicious workdir could exfiltrate any file the SSH user can read. TOCTOU documented; `openat2(RESOLVE_NO_SYMLINKS)` is Linux-only and out of scope.
- **PendingGuard failure-path test** — `RemoteBackend::request()` split into `request_with_timeout(req, timeout)` so the new `pending_map_cleaned_on_rpc_failure` test (kill agent → 100ms RPC → expect `Err` + `pending_len == 0`) is reliable. The existing `pending_map_does_not_leak_on_repeated_requests` only covered the happy path.

## Behavior change — agent error routing

`Response::Err { code, message }` now maps back to the matching `BackendError` variant (`NotFound`, `PathEscape`, `PathExists`, …) instead of collapsing to `BackendError::Rpc(msg)`. The wire `code` field has always carried this info — this just stops dropping it on the client. Callers can now distinguish (e.g.) `PathEscape` over RPC, which the new `remote_read_file_rejects_symlink_escape` test relies on.

Grepped: no existing call sites match on `BackendError::Rpc(_)` outside `remote.rs` itself.

## Symmetry: `BackendError` ↔ `ErrorCode`

Both directions now live on `impl BackendError` in `src/backend/mod.rs`:

- `BackendError::from_wire(code, msg)` — used by `RemoteBackend::request` and the search-path response handler.
- `BackendError::wire_code()` — used by the agent's `backend_err()`.

Adding a new `ErrorCode` variant forces an exhaustive-match update in exactly one place.

## Perf notes

- `LocalBackend` caches `canonicalize(workdir)` in an `OnceLock` — the TUI cursor-move preview path was the motivation; `workdir` is immutable after construction.
- Agent startup canonicalises `--workdir` once, so every `Request::ReadFile` reuses it.
- `load_preview`'s new symlink gate runs **after** the preview LRU lookup so cache hits pay zero extra syscalls.

## Test plan

- [x] `cargo test --test backend_symlink_escape` — 4 new tests (local/remote read_file escape, load_preview escape, internal symlink still resolves)
- [x] `cargo test --test backend_writes_loopback` — includes new `pending_map_cleaned_on_rpc_failure`
- [x] Full backend loopback suite (41 tests) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)