### PR TITLE
feat(git-tab): commit staged changes from the sidebar

### DIFF
--- a/crates/reef-agent/src/main.rs
+++ b/crates/reef-agent/src/main.rs
@@ -285,6 +285,10 @@ fn dispatch(backend: &dyn Backend, workdir: &Path, env: Envelope) -> Option<Resp
             Ok(()) => Ok(serde_json::json!({"ok": true})),
             Err(e) => Err(backend_err(e)),
         },
+        Request::Commit { message } => match backend.commit(&message) {
+            Ok(()) => Ok(serde_json::json!({"ok": true})),
+            Err(e) => Err(backend_err(e)),
+        },
 
         Request::ListCommits { limit } => match backend.list_commits(limit as usize) {
             Ok(list) => {

--- a/crates/reef-proto/src/lib.rs
+++ b/crates/reef-proto/src/lib.rs
@@ -56,7 +56,11 @@ pub const MAX_FRAME_SIZE: u32 = 16 * 1024 * 1024;
 ///       multi-commit range mode. v4 agents would error `Unknown op`
 ///       on these requests, which a v5 client surfaces as a toast — so
 ///       a hard bump keeps the auto-redeploy path honest.
-pub const PROTOCOL_VERSION: u32 = 5;
+/// - v6: adds `Commit { message }` so the Git tab can create commits
+///       from the staged index. A v5 agent would respond `Unknown op`
+///       to the new request, so bumping surfaces the stale agent as a
+///       toast rather than a silent no-op.
+pub const PROTOCOL_VERSION: u32 = 6;
 
 /// Encode a single envelope-level value to `writer` using the
 /// length-prefixed framing. The caller is expected to flush.
@@ -190,6 +194,13 @@ pub enum Request {
 
     Push {
         force: bool,
+    },
+
+    /// Create a commit from the staged index with `message`. Agent-side
+    /// dispatches to `Backend::commit` which shells out to `git commit -F -`;
+    /// wire format on success is `{"ok": true}`.
+    Commit {
+        message: String,
     },
 
     // ── Git: history ────

--- a/src/app.rs
+++ b/src/app.rs
@@ -111,6 +111,27 @@ pub struct GitStatusState {
     pub push_error: Option<String>,
     pub scroll: usize,
     pub ahead_behind: Option<(usize, usize)>,
+
+    // ─── Commit input (VSCode-style "Source Control" message box) ───
+    /// Draft commit message buffer. Freeform UTF-8 — newlines are
+    /// literal `\n`, which the render layer splits into one row per
+    /// line and the commit shell-out passes through on stdin
+    /// unchanged.
+    pub commit_message: String,
+    /// Byte offset of the caret inside `commit_message`. Kept in sync
+    /// by the shared `input_edit` helpers so cursor motion matches the
+    /// other text inputs in the app (search, quick-open, global-search).
+    pub commit_cursor: usize,
+    /// `true` while the commit box is focused for typing — gates
+    /// character input in `handle_key_git` so `s`/`u`/`d` chords don't
+    /// fire when the user is writing a message. Cleared by Esc, by
+    /// submitting the commit, or by clicking anywhere outside the input.
+    pub commit_editing: bool,
+    /// Last `git commit` failure surfaced as an in-panel banner, same
+    /// lifetime semantics as `push_error`. Kept out of the toast queue
+    /// so the user can read a multi-line hook rejection without it
+    /// timing out.
+    pub commit_error: Option<String>,
 }
 
 /// State for the inline commit graph sidebar.
@@ -408,6 +429,14 @@ pub struct App {
     /// `App::tick`; once the result is consumed we drop the channel.
     pub push_rx: Option<mpsc::Receiver<(bool, Result<(), String>)>>,
 
+    /// `true` while a background `git commit` is in flight. Blocks
+    /// additional commit attempts and lets the status panel render a
+    /// "提交中…" indicator.
+    pub commit_in_flight: bool,
+    /// Receives the commit worker's result. Same drain-on-tick pattern
+    /// as `push_rx`.
+    pub commit_rx: Option<mpsc::Receiver<Result<(), String>>>,
+
     /// Host-owned fs watcher channel. `None` when the watcher couldn't start —
     /// the sender inside the thread was dropped so `try_recv` returns `Disconnected`.
     pub fs_watcher_rx: Option<mpsc::Receiver<()>>,
@@ -691,6 +720,8 @@ impl App {
             toasts: Vec::new(),
             push_in_flight: false,
             push_rx: None,
+            commit_in_flight: false,
+            commit_rx: None,
             fs_watcher_rx,
             should_quit: false,
             select_mode: false,
@@ -1900,6 +1931,95 @@ impl App {
         }
     }
 
+    /// Kick off a `git commit` in the background. Snapshots the current
+    /// draft message, hands it to a worker thread, and returns. Empty /
+    /// whitespace-only drafts are rejected client-side (same contract as
+    /// the VSCode SCM "Commit" button, which is disabled until the
+    /// input has content) so the worker never hits the `commit_at`
+    /// guard. A commit already in flight drops the request to avoid
+    /// racing pre-commit hooks against a concurrent run.
+    pub fn run_commit(&mut self) {
+        if self.commit_in_flight {
+            return;
+        }
+        if !self.backend.has_repo() {
+            return;
+        }
+        let message = self.git_status.commit_message.trim().to_string();
+        if message.is_empty() {
+            return;
+        }
+        // Nothing staged → fail fast with an in-panel banner rather than
+        // hitting `git commit` for a "nothing to commit" error
+        // response. Matches VSCode behaviour (Commit button is disabled
+        // when the staged tree is empty; we don't emulate auto-stage-on-
+        // commit yet).
+        if self.staged_files.is_empty() {
+            self.git_status.commit_error = Some(
+                crate::i18n::t(crate::i18n::Msg::CommitNothingStaged).to_string(),
+            );
+            return;
+        }
+        let backend = Arc::clone(&self.backend);
+        let (tx, rx) = mpsc::channel();
+        self.commit_rx = Some(rx);
+        self.commit_in_flight = true;
+        std::thread::spawn(move || {
+            let result = backend.commit(&message).map_err(|e| e.to_string());
+            let _ = tx.send(result);
+        });
+    }
+
+    /// Called from `tick()`. Folds the commit worker's result into App
+    /// state — success clears the draft, pops a toast, and marks caches
+    /// stale (HEAD moved, graph cache key is now wrong); failure lands
+    /// in `git_status.commit_error` as a banner so the user can read
+    /// hook output without losing their draft.
+    fn drain_commit_result(&mut self) {
+        use std::sync::mpsc::TryRecvError;
+        let Some(rx) = self.commit_rx.as_ref() else {
+            return;
+        };
+        match rx.try_recv() {
+            Ok(result) => {
+                self.commit_in_flight = false;
+                self.commit_rx = None;
+                match result {
+                    Ok(()) => {
+                        use crate::i18n::{Msg, t};
+                        self.git_status.commit_error = None;
+                        self.git_status.commit_message.clear();
+                        self.git_status.commit_cursor = 0;
+                        self.git_status.commit_editing = false;
+                        self.toasts.push(Toast::info(t(Msg::CommitSuccess)));
+                    }
+                    Err(e) => {
+                        self.git_status.commit_error = Some(e.clone());
+                        self.toasts
+                            .push(Toast::error(crate::i18n::commit_failed_toast(&e)));
+                    }
+                }
+                // A new commit advances HEAD — bust the graph cache and
+                // mark status stale so the new HEAD / ahead-behind land
+                // on the next coordinator pass. Mirrors
+                // `drain_push_result`.
+                self.git_graph.cache_key = None;
+                self.git_status_load.mark_stale();
+                self.graph_load.mark_stale();
+            }
+            Err(TryRecvError::Empty) => {
+                // Worker still running.
+            }
+            Err(TryRecvError::Disconnected) => {
+                self.commit_in_flight = false;
+                self.commit_rx = None;
+                self.toasts.push(Toast::error(crate::i18n::t(
+                    crate::i18n::Msg::CommitThreadCrashed,
+                )));
+            }
+        }
+    }
+
     /// Kick off a `git push` in the background. Returns immediately; the
     /// result is collected in `App::tick` when the worker thread posts it
     /// back through `push_rx`. If a push is already in flight the new
@@ -2823,6 +2943,7 @@ impl App {
         self.drain_preview_resize_responses();
         self.drain_preview_protocol_builds();
         self.drain_push_result();
+        self.drain_commit_result();
         self.kick_active_tab_work();
         self.tick_place_mode_auto_expand();
         self.drain_task_results();

--- a/src/app.rs
+++ b/src/app.rs
@@ -1955,9 +1955,8 @@ impl App {
         // when the staged tree is empty; we don't emulate auto-stage-on-
         // commit yet).
         if self.staged_files.is_empty() {
-            self.git_status.commit_error = Some(
-                crate::i18n::t(crate::i18n::Msg::CommitNothingStaged).to_string(),
-            );
+            self.git_status.commit_error =
+                Some(crate::i18n::t(crate::i18n::Msg::CommitNothingStaged).to_string());
             return;
         }
         let backend = Arc::clone(&self.backend);

--- a/src/app.rs
+++ b/src/app.rs
@@ -1991,6 +1991,11 @@ impl App {
                         self.git_status.commit_message.clear();
                         self.git_status.commit_cursor = 0;
                         self.git_status.commit_editing = false;
+                        // Previously-selected file is almost certainly no
+                        // longer in staged/unstaged after the commit —
+                        // reload the diff so the right pane doesn't
+                        // linger on stale hunks until the next nav.
+                        self.load_diff();
                         self.toasts.push(Toast::info(t(Msg::CommitSuccess)));
                     }
                     Err(e) => {

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -382,6 +382,10 @@ impl Backend for LocalBackend {
         crate::git::push_at(&self.workdir, force).map_err(BackendError::Git)
     }
 
+    fn commit(&self, message: &str) -> Result<(), BackendError> {
+        crate::git::commit_at(&self.workdir, message).map_err(BackendError::Git)
+    }
+
     fn list_commits(&self, limit: usize) -> Result<Vec<CommitInfo>, BackendError> {
         Ok(self.repo()?.list_commits(limit))
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -314,6 +314,11 @@ pub trait Backend: Send + Sync {
 
     fn push(&self, force: bool) -> Result<(), BackendError>;
 
+    /// Commit the staged index with `message`. Same shell-out rationale
+    /// as `push` — respects hooks, signing, and the user's git config.
+    /// Errors from `git commit` bubble up as `BackendError::Git`.
+    fn commit(&self, message: &str) -> Result<(), BackendError>;
+
     // ─── git: history ───────────────────────────────────────────────────────
     fn list_commits(&self, limit: usize) -> Result<Vec<CommitInfo>, BackendError>;
     fn list_refs(&self) -> Result<HashMap<String, Vec<RefLabel>>, BackendError>;

--- a/src/backend/remote.rs
+++ b/src/backend/remote.rs
@@ -626,6 +626,13 @@ impl Backend for RemoteBackend {
         Ok(())
     }
 
+    fn commit(&self, message: &str) -> Result<(), BackendError> {
+        let _: serde_json::Value = self.request(Request::Commit {
+            message: message.to_string(),
+        })?;
+        Ok(())
+    }
+
     fn list_commits(&self, limit: usize) -> Result<Vec<CommitInfo>, BackendError> {
         let list: Vec<reef_proto::CommitInfoDto> = self.request(Request::ListCommits {
             limit: limit as u64,

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -710,6 +710,70 @@ pub fn push_at(workdir: &Path, force: bool) -> Result<(), String> {
     Ok(())
 }
 
+/// Commit the staged index at `workdir` with `message`. Shells out to
+/// `git commit -F -` (message via stdin) for the same reason `push_at`
+/// does: respects the user's pre-commit / commit-msg hooks, GPG signing
+/// config (`commit.gpgsign`, `user.signingkey`), `user.name`/`user.email`,
+/// and any `commit.template` / `commit.cleanup` behaviour — things that
+/// libgit2's `Repository::commit` would otherwise reimplement piecemeal
+/// and still miss the hook story entirely.
+///
+/// Free function (not a `GitRepo` method) so the background worker
+/// thread can call it: `GitRepo` holds a non-Send libgit2 handle and
+/// can't cross thread boundaries.
+///
+/// An empty / whitespace-only `message` returns an error without
+/// invoking git — matches the UI invariant that the Commit button is
+/// disabled when the draft is empty. `-F -` avoids a temp file and
+/// passes the message bytes through unchanged.
+pub fn commit_at(workdir: &Path, message: &str) -> Result<(), String> {
+    use std::io::Write;
+    if message.trim().is_empty() {
+        return Err("empty commit message".to_string());
+    }
+    let mut child = std::process::Command::new("git")
+        .current_dir(workdir)
+        .args(["commit", "-F", "-"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                "git executable not found on PATH — commit requires a `git` binary \
+                 on the host running the backend (install git on the remote to enable commit)"
+                    .to_string()
+            } else {
+                format!("failed to run git: {e}")
+            }
+        })?;
+    {
+        let stdin = child
+            .stdin
+            .as_mut()
+            .ok_or_else(|| "failed to open git stdin".to_string())?;
+        stdin
+            .write_all(message.as_bytes())
+            .map_err(|e| format!("failed to write commit message: {e}"))?;
+    }
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("failed to wait on git: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let err = if !stderr.is_empty() {
+            stderr
+        } else if !stdout.is_empty() {
+            stdout
+        } else {
+            "commit failed".to_string()
+        };
+        return Err(err);
+    }
+    Ok(())
+}
+
 impl GitRepo {
     // ── commit history / refs ──────────────────────────────────────────────
 

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -450,7 +450,11 @@ pub fn push_failed_toast(e: &str) -> String {
 /// bar items. The full text still surfaces in the in-panel
 /// `commit_error` banner.
 pub fn commit_failed_toast(e: &str) -> String {
-    let first = e.lines().map(str::trim).find(|l| !l.is_empty()).unwrap_or(e);
+    let first = e
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or(e);
     match lang() {
         Lang::Zh => format!("提交失败: {first}"),
         Lang::En => format!("Commit failed: {first}"),

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -67,6 +67,8 @@ pub enum Msg {
     PushSuccess,
     ForcePushSuccess,
     PushThreadCrashed,
+    CommitSuccess,
+    CommitThreadCrashed,
     ClipboardCopied,
     ClipboardCopyFailed,
 
@@ -92,6 +94,14 @@ pub enum Msg {
     UnstageAll,
     DiscardAll,
     NoFiles,
+
+    // Commit box
+    CommitMessagePlaceholder,
+    CommitButton,
+    CommittingHint,
+    CommitFailedPrefix,
+    CommitHint,
+    CommitNothingStaged,
 
     // Diff panel
     DiffEmpty,
@@ -193,6 +203,8 @@ fn t_zh(m: Msg) -> &'static str {
         PushSuccess => "推送成功",
         ForcePushSuccess => "强制推送成功",
         PushThreadCrashed => "推送线程异常退出，请重试",
+        CommitSuccess => "提交成功",
+        CommitThreadCrashed => "提交线程异常退出，请重试",
         ClipboardCopied => "已复制到剪贴板",
         ClipboardCopyFailed => "复制到剪贴板失败",
         PushingHint => "  ⋯ 推送中…",
@@ -216,6 +228,12 @@ fn t_zh(m: Msg) -> &'static str {
         UnstageAll => "取消全部",
         DiscardAll => "全部撤回",
         NoFiles => "  无文件",
+        CommitMessagePlaceholder => "输入提交消息…",
+        CommitButton => " ✓ 提交 ",
+        CommittingHint => "  ⋯ 提交中…",
+        CommitFailedPrefix => "  ✖ 提交失败: ",
+        CommitHint => "(Ctrl+Enter 提交 · Esc 取消)",
+        CommitNothingStaged => "没有可提交的已暂存文件",
         DiffEmpty => "选择一个文件查看 diff",
         PreviewEmpty => "选择一个文件预览内容",
         PreviewImageUnavailable => "当前终端不支持图片预览",
@@ -300,6 +318,8 @@ fn t_en(m: Msg) -> &'static str {
         PushSuccess => "Push succeeded",
         ForcePushSuccess => "Force push succeeded",
         PushThreadCrashed => "Push worker crashed, please retry",
+        CommitSuccess => "Commit succeeded",
+        CommitThreadCrashed => "Commit worker crashed, please retry",
         ClipboardCopied => "Copied to clipboard",
         ClipboardCopyFailed => "Clipboard copy failed",
         PushingHint => "  ⋯ Pushing…",
@@ -323,6 +343,12 @@ fn t_en(m: Msg) -> &'static str {
         UnstageAll => "Unstage all",
         DiscardAll => "Discard all",
         NoFiles => "  (no files)",
+        CommitMessagePlaceholder => "Message (commit staged)…",
+        CommitButton => " ✓ Commit ",
+        CommittingHint => "  ⋯ Committing…",
+        CommitFailedPrefix => "  ✖ Commit failed: ",
+        CommitHint => "(Ctrl+Enter to commit · Esc to cancel)",
+        CommitNothingStaged => "Nothing staged to commit",
         DiffEmpty => "Select a file to view diff",
         PreviewEmpty => "Select a file to preview",
         PreviewImageUnavailable => "image preview unavailable in this terminal",
@@ -415,6 +441,19 @@ pub fn push_failed_toast(e: &str) -> String {
     match lang() {
         Lang::Zh => format!("推送失败: {e}"),
         Lang::En => format!("Push failed: {e}"),
+    }
+}
+
+/// Toast variant for commit failure. Commit errors are often multi-line
+/// (hook output, rejected commit-msg template, etc.); the toast picks
+/// the first non-empty line so it stays readable next to other status
+/// bar items. The full text still surfaces in the in-panel
+/// `commit_error` banner.
+pub fn commit_failed_toast(e: &str) -> String {
+    let first = e.lines().map(str::trim).find(|l| !l.is_empty()).unwrap_or(e);
+    match lang() {
+        Lang::Zh => format!("提交失败: {first}"),
+        Lang::En => format!("Commit failed: {first}"),
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -763,8 +763,142 @@ fn handle_key_graph(key: KeyEvent, app: &mut App) {
     }
 }
 
+/// Route a key event to the commit-box buffer when the Git tab's
+/// commit input is focused. Mirrors the text-input contract used by
+/// `handle_key_search_input_mode`: typing fills the draft, standard
+/// nav / edit keys move the cursor, Esc blurs, Ctrl+Enter submits,
+/// bare Enter inserts a newline (subject + body pattern). Returns
+/// `true` when the key was consumed.
+fn handle_key_git_commit(key: KeyEvent, app: &mut App, ctrl: bool, alt: bool) -> bool {
+    use crate::app::Panel;
+    if app.active_panel != Panel::Files || !app.git_status.commit_editing {
+        return false;
+    }
+    match key.code {
+        KeyCode::Esc => {
+            app.git_status.commit_editing = false;
+            true
+        }
+        KeyCode::Enter if ctrl => {
+            app.run_commit();
+            true
+        }
+        KeyCode::Enter => {
+            crate::input_edit::insert_char(
+                &mut app.git_status.commit_message,
+                &mut app.git_status.commit_cursor,
+                '\n',
+            );
+            true
+        }
+        KeyCode::Backspace if alt || ctrl => {
+            crate::input_edit::delete_word_backward(
+                &mut app.git_status.commit_message,
+                &mut app.git_status.commit_cursor,
+            );
+            true
+        }
+        KeyCode::Backspace => {
+            crate::input_edit::backspace(
+                &mut app.git_status.commit_message,
+                &mut app.git_status.commit_cursor,
+            );
+            true
+        }
+        KeyCode::Delete if alt || ctrl => {
+            crate::input_edit::delete_word_forward(
+                &mut app.git_status.commit_message,
+                &mut app.git_status.commit_cursor,
+            );
+            true
+        }
+        KeyCode::Delete => {
+            crate::input_edit::delete_char_forward(
+                &mut app.git_status.commit_message,
+                &mut app.git_status.commit_cursor,
+            );
+            true
+        }
+        KeyCode::Left if alt || ctrl => {
+            crate::input_edit::move_cursor_word_backward(
+                &app.git_status.commit_message,
+                &mut app.git_status.commit_cursor,
+            );
+            true
+        }
+        KeyCode::Right if alt || ctrl => {
+            crate::input_edit::move_cursor_word_forward(
+                &app.git_status.commit_message,
+                &mut app.git_status.commit_cursor,
+            );
+            true
+        }
+        KeyCode::Left => {
+            crate::input_edit::move_cursor(
+                &app.git_status.commit_message,
+                &mut app.git_status.commit_cursor,
+                -1,
+            );
+            true
+        }
+        KeyCode::Right => {
+            crate::input_edit::move_cursor(
+                &app.git_status.commit_message,
+                &mut app.git_status.commit_cursor,
+                1,
+            );
+            true
+        }
+        KeyCode::Home => {
+            app.git_status.commit_cursor = 0;
+            true
+        }
+        KeyCode::End => {
+            app.git_status.commit_cursor = app.git_status.commit_message.len();
+            true
+        }
+        KeyCode::Char('u') if ctrl => {
+            crate::input_edit::clear(
+                &mut app.git_status.commit_message,
+                &mut app.git_status.commit_cursor,
+            );
+            true
+        }
+        KeyCode::Char('w') if ctrl => {
+            crate::input_edit::delete_word_backward(
+                &mut app.git_status.commit_message,
+                &mut app.git_status.commit_cursor,
+            );
+            true
+        }
+        KeyCode::Char('a') if ctrl => {
+            app.git_status.commit_cursor = 0;
+            true
+        }
+        KeyCode::Char('e') if ctrl => {
+            app.git_status.commit_cursor = app.git_status.commit_message.len();
+            true
+        }
+        KeyCode::Char(c) if !ctrl => {
+            crate::input_edit::insert_char(
+                &mut app.git_status.commit_message,
+                &mut app.git_status.commit_cursor,
+                c,
+            );
+            true
+        }
+        _ => false,
+    }
+}
+
 fn handle_key_git(key: KeyEvent, app: &mut App) {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
+    // Commit-box input mode owns the keyboard while focused so the
+    // letter chords below (s/u/d/…) don't fire mid-message.
+    if handle_key_git_commit(key, app, ctrl, alt) {
+        return;
+    }
     match key.code {
         KeyCode::Up | KeyCode::Char('k') if !ctrl => match app.active_panel {
             Panel::Files => app.navigate_files(-1),

--- a/src/ui/git_status_panel.rs
+++ b/src/ui/git_status_panel.rs
@@ -1212,18 +1212,22 @@ fn push_commit_box(rows: &mut Vec<Row>, app: &App, max_path: usize, theme: &Them
         theme.fg_secondary
     };
     // Top border
-    rows.push(Row::new(vec![RowSpan::styled(
-        format!(" ┌ {} ", t(Msg::CommitMessagePlaceholder)),
-        Style::default().fg(border_color),
-    )])
-    .on_click("git.commitFocus", Value::Null));
-
-    if !has_text && !editing {
-        rows.push(Row::new(vec![RowSpan::styled(
-            " │ ".to_string(),
+    rows.push(
+        Row::new(vec![RowSpan::styled(
+            format!(" ┌ {} ", t(Msg::CommitMessagePlaceholder)),
             Style::default().fg(border_color),
         )])
-        .on_click("git.commitFocus", Value::Null));
+        .on_click("git.commitFocus", Value::Null),
+    );
+
+    if !has_text && !editing {
+        rows.push(
+            Row::new(vec![RowSpan::styled(
+                " │ ".to_string(),
+                Style::default().fg(border_color),
+            )])
+            .on_click("git.commitFocus", Value::Null),
+        );
     } else {
         // Walk the buffer line by line, emitting one row each. Track
         // a running byte offset so we can decide which line holds
@@ -1285,11 +1289,13 @@ fn push_commit_box(rows: &mut Vec<Row>, app: &App, max_path: usize, theme: &Them
     }
 
     // Bottom border
-    rows.push(Row::new(vec![RowSpan::styled(
-        " └".to_string(),
-        Style::default().fg(border_color),
-    )])
-    .on_click("git.commitFocus", Value::Null));
+    rows.push(
+        Row::new(vec![RowSpan::styled(
+            " └".to_string(),
+            Style::default().fg(border_color),
+        )])
+        .on_click("git.commitFocus", Value::Null),
+    );
 
     // Action row: [✓ Commit] + hint. Button is dimmed when the
     // draft or staged tree is empty — click still works but the

--- a/src/ui/git_status_panel.rs
+++ b/src/ui/git_status_panel.rs
@@ -402,6 +402,22 @@ pub fn handle_command(app: &mut App, id: &str, args: &Value) -> bool {
             app.load_diff();
             true
         }
+        "git.commitFocus" => {
+            app.git_status.commit_editing = true;
+            true
+        }
+        "git.commitBlur" => {
+            app.git_status.commit_editing = false;
+            true
+        }
+        "git.commitSubmit" => {
+            app.run_commit();
+            true
+        }
+        "git.dismissCommitError" => {
+            app.git_status.commit_error = None;
+            true
+        }
         _ => false,
     }
 }
@@ -643,6 +659,48 @@ fn build_rows(app: &App, width: u16, theme: &Theme) -> Vec<Row> {
         ]));
         rows.push(Row::blank());
     }
+
+    // Commit in-flight banner — while the worker is committing, the
+    // input is read-only (commit_in_flight gates run_commit) and the
+    // UI shows a spinner.
+    if app.commit_in_flight {
+        rows.push(Row::new(vec![RowSpan::styled(
+            t(Msg::CommittingHint),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )]));
+        rows.push(Row::blank());
+    }
+
+    // Commit error banner — mirrors push_error. Sticks around until
+    // the user clicks [dismiss] or starts a new commit attempt.
+    if let Some(ref err) = status.commit_error {
+        let mut msg = err.clone();
+        truncate_in_place(&mut msg, max_path);
+        rows.push(
+            Row::new(vec![
+                RowSpan::styled(
+                    t(Msg::CommitFailedPrefix),
+                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                ),
+                RowSpan::styled(msg, Style::default().fg(theme.fg_primary)),
+                RowSpan::styled(
+                    t(Msg::DismissClose),
+                    Style::default().fg(theme.fg_secondary),
+                ),
+            ])
+            .on_click("git.dismissCommitError", Value::Null),
+        );
+        rows.push(Row::blank());
+    }
+
+    // Commit message box + Commit button. Anchored just above the
+    // staged/unstaged sections to mirror VSCode's Source Control
+    // layout. Editing is routed through `git.commit*` commands so
+    // mouse and keyboard paths share the same buffer mutation code.
+    push_commit_box(&mut rows, app, max_path, theme);
+    rows.push(Row::blank());
 
     // View mode toggle
     let mode_label = if status.tree_mode {
@@ -1124,6 +1182,155 @@ fn section_header(
     }
 
     Row::new(spans).on_click(toggle_cmd, Value::Null)
+}
+
+/// Render the VSCode-style commit message box.
+///
+/// Layout (single column, the right-hand diff pane stays untouched):
+///   ┌─ Commit message ─┐
+///   │ subject…          │
+///   │ (body line …)     │
+///   └───────────────────┘
+///   [ ✓ Commit ]  (Ctrl+Enter · Esc)
+///
+/// - Empty + unfocused: shows a dimmed placeholder string so the box
+///   communicates its purpose before the user clicks.
+/// - Focused: the caret is drawn as a reverse-video block at
+///   `commit_cursor` so the user can see where typing will land.
+/// - Multi-line messages are split on `\n` and rendered as
+///   successive rows. Long single lines are truncated with `…` to
+///   stay inside the sidebar width; the full buffer is preserved in
+///   state and ships to `git commit -F -` verbatim.
+fn push_commit_box(rows: &mut Vec<Row>, app: &App, max_path: usize, theme: &Theme) {
+    let msg = &app.git_status.commit_message;
+    let editing = app.git_status.commit_editing;
+    let cursor = app.git_status.commit_cursor.min(msg.len());
+    let has_text = !msg.trim().is_empty();
+    let border_color = if editing {
+        theme.accent
+    } else {
+        theme.fg_secondary
+    };
+    // Top border
+    rows.push(Row::new(vec![RowSpan::styled(
+        format!(" ┌ {} ", t(Msg::CommitMessagePlaceholder)),
+        Style::default().fg(border_color),
+    )])
+    .on_click("git.commitFocus", Value::Null));
+
+    if !has_text && !editing {
+        rows.push(Row::new(vec![RowSpan::styled(
+            " │ ".to_string(),
+            Style::default().fg(border_color),
+        )])
+        .on_click("git.commitFocus", Value::Null));
+    } else {
+        // Walk the buffer line by line, emitting one row each. Track
+        // a running byte offset so we can decide which line holds
+        // the caret and compute its intra-line column.
+        let mut offset: usize = 0;
+        let lines: Vec<&str> = msg.split('\n').collect();
+        let last_idx = lines.len().saturating_sub(1);
+        for (i, line) in lines.iter().enumerate() {
+            let line_start = offset;
+            let line_end = offset + line.len();
+            let cursor_in_line = editing
+                && cursor >= line_start
+                && (cursor < line_end
+                    || (cursor == line_end && (i == last_idx || cursor == msg.len())));
+            // Truncate overly long lines so the box stays inside
+            // the sidebar budget. Cursor clipping falls out of
+            // `char_count.min(truncated_len)` below.
+            let budget = max_path.saturating_sub(4).max(1);
+            let mut display = (*line).to_string();
+            let chars: Vec<char> = display.chars().collect();
+            if chars.len() > budget {
+                display = chars.into_iter().take(budget.saturating_sub(1)).collect();
+                display.push('…');
+            }
+            let mut spans = vec![RowSpan::styled(
+                " │ ".to_string(),
+                Style::default().fg(border_color),
+            )];
+            if cursor_in_line {
+                let col_bytes = cursor - line_start;
+                // Convert byte offset to char offset so the caret
+                // lands on a grapheme boundary in the displayed line.
+                let before_chars = line[..col_bytes.min(line.len())]
+                    .chars()
+                    .count()
+                    .min(budget);
+                let (before, after) = split_chars(&display, before_chars);
+                spans.push(RowSpan::plain(before));
+                // Caret glyph: reverse-video space so it shows at
+                // end-of-line too. When there's a char under the
+                // caret, render it with reverse-video so the user
+                // sees which char they're on.
+                let (caret, rest) = split_chars(&after, 1);
+                let caret_glyph = if caret.is_empty() {
+                    " ".to_string()
+                } else {
+                    caret
+                };
+                spans.push(RowSpan::styled(
+                    caret_glyph,
+                    Style::default().add_modifier(Modifier::REVERSED),
+                ));
+                spans.push(RowSpan::plain(rest));
+            } else if display.is_empty() {
+                spans.push(RowSpan::plain(" "));
+            } else {
+                spans.push(RowSpan::plain(display));
+            }
+            rows.push(Row::new(spans).on_click("git.commitFocus", Value::Null));
+            offset = line_end + 1; // +1 for the consumed '\n'
+        }
+    }
+
+    // Bottom border
+    rows.push(Row::new(vec![RowSpan::styled(
+        " └".to_string(),
+        Style::default().fg(border_color),
+    )])
+    .on_click("git.commitFocus", Value::Null));
+
+    // Action row: [✓ Commit] + hint. Button is dimmed when the
+    // draft or staged tree is empty — click still works but the
+    // toast/banner tells the user why nothing happened.
+    let enabled = has_text && !app.staged_files.is_empty() && !app.commit_in_flight;
+    let (btn_fg, btn_bg) = if enabled {
+        (Color::Black, Color::Green)
+    } else {
+        (theme.chrome_fg, theme.chrome_muted_fg)
+    };
+    rows.push(Row::new(vec![
+        RowSpan::plain("  "),
+        RowSpan {
+            text: t(Msg::CommitButton).to_string(),
+            style: Style::default()
+                .fg(btn_fg)
+                .bg(btn_bg)
+                .add_modifier(Modifier::BOLD),
+            click: Some(("git.commitSubmit".into(), Value::Null)),
+            dbl: None,
+        },
+        RowSpan::plain("  "),
+        RowSpan::styled(
+            t(Msg::CommitHint).to_string(),
+            Style::default().fg(theme.fg_secondary),
+        ),
+    ]));
+}
+
+/// Split `s` into `(first n chars, rest)` in char units so truncation
+/// respects grapheme-ish boundaries instead of slicing mid-UTF-8.
+/// Used by `push_commit_box` to draw the caret glyph between
+/// before/after runs.
+fn split_chars(s: &str, n: usize) -> (String, String) {
+    let mut chars = s.chars();
+    let before: String = (&mut chars).take(n).collect();
+    let after: String = chars.collect();
+    (before, after)
 }
 
 fn push_indicator_row(ahead: usize, behind: usize) -> Option<Row> {

--- a/src/ui/git_status_panel.rs
+++ b/src/ui/git_status_panel.rs
@@ -1239,15 +1239,12 @@ fn push_commit_box(rows: &mut Vec<Row>, app: &App, max_path: usize, theme: &Them
                 && (cursor < line_end
                     || (cursor == line_end && (i == last_idx || cursor == msg.len())));
             // Truncate overly long lines so the box stays inside
-            // the sidebar budget. Cursor clipping falls out of
-            // `char_count.min(truncated_len)` below.
+            // the sidebar budget. Budget is in *display columns*
+            // (via UnicodeWidthStr) not chars, so a CJK-heavy
+            // message line doesn't overflow the sidebar — each
+            // ideograph counts as 2 cells on most terminals.
             let budget = max_path.saturating_sub(4).max(1);
-            let mut display = (*line).to_string();
-            let chars: Vec<char> = display.chars().collect();
-            if chars.len() > budget {
-                display = chars.into_iter().take(budget.saturating_sub(1)).collect();
-                display.push('…');
-            }
+            let display = truncate_to_width(line, budget);
             let mut spans = vec![RowSpan::styled(
                 " │ ".to_string(),
                 Style::default().fg(border_color),
@@ -1331,6 +1328,34 @@ fn split_chars(s: &str, n: usize) -> (String, String) {
     let before: String = (&mut chars).take(n).collect();
     let after: String = chars.collect();
     (before, after)
+}
+
+/// Clip `s` so its rendered width is ≤ `max_cols` display columns
+/// (via `UnicodeWidthStr`). Appends an `…` when truncation happens.
+/// Used by `push_commit_box` instead of char-count clipping so
+/// wide-column glyphs (CJK, emoji) don't overflow the sidebar.
+fn truncate_to_width(s: &str, max_cols: usize) -> String {
+    use unicode_width::UnicodeWidthChar;
+    if max_cols == 0 {
+        return String::new();
+    }
+    if UnicodeWidthStr::width(s) <= max_cols {
+        return s.to_string();
+    }
+    // Reserve one column for the trailing ellipsis.
+    let cap = max_cols.saturating_sub(1);
+    let mut out = String::new();
+    let mut used = 0usize;
+    for c in s.chars() {
+        let w = UnicodeWidthChar::width(c).unwrap_or(0);
+        if used + w > cap {
+            break;
+        }
+        out.push(c);
+        used += w;
+    }
+    out.push('…');
+    out
 }
 
 fn push_indicator_row(ahead: usize, behind: usize) -> Option<Row> {

--- a/tests/snapshots/ui_snapshots__with_staged_and_unstaged.snap
+++ b/tests/snapshots/ui_snapshots__with_staged_and_unstaged.snap
@@ -1,20 +1,20 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 134
+assertion_line: 136
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
  📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph           1:Files 2:Search 3:Git 4:Graph
+  ┌ Message (commit sta│
+  │                    │
+  └                    │
+    ✓ Commit   (Ctrl+En│
+                       │
  View: list            │
                        │
  ⌄ Changes  2 Stage all│
-   new.txt +1 U + ↺    │
+   new.txt +1 U + ↺    │                 Select a file to view diff
    ...txt +1 -1 M + ↺  │
-                       │
-                       │
-                       │
-                       │                 Select a file to view diff
-                       │
                        │
                        │
                        │

--- a/tests/snapshots/ui_snapshots__with_staged_and_unstaged_light.snap
+++ b/tests/snapshots/ui_snapshots__with_staged_and_unstaged_light.snap
@@ -1,20 +1,20 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 281
+assertion_line: 454
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
  📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph           1:Files 2:Search 3:Git 4:Graph
+  ┌ Message (commit sta│
+  │                    │
+  └                    │
+    ✓ Commit   (Ctrl+En│
+                       │
  View: list            │
                        │
  ⌄ Changes  2 Stage all│
-   new.txt +1 U + ↺    │
+   new.txt +1 U + ↺    │                 Select a file to view diff
    ...txt +1 -1 M + ↺  │
-                       │
-                       │
-                       │
-                       │                 Select a file to view diff
-                       │
                        │
                        │
                        │


### PR DESCRIPTION
## Summary

- Add a VS Code–style commit message box to the Git tab: bordered text input with caret, a ` ✓ Commit ` button, plus in-flight / error banners — users can now write a commit message and commit the staged index without leaving reef.
- Plumbing: `git/mod.rs::commit_at` shells out to `git commit -F -` (message via stdin) so pre-commit / commit-msg hooks, GPG signing, and the user's git config all keep working. Threaded through `Backend::commit` + Local/Remote impls + new `Request::Commit` RPC (PROTOCOL_VERSION 5 → 6).
- Async: `App::run_commit` spawns a worker, `drain_commit_result` folds the result on tick — success clears the draft + reloads the diff + busts the graph cache, failure sticks a banner and pops a toast. Mirrors the existing push flow one-for-one.
- Input: new `handle_key_git_commit` owns the keyboard while the box is focused so the bare-letter chords (s/u/d/…) don't fire mid-message. Esc blurs, bare Enter inserts a newline (subject + body pattern), Ctrl+Enter submits.
- i18n (zh/en) + `commit_failed_toast` helper that picks the first non-empty line for the toast while the full text stays in the banner.
- Snapshot tests updated for the new sidebar layout.

Review follow-ups already folded in:
- `drain_commit_result` now calls `load_diff()` after success so the right pane doesn't keep showing hunks for a file that's no longer in staged/unstaged.
- Commit-box line truncation uses `UnicodeWidthStr`-based column width (new `truncate_to_width` helper) so CJK / emoji messages don't overflow the sidebar.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace` — 365 passed, 0 failed (includes updated ui_snapshots)
- [x] `cargo fmt --all -- --check` clean
- [ ] Manual: stage a file, click into the box, type \`feat: demo\`, Ctrl+Enter → commit lands, draft clears, graph advances
- [ ] Manual: empty staged tree + click Commit → \"Nothing staged to commit\" banner
- [ ] Manual: pre-commit hook exit 1 → banner shows first hook line, draft preserved
- [ ] Manual: multi-line message with Enter for body, verify \`git log -1 --format=%B\` round-trips the newlines
- [ ] Manual: CJK message in a narrow sidebar — does not overflow