### PR TITLE
fix(git-tab): enlarge click target for commit input and button

### DIFF
--- a/src/ui/git_status_panel.rs
+++ b/src/ui/git_status_panel.rs
@@ -1220,12 +1220,18 @@ fn push_commit_box(rows: &mut Vec<Row>, app: &App, max_path: usize, theme: &Them
         .on_click("git.commitFocus", Value::Null),
     );
 
+    // Trailing pad width so the whole interior of the box is a click
+    // target for `git.commitFocus`, not just the `│` and caret cells.
+    let pad_to = |used: usize| -> String { " ".repeat(max_path.saturating_sub(used)) };
+
     if !has_text && !editing {
+        let prefix = " │ ";
+        let used = UnicodeWidthStr::width(prefix);
         rows.push(
-            Row::new(vec![RowSpan::styled(
-                " │ ".to_string(),
-                Style::default().fg(border_color),
-            )])
+            Row::new(vec![
+                RowSpan::styled(prefix.to_string(), Style::default().fg(border_color)),
+                RowSpan::plain(pad_to(used)),
+            ])
             .on_click("git.commitFocus", Value::Null),
         );
     } else {
@@ -1283,6 +1289,11 @@ fn push_commit_box(rows: &mut Vec<Row>, app: &App, max_path: usize, theme: &Them
             } else {
                 spans.push(RowSpan::plain(display));
             }
+            let used: usize = spans
+                .iter()
+                .map(|s| UnicodeWidthStr::width(s.text.as_str()))
+                .sum();
+            spans.push(RowSpan::plain(pad_to(used)));
             rows.push(Row::new(spans).on_click("git.commitFocus", Value::Null));
             offset = line_end + 1; // +1 for the consumed '\n'
         }
@@ -1306,23 +1317,26 @@ fn push_commit_box(rows: &mut Vec<Row>, app: &App, max_path: usize, theme: &Them
     } else {
         (theme.chrome_fg, theme.chrome_muted_fg)
     };
-    rows.push(Row::new(vec![
-        RowSpan::plain("  "),
-        RowSpan {
-            text: t(Msg::CommitButton).to_string(),
-            style: Style::default()
-                .fg(btn_fg)
-                .bg(btn_bg)
-                .add_modifier(Modifier::BOLD),
-            click: Some(("git.commitSubmit".into(), Value::Null)),
-            dbl: None,
-        },
-        RowSpan::plain("  "),
-        RowSpan::styled(
-            t(Msg::CommitHint).to_string(),
-            Style::default().fg(theme.fg_secondary),
-        ),
-    ]));
+    rows.push(
+        Row::new(vec![
+            RowSpan::plain("  "),
+            RowSpan {
+                text: t(Msg::CommitButton).to_string(),
+                style: Style::default()
+                    .fg(btn_fg)
+                    .bg(btn_bg)
+                    .add_modifier(Modifier::BOLD),
+                click: Some(("git.commitSubmit".into(), Value::Null)),
+                dbl: None,
+            },
+            RowSpan::plain("  "),
+            RowSpan::styled(
+                t(Msg::CommitHint).to_string(),
+                Style::default().fg(theme.fg_secondary),
+            ),
+        ])
+        .on_click("git.commitSubmit", Value::Null),
+    );
 }
 
 /// Split `s` into `(first n chars, rest)` in char units so truncation


### PR DESCRIPTION
## Summary
- Only the visible `│`/caret cells and the `✓ Commit` text itself were registering hitboxes in the sidebar commit box, so clicks landing in the empty interior of the message box or in the padding/hint next to the button missed.
- Pad each commit-message content row out to `max_path` so the whole row (not just the drawn glyphs) falls back to the row-level `git.commitFocus` action.
- Attach a row-level `git.commitSubmit` to the action row so clicks in the padding spaces and the hint text also submit — the button's own span-level click still takes precedence.

## Test plan
- [ ] With an empty, unfocused commit box, click anywhere to the right of `│` → focuses the input.
- [ ] While editing, click anywhere on a message line (including trailing empty area) → keeps focus on the input.
- [ ] Click on the `✓ Commit` button itself → submits.
- [ ] Click on the padding/hint text to the right of the button → submits.
- [ ] `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings` pass.