### PR TITLE
feat: in-TUI diff selection + Graph tab 3-col layout

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -921,6 +921,16 @@ impl App {
         )
     }
 
+    /// Drop the in-panel diff selection and its click counter. Called
+    /// whenever the underlying row list is about to shift out from under
+    /// the cached `(row_idx, byte_offset)` anchor — file swap, layout /
+    /// mode toggle, tab switch, 3-col→2-col transition. Keeping this in
+    /// one place means future reset sites can't miss the click counter.
+    pub fn clear_diff_selection(&mut self) {
+        self.diff_selection = None;
+        self.diff_click_state = None;
+    }
+
     /// Drop `Panel::Commit` back to a two-column-compatible panel when the
     /// layout no longer exposes a middle column (narrow terminal, diff
     /// unloaded, tab switched away). Prevents the user from being stuck
@@ -941,8 +951,7 @@ impl App {
             && self.diff_selection.is_some()
             && !self.graph_uses_three_col()
         {
-            self.diff_selection = None;
-            self.diff_click_state = None;
+            self.clear_diff_selection();
         }
     }
 
@@ -1657,8 +1666,7 @@ impl App {
         self.diff_h_scroll = 0;
         self.sbs_left_h_scroll = 0;
         self.sbs_right_h_scroll = 0;
-        self.diff_selection = None;
-        self.diff_click_state = None;
+        self.clear_diff_selection();
         self.load_diff();
     }
 
@@ -1697,8 +1705,7 @@ impl App {
         self.sbs_right_h_scroll = 0;
         // Unified↔SBS row counts differ (SBS pairs adjacent - / + lines),
         // so a selection anchored in one layout doesn't map into the other.
-        self.diff_selection = None;
-        self.diff_click_state = None;
+        self.clear_diff_selection();
         save_prefs(self.diff_layout, self.diff_mode);
     }
 
@@ -1711,8 +1718,7 @@ impl App {
         self.diff_h_scroll = 0;
         self.sbs_left_h_scroll = 0;
         self.sbs_right_h_scroll = 0;
-        self.diff_selection = None;
-        self.diff_click_state = None;
+        self.clear_diff_selection();
         self.load_diff();
         save_prefs(self.diff_layout, self.diff_mode);
     }
@@ -2030,8 +2036,7 @@ impl App {
             self.commit_detail.file_diff_h_scroll = 0;
             self.commit_detail.file_diff_sbs_left_h_scroll = 0;
             self.commit_detail.file_diff_sbs_right_h_scroll = 0;
-            self.diff_selection = None;
-            self.diff_click_state = None;
+            self.clear_diff_selection();
         }
         if self.git_graph.is_range() {
             let Some(range) = self.commit_detail.range_detail.as_ref() else {
@@ -2845,8 +2850,7 @@ impl App {
         // Same for diff-panel selection — the Git tab and the Graph tab
         // 3-col diff column share this state, and tab-switching between
         // them (or to Files/Search) should start fresh.
-        self.diff_selection = None;
-        self.diff_click_state = None;
+        self.clear_diff_selection();
         match tab {
             Tab::Git => self.git_status_load.mark_stale(),
             Tab::Graph => self.graph_load.mark_stale(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -431,6 +431,23 @@ pub struct App {
     /// hit_registry 的 double-click 逻辑。
     pub preview_click_state: Option<(Instant, u16, u16, u8)>,
 
+    /// Diff 面板选中状态——Git tab 的 diff 和 Graph tab 3-col 右栏共用
+    /// 同一组字段(它们永远不会同时处于激活状态)。SBS 模式下锚点
+    /// 绑定一侧(左/右),跨侧拖拽把列 clamp 回本侧。None 表示无选中。
+    pub diff_selection: Option<crate::ui::selection::DiffSelection>,
+    /// 上一帧 diff 面板的整体 rect,供 hit test 使用。跟
+    /// `last_preview_rect` 并列。切到不渲染 diff 的 tab 时被
+    /// `ui::render` 在帧头清零。
+    pub last_diff_rect: Option<ratatui::layout::Rect>,
+    /// 上一帧 diff 面板的几何快照 + 行文本快照,鼠标处理把终端列行坐标
+    /// 映射回 `(side, display_row, byte_offset)`,以及在 Up 时从缓存的
+    /// 行文本里抽取选中区间写到剪贴板。只活一帧,下一帧 render 要么覆写
+    /// 要么被清零。
+    pub last_diff_hit: Option<crate::ui::selection::DiffHit>,
+    /// 连击计数器:diff 面板的 Down(Left) 序列,和 `preview_click_state`
+    /// 语义一致,但分开存以防两个 tab 之间的点击串扰。
+    pub diff_click_state: Option<(Instant, u16, u16, u8)>,
+
     // Layout
     pub split_percent: u16,
     pub dragging_split: bool,
@@ -739,6 +756,10 @@ impl App {
             last_preview_rect: None,
             last_preview_content_origin: None,
             preview_click_state: None,
+            diff_selection: None,
+            last_diff_rect: None,
+            last_diff_hit: None,
+            diff_click_state: None,
             split_percent: 30,
             dragging_split: false,
             graph_diff_split_percent: 60,
@@ -838,9 +859,23 @@ impl App {
     /// unloaded, tab switched away). Prevents the user from being stuck
     /// focusing a column that isn't rendered. Called at the top of
     /// `ui::render` alongside `last_total_width` update.
+    ///
+    /// Also drops a stale diff selection if we just lost the panel that
+    /// owned it — row indices from the old frame would overlay on top of
+    /// whatever renders next (commit_detail's flat row list doesn't match
+    /// `DiffHit.rows`), producing a bogus highlight.
     pub fn normalize_active_panel(&mut self) {
         if self.active_panel == Panel::Commit && !self.graph_uses_three_col() {
             self.active_panel = Panel::Diff;
+        }
+        // If we're on Graph and the 3-col diff column isn't visible anymore,
+        // any selection was anchored into rows that no panel will render.
+        if self.active_tab == Tab::Graph
+            && self.diff_selection.is_some()
+            && !self.graph_uses_three_col()
+        {
+            self.diff_selection = None;
+            self.diff_click_state = None;
         }
     }
 
@@ -1555,6 +1590,8 @@ impl App {
         self.diff_h_scroll = 0;
         self.sbs_left_h_scroll = 0;
         self.sbs_right_h_scroll = 0;
+        self.diff_selection = None;
+        self.diff_click_state = None;
         self.load_diff();
     }
 
@@ -1591,6 +1628,10 @@ impl App {
         self.diff_h_scroll = 0;
         self.sbs_left_h_scroll = 0;
         self.sbs_right_h_scroll = 0;
+        // Unified↔SBS row counts differ (SBS pairs adjacent - / + lines),
+        // so a selection anchored in one layout doesn't map into the other.
+        self.diff_selection = None;
+        self.diff_click_state = None;
         save_prefs(self.diff_layout, self.diff_mode);
     }
 
@@ -1603,6 +1644,8 @@ impl App {
         self.diff_h_scroll = 0;
         self.sbs_left_h_scroll = 0;
         self.sbs_right_h_scroll = 0;
+        self.diff_selection = None;
+        self.diff_click_state = None;
         self.load_diff();
         save_prefs(self.diff_layout, self.diff_mode);
     }
@@ -1920,6 +1963,8 @@ impl App {
             self.commit_detail.file_diff_h_scroll = 0;
             self.commit_detail.file_diff_sbs_left_h_scroll = 0;
             self.commit_detail.file_diff_sbs_right_h_scroll = 0;
+            self.diff_selection = None;
+            self.diff_click_state = None;
         }
         if self.git_graph.is_range() {
             let Some(range) = self.commit_detail.range_detail.as_ref() else {
@@ -2730,6 +2775,11 @@ impl App {
         // appears on return and the click-count resets cleanly.
         self.preview_selection = None;
         self.preview_click_state = None;
+        // Same for diff-panel selection — the Git tab and the Graph tab
+        // 3-col diff column share this state, and tab-switching between
+        // them (or to Files/Search) should start fresh.
+        self.diff_selection = None;
+        self.diff_click_state = None;
         match tab {
             Tab::Git => self.git_status_load.mark_stale(),
             Tab::Graph => self.graph_load.mark_stale(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -68,8 +68,15 @@ impl Tab {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Panel {
-    Files, // left
-    Diff,  // right
+    /// 左列(或两列布局里的唯一左列)。Git/Files/Search tab 用作 tree /
+    /// 文件列表;Graph tab 用作 graph 侧栏。
+    Files,
+    /// Graph tab 三列布局里的"中间列"——commit 元数据 + 改动文件树。
+    /// 只在 Graph tab 三列模式下有效;其他 tab 不会切到这里。
+    Commit,
+    /// 右列,通常是 diff 或 preview。Graph tab 三列模式下指最右侧
+    /// 的 diff 栏;二列模式下是 commit detail(含内联 diff)。
+    Diff,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -255,21 +262,32 @@ pub struct CommitDetailState {
     pub diff_mode: DiffMode,
     pub files_tree_mode: bool,
     pub files_collapsed: HashSet<String>,
-    /// Vertical scroll for the entire panel (header + files + diff). One
-    /// offset covers the whole view — the commit detail is rendered as a
-    /// single list rather than split scroll regions.
+    /// Vertical scroll for the entire panel (header + files + diff in
+    /// 2-col fallback;header + files only in 3-col mode).
     pub scroll: usize,
-    /// Horizontal scroll for Unified layout. Shared across the header /
-    /// files list / diff rows — the panel renders as a single list, and
-    /// `clip_spans` applies this offset uniformly per row. SBS uses the
-    /// two fields below instead (each half scrolls independently).
+    /// Vertical scroll for the Graph 3-col diff column. Independent of
+    /// `scroll` so the user can pan the diff viewport without the commit
+    /// metadata / file tree jumping around. Unused in 2-col fallback —
+    /// there the diff is inline and pans via `scroll`.
+    pub file_diff_scroll: usize,
+    /// Horizontal scroll for Unified layout. In 2-col mode this applies
+    /// to the whole row list (metadata + files + inline diff). In 3-col
+    /// mode the inline diff is gone from this panel, so this field only
+    /// pans the metadata / file-tree rows; the standalone diff column
+    /// uses the `file_diff_*_h_scroll` triad below.
     pub diff_h_scroll: usize,
-    /// Horizontal scroll for the SBS left half (old version). Independent
-    /// of the right half and of `diff_h_scroll` — switching diff layouts
-    /// preserves all three.
+    /// SBS horizontal scrolls for the mid-panel view (only meaningful
+    /// in 2-col fallback, where the inline SBS diff is part of this
+    /// panel's row stream).
     pub sbs_left_h_scroll: usize,
-    /// Horizontal scroll for the SBS right half (new version).
     pub sbs_right_h_scroll: usize,
+    /// Horizontal scrolls for the 3-col diff column. Kept separate from
+    /// the mid-panel `diff_h_scroll`/`sbs_*` triad above so panning the
+    /// commit metadata doesn't shift the diff viewport and vice versa.
+    /// Unused in 2-col fallback.
+    pub file_diff_h_scroll: usize,
+    pub file_diff_sbs_left_h_scroll: usize,
+    pub file_diff_sbs_right_h_scroll: usize,
 }
 
 impl Default for CommitDetailState {
@@ -283,9 +301,13 @@ impl Default for CommitDetailState {
             files_tree_mode: false,
             files_collapsed: HashSet::new(),
             scroll: 0,
+            file_diff_scroll: 0,
             diff_h_scroll: 0,
             sbs_left_h_scroll: 0,
             sbs_right_h_scroll: 0,
+            file_diff_h_scroll: 0,
+            file_diff_sbs_left_h_scroll: 0,
+            file_diff_sbs_right_h_scroll: 0,
         }
     }
 }
@@ -412,6 +434,21 @@ pub struct App {
     // Layout
     pub split_percent: u16,
     pub dragging_split: bool,
+    /// Graph tab 三列布局下,中间 commit 列与右侧 diff 列的分割位置,用
+    /// "非 graph 区域的百分比" 表示,从左向右计:中间列占 `100 -
+    /// graph_diff_split_percent`%,右侧 diff 列占 `graph_diff_split_percent`%。
+    /// 默认 60 —— diff 比元数据略宽一些。只在 `graph_uses_three_col()`
+    /// 返回 true 时有效。
+    pub graph_diff_split_percent: u16,
+    /// 是否正在拖拽 Graph tab 中间|右侧分割线。跟 `dragging_split` 并列,
+    /// 互不影响。
+    pub dragging_graph_diff_split: bool,
+    /// Cache of the most recent rendered body width. `ui::render` writes
+    /// this every frame so that logic running outside the render path
+    /// (search target resolution, panel normalization, handlers that
+    /// need to know layout) can ask "are we in 3-col Graph right now"
+    /// without threading terminal size through every call site.
+    pub last_total_width: u16,
 
     // Mouse
     pub hit_registry: HitTestRegistry,
@@ -704,6 +741,9 @@ impl App {
             preview_click_state: None,
             split_percent: 30,
             dragging_split: false,
+            graph_diff_split_percent: 60,
+            dragging_graph_diff_split: false,
+            last_total_width: 0,
             hit_registry: HitTestRegistry::new(),
             hover_row: None,
             hover_col: None,
@@ -769,6 +809,39 @@ impl App {
         app.refresh_status();
         app.refresh_file_tree();
         app
+    }
+
+    /// Minimum total width for the Graph tab's 3-column layout. Below this
+    /// the panel falls back to the 2-column layout with the diff rendered
+    /// inline inside `commit_detail_panel` (the pre-split behaviour).
+    /// Chosen so the middle column still shows readable file names and the
+    /// diff column has at least ~40 cols for content after its gutter.
+    pub const GRAPH_THREE_COL_MIN_WIDTH: u16 = 100;
+
+    /// Whether the Graph tab should render with 3 columns right now —
+    /// graph | commit metadata+files | diff. True when a file diff is
+    /// loaded (or currently loading) AND the terminal is wide enough.
+    /// Other tabs and narrow terminals fall back to the existing 2-col
+    /// layout where the diff is inline under the file list.
+    ///
+    /// Callers that need this in non-render contexts (search target
+    /// resolution, panel normalization) should read `last_total_width`
+    /// — `ui::render` caches it every frame before any panel runs.
+    pub fn graph_uses_three_col(&self) -> bool {
+        self.active_tab == Tab::Graph
+            && self.last_total_width >= Self::GRAPH_THREE_COL_MIN_WIDTH
+            && (self.commit_detail.file_diff.is_some() || self.commit_file_diff_load.loading)
+    }
+
+    /// Drop `Panel::Commit` back to a two-column-compatible panel when the
+    /// layout no longer exposes a middle column (narrow terminal, diff
+    /// unloaded, tab switched away). Prevents the user from being stuck
+    /// focusing a column that isn't rendered. Called at the top of
+    /// `ui::render` alongside `last_total_width` update.
+    pub fn normalize_active_panel(&mut self) {
+        if self.active_panel == Panel::Commit && !self.graph_uses_three_col() {
+            self.active_panel = Panel::Diff;
+        }
     }
 
     pub fn refresh_status(&mut self) {
@@ -1809,7 +1882,19 @@ impl App {
     /// Load the inline diff for a file inside the currently-selected commit
     /// or commit range. Routes to range-file-diff plumbing when a range is
     /// active so the diff baseline matches the file list.
+    ///
+    /// In 3-col mode the right column owns the diff, so picking a file also
+    /// moves focus there — the user's next arrow-key pans the viewport
+    /// instead of scrolling the commit metadata they were already looking at.
     pub fn load_commit_file_diff(&mut self, path: &str) {
+        // Move focus to the diff column so scroll keys target it after the
+        // click. Only when we're actually on the Graph tab — some paths
+        // (search restore) call this while on other tabs.
+        if self.active_tab == Tab::Graph
+            && self.last_total_width >= Self::GRAPH_THREE_COL_MIN_WIDTH
+        {
+            self.active_panel = Panel::Diff;
+        }
         let context = match self.commit_detail.diff_mode {
             DiffMode::Compact => 3,
             DiffMode::FullFile => 9999,
@@ -1831,6 +1916,10 @@ impl App {
             self.commit_detail.diff_h_scroll = 0;
             self.commit_detail.sbs_left_h_scroll = 0;
             self.commit_detail.sbs_right_h_scroll = 0;
+            self.commit_detail.file_diff_scroll = 0;
+            self.commit_detail.file_diff_h_scroll = 0;
+            self.commit_detail.file_diff_sbs_left_h_scroll = 0;
+            self.commit_detail.file_diff_sbs_right_h_scroll = 0;
         }
         if self.git_graph.is_range() {
             let Some(range) = self.commit_detail.range_detail.as_ref() else {
@@ -2728,6 +2817,9 @@ impl App {
             }
             ClickAction::StartDragSplit => {
                 self.dragging_split = true;
+            }
+            ClickAction::StartDragGraphDiffSplit => {
+                self.dragging_graph_diff_split = true;
             }
             ClickAction::GitCommand { command, args, .. } => {
                 // Try each panel's dispatcher in turn. Unknown commands are

--- a/src/app.rs
+++ b/src/app.rs
@@ -2006,8 +2006,7 @@ impl App {
         // Move focus to the diff column so scroll keys target it after the
         // click. Only when we're actually on the Graph tab — some paths
         // (search restore) call this while on other tabs.
-        if self.active_tab == Tab::Graph
-            && self.last_total_width >= Self::GRAPH_THREE_COL_MIN_WIDTH
+        if self.active_tab == Tab::Graph && self.last_total_width >= Self::GRAPH_THREE_COL_MIN_WIDTH
         {
             self.active_panel = Panel::Diff;
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -320,6 +320,12 @@ pub struct App {
     pub file_scroll: usize,
     pub diff_scroll: usize,
     pub diff_h_scroll: usize,
+    /// SBS 模式下左右列各自的横向滚动偏移。Unified 模式用 `diff_h_scroll`,
+    /// 切到 SBS 时两列独立滚动 —— 旧版本 / 新版本的行宽差异常常较大,
+    /// 独立滚比同步滚更符合直觉。键盘 ←/→ 同步两侧,鼠标滚按光标所在
+    /// 侧路由到其中一个。语义跟 `commit_detail.sbs_left_h_scroll` 一致。
+    pub sbs_left_h_scroll: usize,
+    pub sbs_right_h_scroll: usize,
 
     // ── Files tab state ──
     pub file_tree: FileTree,
@@ -674,6 +680,8 @@ impl App {
             file_scroll: 0,
             diff_scroll: 0,
             diff_h_scroll: 0,
+            sbs_left_h_scroll: 0,
+            sbs_right_h_scroll: 0,
             file_tree,
             preview_content: None,
             image_picker,
@@ -1472,6 +1480,8 @@ impl App {
         });
         self.diff_scroll = 0;
         self.diff_h_scroll = 0;
+        self.sbs_left_h_scroll = 0;
+        self.sbs_right_h_scroll = 0;
         self.load_diff();
     }
 
@@ -1506,6 +1516,8 @@ impl App {
         };
         self.diff_scroll = 0;
         self.diff_h_scroll = 0;
+        self.sbs_left_h_scroll = 0;
+        self.sbs_right_h_scroll = 0;
         save_prefs(self.diff_layout, self.diff_mode);
     }
 
@@ -1516,6 +1528,8 @@ impl App {
         };
         self.diff_scroll = 0;
         self.diff_h_scroll = 0;
+        self.sbs_left_h_scroll = 0;
+        self.sbs_right_h_scroll = 0;
         self.load_diff();
         save_prefs(self.diff_layout, self.diff_mode);
     }
@@ -2913,6 +2927,8 @@ impl App {
         });
         self.diff_scroll = 0;
         self.diff_h_scroll = 0;
+        self.sbs_left_h_scroll = 0;
+        self.sbs_right_h_scroll = 0;
     }
 
     /// Called every frame: drain fs-watcher events and the push worker's

--- a/src/app.rs
+++ b/src/app.rs
@@ -648,6 +648,45 @@ pub struct PreviewHighlight {
     pub byte_range: std::ops::Range<usize>,
 }
 
+/// Pure predicate: does the Graph tab want 3-col layout given these
+/// inputs? Factored out so tests can exercise the switch matrix without
+/// instantiating a full `App`. `App::graph_uses_three_col` forwards here.
+pub(crate) fn compute_uses_three_col(
+    active_tab: Tab,
+    total_width: u16,
+    has_file_diff: bool,
+    load_in_flight: bool,
+) -> bool {
+    active_tab == Tab::Graph
+        && total_width >= App::GRAPH_THREE_COL_MIN_WIDTH
+        && (has_file_diff || load_in_flight)
+}
+
+/// Pure layout: left-sidebar width given the split percent. Kept free-
+/// standing so `ui::render`, hit-testing, and h-scroll routing share one
+/// definition; the `App::graph_sidebar_width` method forwards here.
+pub(crate) fn compute_sidebar_width(total_width: u16, split_percent: u16) -> u16 {
+    let raw = (total_width as u32 * split_percent as u32 / 100) as u16;
+    raw.max(10).min(total_width.saturating_sub(20))
+}
+
+/// Pure layout: 3-col widths `(graph, commit, diff)` summing to
+/// `total_width`. See `App::graph_three_col_widths` for caller rules.
+pub(crate) fn compute_three_col_widths(
+    total_width: u16,
+    split_percent: u16,
+    graph_diff_split_percent: u16,
+) -> (u16, u16, u16) {
+    let graph_w = compute_sidebar_width(total_width, split_percent);
+    let remainder = total_width.saturating_sub(graph_w);
+    let diff_w_raw = (remainder as u32 * graph_diff_split_percent as u32 / 100) as u16;
+    // `.max(20)` + `.min(remainder - 20)` keeps both sub-columns usable
+    // even when `graph_diff_split_percent` hits its drag clamp edges.
+    let diff_w = diff_w_raw.max(20).min(remainder.saturating_sub(20));
+    let commit_w = remainder.saturating_sub(diff_w);
+    (graph_w, commit_w, diff_w)
+}
+
 impl App {
     /// Local-backend entry point. Threads `image_picker` straight through
     /// to `new_with_backend`. Tests construct via `new(Theme::dark(), None)`;
@@ -839,6 +878,31 @@ impl App {
     /// diff column has at least ~40 cols for content after its gutter.
     pub const GRAPH_THREE_COL_MIN_WIDTH: u16 = 100;
 
+    /// Width of the left (graph / tree / status) sidebar for the current
+    /// frame. Single source of truth for the `split_percent → columns`
+    /// clamp so `ui::render`, mouse hit-testing, and h-scroll routing
+    /// never disagree about where the boundary is. Mirror of the
+    /// `.max(10).min(total - 20)` clamp `ui::render` has applied since
+    /// v0 — factored here so `input::*` and the render stay aligned
+    /// even when `split_percent` lands near the extremes.
+    pub fn graph_sidebar_width(&self, total_width: u16) -> u16 {
+        compute_sidebar_width(total_width, self.split_percent)
+    }
+
+    /// Widths for the Graph 3-col layout: `(graph, commit, diff)`. Sum
+    /// equals `total_width`. Only meaningful when `graph_uses_three_col()`
+    /// is true; callers outside the render path should gate on that
+    /// first. The `(20, 20)` floors keep both right-side columns usable
+    /// when either `split_percent` or `graph_diff_split_percent` is
+    /// near its edge — matches `ui::render`'s constraint math.
+    pub fn graph_three_col_widths(&self, total_width: u16) -> (u16, u16, u16) {
+        compute_three_col_widths(
+            total_width,
+            self.split_percent,
+            self.graph_diff_split_percent,
+        )
+    }
+
     /// Whether the Graph tab should render with 3 columns right now —
     /// graph | commit metadata+files | diff. True when a file diff is
     /// loaded (or currently loading) AND the terminal is wide enough.
@@ -849,9 +913,12 @@ impl App {
     /// resolution, panel normalization) should read `last_total_width`
     /// — `ui::render` caches it every frame before any panel runs.
     pub fn graph_uses_three_col(&self) -> bool {
-        self.active_tab == Tab::Graph
-            && self.last_total_width >= Self::GRAPH_THREE_COL_MIN_WIDTH
-            && (self.commit_detail.file_diff.is_some() || self.commit_file_diff_load.loading)
+        compute_uses_three_col(
+            self.active_tab,
+            self.last_total_width,
+            self.commit_detail.file_diff.is_some(),
+            self.commit_file_diff_load.loading,
+        )
     }
 
     /// Drop `Panel::Commit` back to a two-column-compatible panel when the
@@ -3463,5 +3530,114 @@ mod tests {
         // which makes an empty target a safe no-op rather than a
         // "revert everything" footgun.
         assert!(!folder_contains("", "anything.rs"));
+    }
+
+    // ── Graph layout math ────────────────────────────────────────────────
+
+    use super::{Tab, compute_sidebar_width, compute_three_col_widths, compute_uses_three_col};
+
+    // ── graph_uses_three_col switch matrix ───────────────────────────────
+
+    #[test]
+    fn uses_three_col_needs_graph_tab() {
+        // Exact same inputs, only the tab changes — 3-col is Graph-only.
+        assert!(compute_uses_three_col(Tab::Graph, 200, true, false));
+        assert!(!compute_uses_three_col(Tab::Git, 200, true, false));
+        assert!(!compute_uses_three_col(Tab::Files, 200, true, false));
+        assert!(!compute_uses_three_col(Tab::Search, 200, true, false));
+    }
+
+    #[test]
+    fn uses_three_col_needs_min_width() {
+        // 99 cols → below `GRAPH_THREE_COL_MIN_WIDTH` (100) → 2-col fallback.
+        assert!(!compute_uses_three_col(Tab::Graph, 99, true, false));
+        assert!(compute_uses_three_col(Tab::Graph, 100, true, false));
+    }
+
+    #[test]
+    fn uses_three_col_needs_file_diff_or_loading() {
+        // Graph tab + wide terminal but nothing to show in the diff column.
+        assert!(!compute_uses_three_col(Tab::Graph, 200, false, false));
+        // Either flag on activates 3-col.
+        assert!(compute_uses_three_col(Tab::Graph, 200, true, false));
+        assert!(compute_uses_three_col(Tab::Graph, 200, false, true));
+        // Loading-in-flight during a file click: 3-col stays active so the
+        // "loading…" banner renders where the diff will land instead of
+        // flashing 2-col for a frame.
+    }
+
+    #[test]
+    fn sidebar_width_clamps_min_10() {
+        // split_percent = 5 → raw = 5 → floor at 10.
+        assert_eq!(compute_sidebar_width(100, 5), 10);
+    }
+
+    #[test]
+    fn sidebar_width_clamps_to_leave_20_for_right() {
+        // split_percent = 95 on width 100 → raw = 95, but right panel
+        // needs at least 20 cols → clamp to 80.
+        assert_eq!(compute_sidebar_width(100, 95), 80);
+    }
+
+    #[test]
+    fn sidebar_width_passes_mid_range_through() {
+        // Default 30% on a generous terminal.
+        assert_eq!(compute_sidebar_width(200, 30), 60);
+    }
+
+    #[test]
+    fn three_col_widths_sum_to_total() {
+        // Regression guard: if the rounding ever changes, the assert below
+        // pins the invariant `graph + commit + diff == total_width`. Hit-
+        // testing + h-scroll routing rely on this exactly.
+        let (g, c, d) = compute_three_col_widths(200, 30, 60);
+        assert_eq!(g + c + d, 200);
+    }
+
+    #[test]
+    fn three_col_widths_diff_floor_20() {
+        // graph_diff_split_percent = 0 shouldn't squeeze diff to 0 —
+        // `.max(20)` keeps it usable.
+        let (_, _, d) = compute_three_col_widths(200, 30, 0);
+        assert!(d >= 20, "diff col floored at 20, got {d}");
+    }
+
+    #[test]
+    fn three_col_widths_commit_floor_20() {
+        // graph_diff_split_percent = 100 shouldn't squeeze commit to 0 —
+        // `.min(remainder - 20)` leaves commit at least 20 cols.
+        let (_, c, _) = compute_three_col_widths(200, 30, 100);
+        assert!(c >= 20, "commit col floored at 20, got {c}");
+    }
+
+    #[test]
+    fn three_col_widths_default_proportions() {
+        // Default tuning: split_percent=30, graph_diff_split_percent=60
+        // on a 200-wide terminal. Sanity-check the split feels right.
+        let (g, c, d) = compute_three_col_widths(200, 30, 60);
+        assert_eq!(g, 60);
+        // remainder = 140, diff = 60% of 140 = 84, commit = 56.
+        assert_eq!(d, 84);
+        assert_eq!(c, 56);
+    }
+
+    #[test]
+    fn three_col_widths_at_min_terminal_width() {
+        // At the 100-col 3-col threshold the floors kick in hard:
+        // graph = 30, remainder = 70, diff = 42 (rounded from 60% * 70),
+        // commit = 28. All columns remain ≥ 20.
+        let (g, c, d) = compute_three_col_widths(100, 30, 60);
+        assert_eq!(g + c + d, 100);
+        assert!(c >= 20 && d >= 20, "both right cols ≥ 20: c={c} d={d}");
+    }
+
+    #[test]
+    fn three_col_widths_share_sidebar_with_2col() {
+        // Whether the UI ends up in 2-col or 3-col, the graph sidebar
+        // width is the same value. `graph_diff_column_start` and
+        // `focus_panel_under_cursor` depend on this.
+        let sidebar_2 = compute_sidebar_width(150, 30);
+        let (graph_3, _, _) = compute_three_col_widths(150, 30, 60);
+        assert_eq!(sidebar_2, graph_3);
     }
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -105,6 +105,7 @@ pub enum Msg {
 
     // Diff panel
     DiffEmpty,
+    DiffLoading,
     PreviewEmpty,
     PreviewImageUnavailable,
     PreviewLoading,
@@ -235,6 +236,7 @@ fn t_zh(m: Msg) -> &'static str {
         CommitHint => "(Ctrl+Enter 提交 · Esc 取消)",
         CommitNothingStaged => "没有可提交的已暂存文件",
         DiffEmpty => "选择一个文件查看 diff",
+        DiffLoading => "diff 载入中…",
         PreviewEmpty => "选择一个文件预览内容",
         PreviewImageUnavailable => "当前终端不支持图片预览",
         PreviewLoading => "加载中…",
@@ -350,6 +352,7 @@ fn t_en(m: Msg) -> &'static str {
         CommitHint => "(Ctrl+Enter to commit · Esc to cancel)",
         CommitNothingStaged => "Nothing staged to commit",
         DiffEmpty => "Select a file to view diff",
+        DiffLoading => "Loading diff…",
         PreviewEmpty => "Select a file to preview",
         PreviewImageUnavailable => "image preview unavailable in this terminal",
         PreviewLoading => "loading…",

--- a/src/input.rs
+++ b/src/input.rs
@@ -2040,6 +2040,14 @@ fn mouse_to_file_coord(
     Some((file_line, byte_offset))
 }
 
+/// `true` when a cursor at `column` lands on the left half of an SBS panel
+/// spanning `[panel_start, panel_start + panel_w)`. Shared between the Git
+/// and Graph SBS routing so they can't drift apart.
+fn sbs_cursor_on_left(panel_start: u16, panel_w: u16, column: u16) -> bool {
+    let panel_mid = panel_start.saturating_add(panel_w / 2);
+    column < panel_mid
+}
+
 /// Apply a horizontal-scroll delta (in display columns) to whichever panel
 /// the cursor sits over. Routed from Shift+wheel, trackpad ScrollLeft/Right,
 /// and bare ← / → keys. Tab::Search is the only tab whose LEFT panel also
@@ -2062,10 +2070,8 @@ fn apply_horizontal_scroll(app: &mut App, column: u16, total_width: u16, delta: 
             // line widths often diverge — rename, large rewrite). Route
             // to whichever side the cursor sits over.
             crate::app::DiffLayout::SideBySide => {
-                let panel_start = split_x;
-                let panel_w = total_width.saturating_sub(panel_start);
-                let panel_mid = panel_start.saturating_add(panel_w / 2);
-                if column < panel_mid {
+                let panel_w = total_width.saturating_sub(split_x);
+                if sbs_cursor_on_left(split_x, panel_w, column) {
                     Some(&mut app.sbs_left_h_scroll)
                 } else {
                     Some(&mut app.sbs_right_h_scroll)
@@ -2097,8 +2103,7 @@ fn apply_horizontal_scroll(app: &mut App, column: u16, total_width: u16, delta: 
                             &mut app.commit_detail.file_diff_sbs_right_h_scroll,
                         )
                     } else {
-                        let panel_end = diff_start;
-                        let panel_w = panel_end.saturating_sub(split_x);
+                        let panel_w = diff_start.saturating_sub(split_x);
                         (
                             split_x,
                             panel_w,
@@ -2106,8 +2111,7 @@ fn apply_horizontal_scroll(app: &mut App, column: u16, total_width: u16, delta: 
                             &mut app.commit_detail.sbs_right_h_scroll,
                         )
                     };
-                    let panel_mid = panel_start.saturating_add(panel_w / 2);
-                    if column < panel_mid {
+                    if sbs_cursor_on_left(panel_start, panel_w, column) {
                         Some(left_h)
                     } else {
                         Some(right_h)

--- a/src/input.rs
+++ b/src/input.rs
@@ -247,9 +247,20 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
             return;
         }
         KeyCode::BackTab => {
-            app.active_panel = match app.active_panel {
-                Panel::Files => Panel::Diff,
-                Panel::Diff => Panel::Files,
+            // Graph tab 3-col cycles Files → Commit → Diff → Files so
+            // Shift+Tab reaches the new middle column. Other tabs (and the
+            // Graph 2-col fallback) keep the two-way toggle.
+            app.active_panel = if app.graph_uses_three_col() {
+                match app.active_panel {
+                    Panel::Files => Panel::Commit,
+                    Panel::Commit => Panel::Diff,
+                    Panel::Diff => Panel::Files,
+                }
+            } else {
+                match app.active_panel {
+                    Panel::Files | Panel::Commit => Panel::Diff,
+                    Panel::Diff => Panel::Files,
+                }
             };
             app.search.clear();
             return;
@@ -366,6 +377,10 @@ fn handle_key_search(key: KeyEvent, app: &mut App) {
                 handle_key_search_list_mode(key, app, ctrl);
             }
         }
+        // Search tab has no middle column. `normalize_active_panel`
+        // demotes Commit elsewhere, but guard here in case a key lands
+        // mid-transition.
+        Panel::Commit => {}
         Panel::Diff => {
             // Preview panel on the right — same scrolling keys as the
             // Files-tab Diff panel. `/` is handled at the global level
@@ -650,6 +665,76 @@ fn handle_key_search_input_mode(key: KeyEvent, app: &mut App, ctrl: bool, alt: b
     }
 }
 
+/// Set `active_panel` based on which column the cursor hit. For tabs with
+/// only two columns this is a Files/Diff toggle; Graph 3-col adds a
+/// Commit variant for the middle column. Called on every Down(Left) so
+/// the user's subsequent arrow keys go to whatever they just clicked —
+/// matching the VSCode focus-follows-click behaviour, and avoiding the
+/// surprise where the scroll keys "aim" at a different column than the
+/// mouse just poked.
+fn focus_panel_under_cursor(app: &mut App, column: u16, total_width: u16) {
+    let graph_x = total_width * app.split_percent / 100;
+    if column < graph_x {
+        app.active_panel = Panel::Files;
+        return;
+    }
+    // Right of the graph split. 3-col Graph splits this further.
+    if let Some(diff_start) = graph_diff_column_start(app, total_width) {
+        if column >= diff_start {
+            app.active_panel = Panel::Diff;
+        } else {
+            app.active_panel = Panel::Commit;
+        }
+    } else {
+        app.active_panel = Panel::Diff;
+    }
+}
+
+/// Screen column where the Graph 3-col diff column starts, mirroring the
+/// layout math in `ui::render`. Returns `None` when the Graph tab isn't in
+/// 3-col mode (no standalone diff column), so callers can fall through to
+/// the 2-col routing. Stays in sync with `ui::render` by using the same
+/// floors/clamps — update both together if the ratio constants change.
+fn graph_diff_column_start(app: &App, total_width: u16) -> Option<u16> {
+    if !app.graph_uses_three_col() {
+        return None;
+    }
+    let graph_x = total_width * app.split_percent / 100;
+    let remainder = total_width.saturating_sub(graph_x);
+    let diff_w_raw = remainder as u32 * app.graph_diff_split_percent as u32 / 100;
+    let diff_w = (diff_w_raw as u16)
+        .max(20)
+        .min(remainder.saturating_sub(20));
+    Some(total_width.saturating_sub(diff_w))
+}
+
+/// Route a vertical-scroll delta to whichever Graph-tab panel currently
+/// owns focus. Panel::Files (the graph sidebar) is handled by the caller
+/// — its delta is tied to visual-mode extend vs graph navigation and
+/// doesn't reduce to a plain scroll. Panel::Commit always scrolls the
+/// commit-detail row list (metadata + files). Panel::Diff scrolls the
+/// standalone diff column in 3-col mode, or the whole commit-detail
+/// panel in 2-col fallback (where the diff is rendered inline).
+fn graph_scroll_right_panel(app: &mut App, delta: i32) {
+    use ui::commit_detail_panel;
+    match app.active_panel {
+        Panel::Files => {}
+        Panel::Commit => commit_detail_panel::scroll(app, delta),
+        Panel::Diff => {
+            if app.graph_uses_three_col() {
+                let s = &mut app.commit_detail.file_diff_scroll;
+                *s = if delta < 0 {
+                    s.saturating_sub((-delta) as usize)
+                } else {
+                    s.saturating_add(delta as usize)
+                };
+            } else {
+                commit_detail_panel::scroll(app, delta);
+            }
+        }
+    }
+}
+
 fn handle_key_graph(key: KeyEvent, app: &mut App) {
     use ui::{commit_detail_panel, git_graph_panel};
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
@@ -661,50 +746,54 @@ fn handle_key_graph(key: KeyEvent, app: &mut App) {
     // a convenience for terminals that *do* forward the modifier.
     let in_visual = app.git_graph.in_visual_mode() && app.active_panel == Panel::Files;
     match key.code {
-        KeyCode::Up | KeyCode::Char('k') if !ctrl => match app.active_panel {
-            Panel::Files => {
+        KeyCode::Up | KeyCode::Char('k') if !ctrl => {
+            if app.active_panel == Panel::Files {
                 if shift || in_visual {
                     app.extend_graph_selection(-1);
                 } else {
                     git_graph_panel::handle_key(app, "k");
                 }
+            } else {
+                graph_scroll_right_panel(app, -1);
             }
-            Panel::Diff => commit_detail_panel::scroll(app, -1),
-        },
-        KeyCode::Down | KeyCode::Char('j') if !ctrl => match app.active_panel {
-            Panel::Files => {
+        }
+        KeyCode::Down | KeyCode::Char('j') if !ctrl => {
+            if app.active_panel == Panel::Files {
                 if shift || in_visual {
                     app.extend_graph_selection(1);
                 } else {
                     git_graph_panel::handle_key(app, "j");
                 }
+            } else {
+                graph_scroll_right_panel(app, 1);
             }
-            Panel::Diff => commit_detail_panel::scroll(app, 1),
-        },
+        }
         // Readline-style nav aliases (parallel to what palettes and
         // Files/Git tabs bind).
-        KeyCode::Char('p' | 'k') if ctrl => match app.active_panel {
-            Panel::Files => {
+        KeyCode::Char('p' | 'k') if ctrl => {
+            if app.active_panel == Panel::Files {
                 if shift || in_visual {
                     app.extend_graph_selection(-1);
                 } else {
                     git_graph_panel::handle_key(app, "k");
                 }
+            } else {
+                graph_scroll_right_panel(app, -1);
             }
-            Panel::Diff => commit_detail_panel::scroll(app, -1),
-        },
-        KeyCode::Char('n' | 'j') if ctrl => match app.active_panel {
-            Panel::Files => {
+        }
+        KeyCode::Char('n' | 'j') if ctrl => {
+            if app.active_panel == Panel::Files {
                 if shift || in_visual {
                     app.extend_graph_selection(1);
                 } else {
                     git_graph_panel::handle_key(app, "j");
                 }
+            } else {
+                graph_scroll_right_panel(app, 1);
             }
-            Panel::Diff => commit_detail_panel::scroll(app, 1),
-        },
-        KeyCode::PageUp => match app.active_panel {
-            Panel::Files => {
+        }
+        KeyCode::PageUp => {
+            if app.active_panel == Panel::Files {
                 if shift || in_visual {
                     app.extend_graph_selection(-10);
                 } else {
@@ -712,11 +801,12 @@ fn handle_key_graph(key: KeyEvent, app: &mut App) {
                         git_graph_panel::handle_key(app, "k");
                     }
                 }
+            } else {
+                graph_scroll_right_panel(app, -20);
             }
-            Panel::Diff => commit_detail_panel::scroll(app, -20),
-        },
-        KeyCode::PageDown => match app.active_panel {
-            Panel::Files => {
+        }
+        KeyCode::PageDown => {
+            if app.active_panel == Panel::Files {
                 if shift || in_visual {
                     app.extend_graph_selection(10);
                 } else {
@@ -724,9 +814,10 @@ fn handle_key_graph(key: KeyEvent, app: &mut App) {
                         git_graph_panel::handle_key(app, "j");
                     }
                 }
+            } else {
+                graph_scroll_right_panel(app, 20);
             }
-            Panel::Diff => commit_detail_panel::scroll(app, 20),
-        },
+        }
         // `V` (uppercase = Shift+v) toggles visual mode. Entering: anchor
         // collapses onto the cursor (is_range() stays false until the user
         // actually extends), so the status bar can distinguish "armed but
@@ -902,13 +993,15 @@ fn handle_key_git(key: KeyEvent, app: &mut App) {
     match key.code {
         KeyCode::Up | KeyCode::Char('k') if !ctrl => match app.active_panel {
             Panel::Files => app.navigate_files(-1),
-            Panel::Diff => {
+            // Git tab has no middle column — Panel::Commit should never
+            // be set here, but if it slips through treat it as Diff.
+            Panel::Diff | Panel::Commit => {
                 app.diff_scroll = app.diff_scroll.saturating_sub(1);
             }
         },
         KeyCode::Down | KeyCode::Char('j') if !ctrl => match app.active_panel {
             Panel::Files => app.navigate_files(1),
-            Panel::Diff => {
+            Panel::Diff | Panel::Commit => {
                 app.diff_scroll += 1;
             }
         },
@@ -920,25 +1013,25 @@ fn handle_key_git(key: KeyEvent, app: &mut App) {
         // matched only if the Ctrl arm above didn't fire.
         KeyCode::Char('p' | 'k') if ctrl => match app.active_panel {
             Panel::Files => app.navigate_files(-1),
-            Panel::Diff => {
+            Panel::Diff | Panel::Commit => {
                 app.diff_scroll = app.diff_scroll.saturating_sub(1);
             }
         },
         KeyCode::Char('n' | 'j') if ctrl => match app.active_panel {
             Panel::Files => app.navigate_files(1),
-            Panel::Diff => {
+            Panel::Diff | Panel::Commit => {
                 app.diff_scroll += 1;
             }
         },
         KeyCode::PageUp => match app.active_panel {
             Panel::Files => app.navigate_files(-10),
-            Panel::Diff => {
+            Panel::Diff | Panel::Commit => {
                 app.diff_scroll = app.diff_scroll.saturating_sub(20);
             }
         },
         KeyCode::PageDown => match app.active_panel {
             Panel::Files => app.navigate_files(10),
-            Panel::Diff => {
+            Panel::Diff | Panel::Commit => {
                 app.diff_scroll += 20;
             }
         },
@@ -1028,7 +1121,9 @@ fn handle_key_files(key: KeyEvent, app: &mut App) {
                 app.file_tree.navigate(-1);
                 app.load_preview();
             }
-            Panel::Diff => {
+            // Files tab has no middle column — Panel::Commit should never
+            // be set here, but fall back to Diff behaviour defensively.
+            Panel::Diff | Panel::Commit => {
                 app.preview_scroll = app.preview_scroll.saturating_sub(1);
             }
         },
@@ -1037,7 +1132,7 @@ fn handle_key_files(key: KeyEvent, app: &mut App) {
                 app.file_tree.navigate(1);
                 app.load_preview();
             }
-            Panel::Diff => {
+            Panel::Diff | Panel::Commit => {
                 app.preview_scroll += 1;
             }
         },
@@ -1051,7 +1146,7 @@ fn handle_key_files(key: KeyEvent, app: &mut App) {
                 app.file_tree.navigate(-1);
                 app.load_preview();
             }
-            Panel::Diff => {
+            Panel::Diff | Panel::Commit => {
                 app.preview_scroll = app.preview_scroll.saturating_sub(1);
             }
         },
@@ -1060,7 +1155,7 @@ fn handle_key_files(key: KeyEvent, app: &mut App) {
                 app.file_tree.navigate(1);
                 app.load_preview();
             }
-            Panel::Diff => {
+            Panel::Diff | Panel::Commit => {
                 app.preview_scroll += 1;
             }
         },
@@ -1069,7 +1164,7 @@ fn handle_key_files(key: KeyEvent, app: &mut App) {
                 app.file_tree.navigate(-10);
                 app.load_preview();
             }
-            Panel::Diff => {
+            Panel::Diff | Panel::Commit => {
                 app.preview_scroll = app.preview_scroll.saturating_sub(20);
             }
         },
@@ -1078,7 +1173,7 @@ fn handle_key_files(key: KeyEvent, app: &mut App) {
                 app.file_tree.navigate(10);
                 app.load_preview();
             }
-            Panel::Diff => {
+            Panel::Diff | Panel::Commit => {
                 app.preview_scroll += 20;
             }
         },
@@ -1410,6 +1505,13 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
 
     match mouse.kind {
         MouseEventKind::Down(MouseButton::Left) => {
+            // Click-to-focus: land the active panel on whichever column
+            // the click landed in. VSCode-style — previously you had to
+            // Shift+Tab into a column before its arrows responded.
+            if let Ok(size) = terminal.size() {
+                focus_panel_under_cursor(app, mouse.column, size.width);
+            }
+
             let now = Instant::now();
             let is_double = matches!(
                 app.last_click,
@@ -1487,13 +1589,27 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
         }
         MouseEventKind::Up(MouseButton::Left) => {
             app.dragging_split = false;
+            app.dragging_graph_diff_split = false;
         }
         MouseEventKind::Drag(MouseButton::Left) => {
+            let total_width = terminal.size().map(|s| s.width).unwrap_or(80);
             if app.dragging_split {
-                let total_width = terminal.size().map(|s| s.width).unwrap_or(80);
                 if total_width > 0 {
                     let percent = (mouse.column * 100 / total_width).clamp(10, 80);
                     app.split_percent = percent;
+                }
+            } else if app.dragging_graph_diff_split && total_width > 0 {
+                // Boundary is inside the non-graph region. Express the drag
+                // position as the diff column's fraction of the remainder,
+                // measured from the right edge so "pull left" = grow diff.
+                let graph_x = total_width * app.split_percent / 100;
+                let remainder = total_width.saturating_sub(graph_x);
+                if remainder > 0 {
+                    let from_right = total_width.saturating_sub(mouse.column);
+                    let diff_pct = (from_right as u32 * 100 / remainder as u32) as u16;
+                    // Floor 20 / ceiling 80 keeps both sub-columns usable
+                    // and leaves room for drag to snap back either way.
+                    app.graph_diff_split_percent = diff_pct.clamp(20, 80);
                 }
             }
         }
@@ -1524,6 +1640,13 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
                 Tab::Graph => {
                     if is_left {
                         ui::git_graph_panel::scroll(app, -3);
+                    } else if let Some(diff_start) = graph_diff_column_start(app, total_width)
+                        && mouse.column >= diff_start
+                    {
+                        // 3-col diff column — scroll only the diff viewport
+                        // so commit metadata under the cursor's path stays put.
+                        app.commit_detail.file_diff_scroll =
+                            app.commit_detail.file_diff_scroll.saturating_sub(3);
                     } else {
                         ui::commit_detail_panel::scroll(app, -3);
                     }
@@ -1566,6 +1689,10 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
                 Tab::Graph => {
                     if is_left {
                         ui::git_graph_panel::scroll(app, 3);
+                    } else if let Some(diff_start) = graph_diff_column_start(app, total_width)
+                        && mouse.column >= diff_start
+                    {
+                        app.commit_detail.file_diff_scroll += 3;
                     } else {
                         ui::commit_detail_panel::scroll(app, 3);
                     }
@@ -1797,20 +1924,55 @@ fn apply_horizontal_scroll(app: &mut App, column: u16, total_width: u16, delta: 
         },
         (Tab::Search, false) => Some(&mut app.preview_h_scroll),
         (Tab::Graph, false) => {
-            // Graph's right panel is the commit detail. SBS layout splits
-            // that panel in half visually, and each half scrolls
-            // independently (old vs new version). Unified layout has one
-            // scroll for the whole panel.
+            // In 3-col mode the right portion is [commit | diff]; figure
+            // out which column the cursor sits over so h_scroll targets
+            // the right triad.
+            let three_col = app.graph_uses_three_col();
+            let diff_start = if three_col {
+                let remainder = total_width.saturating_sub(split_x);
+                let diff_w_raw = remainder as u32 * app.graph_diff_split_percent as u32 / 100;
+                let diff_w = (diff_w_raw as u16)
+                    .max(20)
+                    .min(remainder.saturating_sub(20));
+                total_width.saturating_sub(diff_w)
+            } else {
+                // No diff column — every column in the right portion is
+                // the commit-detail panel.
+                total_width
+            };
+            let in_diff_column = three_col && column >= diff_start;
             match app.commit_detail.diff_layout {
-                crate::app::DiffLayout::Unified => Some(&mut app.commit_detail.diff_h_scroll),
+                crate::app::DiffLayout::Unified => {
+                    if in_diff_column {
+                        Some(&mut app.commit_detail.file_diff_h_scroll)
+                    } else {
+                        Some(&mut app.commit_detail.diff_h_scroll)
+                    }
+                }
                 crate::app::DiffLayout::SideBySide => {
-                    let panel_start = split_x;
-                    let panel_w = total_width.saturating_sub(panel_start);
+                    let (panel_start, panel_w, left_h, right_h) = if in_diff_column {
+                        let panel_w = total_width.saturating_sub(diff_start);
+                        (
+                            diff_start,
+                            panel_w,
+                            &mut app.commit_detail.file_diff_sbs_left_h_scroll,
+                            &mut app.commit_detail.file_diff_sbs_right_h_scroll,
+                        )
+                    } else {
+                        let panel_end = diff_start;
+                        let panel_w = panel_end.saturating_sub(split_x);
+                        (
+                            split_x,
+                            panel_w,
+                            &mut app.commit_detail.sbs_left_h_scroll,
+                            &mut app.commit_detail.sbs_right_h_scroll,
+                        )
+                    };
                     let panel_mid = panel_start.saturating_add(panel_w / 2);
                     if column < panel_mid {
-                        Some(&mut app.commit_detail.sbs_left_h_scroll)
+                        Some(left_h)
                     } else {
-                        Some(&mut app.commit_detail.sbs_right_h_scroll)
+                        Some(right_h)
                     }
                 }
             }

--- a/src/input.rs
+++ b/src/input.rs
@@ -674,7 +674,7 @@ fn handle_key_search_input_mode(key: KeyEvent, app: &mut App, ctrl: bool, alt: b
 /// surprise where the scroll keys "aim" at a different column than the
 /// mouse just poked.
 fn focus_panel_under_cursor(app: &mut App, column: u16, total_width: u16) {
-    let graph_x = total_width * app.split_percent / 100;
+    let graph_x = app.graph_sidebar_width(total_width);
     if column < graph_x {
         app.active_panel = Panel::Files;
         return;
@@ -691,21 +691,15 @@ fn focus_panel_under_cursor(app: &mut App, column: u16, total_width: u16) {
     }
 }
 
-/// Screen column where the Graph 3-col diff column starts, mirroring the
-/// layout math in `ui::render`. Returns `None` when the Graph tab isn't in
-/// 3-col mode (no standalone diff column), so callers can fall through to
-/// the 2-col routing. Stays in sync with `ui::render` by using the same
-/// floors/clamps — update both together if the ratio constants change.
+/// Screen column where the Graph 3-col diff column starts. Returns `None`
+/// when the Graph tab isn't in 3-col mode so callers can fall through to
+/// the 2-col routing. Shares `App::graph_three_col_widths` with `ui::render`
+/// — the two paths can't drift apart.
 fn graph_diff_column_start(app: &App, total_width: u16) -> Option<u16> {
     if !app.graph_uses_three_col() {
         return None;
     }
-    let graph_x = total_width * app.split_percent / 100;
-    let remainder = total_width.saturating_sub(graph_x);
-    let diff_w_raw = remainder as u32 * app.graph_diff_split_percent as u32 / 100;
-    let diff_w = (diff_w_raw as u16)
-        .max(20)
-        .min(remainder.saturating_sub(20));
+    let (_, _, diff_w) = app.graph_three_col_widths(total_width);
     Some(total_width.saturating_sub(diff_w))
 }
 
@@ -1891,6 +1885,14 @@ fn handle_diff_selection(mouse: &MouseEvent, app: &mut App) -> bool {
                 return false;
             };
 
+            // Focus follows the click — otherwise the user is stuck
+            // scrolling the panel they came from (common in Graph 3-col:
+            // start on Panel::Commit, click into diff, expect arrows to
+            // pan the diff). Mirror of `focus_panel_under_cursor` but
+            // local — the main-dispatcher version never runs because
+            // this handler returns early on Down.
+            app.active_panel = Panel::Diff;
+
             // Advance (or reset) the click counter — same 400 ms window as
             // the preview panel so users get consistent double/triple-click
             // timing across both surfaces.
@@ -2044,7 +2046,9 @@ fn mouse_to_file_coord(
 /// h-scrolls (the results list) — other tabs' left panels are tree/list
 /// widgets with no long horizontal content.
 fn apply_horizontal_scroll(app: &mut App, column: u16, total_width: u16, delta: i32) {
-    let split_x = total_width * app.split_percent / 100;
+    // Use the shared sidebar clamp so this matches `ui::render` even when
+    // `split_percent` lives near its edges on narrow terminals.
+    let split_x = app.graph_sidebar_width(total_width);
     let is_left = column < split_x;
 
     let target: Option<&mut usize> = match (app.active_tab, is_left) {
@@ -2073,20 +2077,8 @@ fn apply_horizontal_scroll(app: &mut App, column: u16, total_width: u16, delta: 
             // In 3-col mode the right portion is [commit | diff]; figure
             // out which column the cursor sits over so h_scroll targets
             // the right triad.
-            let three_col = app.graph_uses_three_col();
-            let diff_start = if three_col {
-                let remainder = total_width.saturating_sub(split_x);
-                let diff_w_raw = remainder as u32 * app.graph_diff_split_percent as u32 / 100;
-                let diff_w = (diff_w_raw as u16)
-                    .max(20)
-                    .min(remainder.saturating_sub(20));
-                total_width.saturating_sub(diff_w)
-            } else {
-                // No diff column — every column in the right portion is
-                // the commit-detail panel.
-                total_width
-            };
-            let in_diff_column = three_col && column >= diff_start;
+            let diff_start = graph_diff_column_start(app, total_width).unwrap_or(total_width);
+            let in_diff_column = diff_start < total_width && column >= diff_start;
             match app.commit_detail.diff_layout {
                 crate::app::DiffLayout::Unified => {
                     if in_diff_column {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1980,11 +1980,7 @@ fn handle_diff_selection(mouse: &MouseEvent, app: &mut App) -> bool {
 /// Clamp `col` into the content range of the given SBS side so drag-
 /// through-divider doesn't bleed the selection onto the other half.
 /// In Unified layout there's nothing to clamp and `col` passes through.
-fn clamp_col_to_side(
-    hit: &crate::ui::selection::DiffHit,
-    col: u16,
-    side: DiffSide,
-) -> u16 {
+fn clamp_col_to_side(hit: &crate::ui::selection::DiffHit, col: u16, side: DiffSide) -> u16 {
     match (hit.layout, side) {
         (crate::app::DiffLayout::Unified, _) => col,
         (crate::app::DiffLayout::SideBySide, DiffSide::Unified) => col,
@@ -1994,9 +1990,7 @@ fn clamp_col_to_side(
             // on the left half's last content column.
             col.min(hit.right_start_x.saturating_sub(1))
         }
-        (crate::app::DiffLayout::SideBySide, DiffSide::SbsRight) => {
-            col.max(hit.right_start_x)
-        }
+        (crate::app::DiffLayout::SideBySide, DiffSide::SbsRight) => col.max(hit.right_start_x),
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -16,7 +16,8 @@ use crate::quick_open;
 use crate::search;
 use crate::ui;
 use crate::ui::selection::{
-    PreviewSelection, col_to_byte_offset, collect_selected_text, word_at_byte,
+    DiffSelection, DiffSide, PreviewSelection, col_to_byte_offset, collect_diff_selected_text,
+    collect_selected_text, word_at_byte,
 };
 use crate::ui::toast::Toast;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
@@ -1502,6 +1503,13 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
     if handle_preview_selection(&mouse, app) {
         return;
     }
+    // Diff-panel selection gets the same priority as preview: Down inside
+    // the cached diff rect owns the drag through Up, even if the cursor
+    // later leaves the panel. Wheel / right-click / Down outside fall
+    // through below.
+    if handle_diff_selection(&mouse, app) {
+        return;
+    }
 
     match mouse.kind {
         MouseEventKind::Down(MouseButton::Left) => {
@@ -1849,6 +1857,144 @@ fn handle_preview_selection(mouse: &MouseEvent, app: &mut App) -> bool {
             true
         }
         _ => false,
+    }
+}
+
+/// Drive in-panel text selection on the diff panel. Returns `true` when
+/// the mouse event was consumed. Mirrors `handle_preview_selection` shape —
+/// click levels, anchor-drag-extend-on-Drag, copy-on-Up — but works on the
+/// flattened display-row list in `DiffHit` instead of file lines.
+///
+/// SBS side lock: the Down gesture picks a side (left/right of the divider,
+/// or `Unified` in unified layout) and stores it with the selection. A
+/// subsequent Drag clamps the cursor column into that side's content area
+/// before translating to byte offsets, so crossing the divider extends
+/// vertically along the anchored side instead of flipping. Matches VSCode's
+/// diff editor.
+fn handle_diff_selection(mouse: &MouseEvent, app: &mut App) -> bool {
+    let Some(rect) = app.last_diff_rect else {
+        return false;
+    };
+    match mouse.kind {
+        MouseEventKind::Down(MouseButton::Left) => {
+            if !point_in_rect(rect, mouse.column, mouse.row) {
+                return false;
+            }
+            let Some(hit) = app.last_diff_hit.as_ref() else {
+                return false;
+            };
+            if hit.rows.is_empty() {
+                return false;
+            }
+            let side = hit.side_for_column(mouse.column);
+            let Some((row_idx, byte_offset)) = hit.coord_for(mouse.column, mouse.row, side) else {
+                return false;
+            };
+
+            // Advance (or reset) the click counter — same 400 ms window as
+            // the preview panel so users get consistent double/triple-click
+            // timing across both surfaces.
+            let now = Instant::now();
+            let click_count = if let Some((t, c, r, n)) = app.diff_click_state {
+                if c == mouse.column
+                    && r == mouse.row
+                    && now.duration_since(t) < DOUBLE_CLICK_WINDOW
+                {
+                    (n + 1).min(3)
+                } else {
+                    1
+                }
+            } else {
+                1
+            };
+            app.diff_click_state = Some((now, mouse.column, mouse.row, click_count));
+
+            let row_text = hit.rows[row_idx].text_for(side).to_string();
+            let sel = match click_count {
+                2 => {
+                    let word = word_at_byte(&row_text, byte_offset);
+                    PreviewSelection {
+                        anchor: (row_idx, word.start),
+                        active: (row_idx, word.end),
+                        dragging: true,
+                    }
+                }
+                3 => PreviewSelection {
+                    anchor: (row_idx, 0),
+                    active: (row_idx, row_text.len()),
+                    dragging: true,
+                },
+                _ => PreviewSelection::new((row_idx, byte_offset)),
+            };
+            app.diff_selection = Some(DiffSelection { sel, side });
+            true
+        }
+        MouseEventKind::Drag(MouseButton::Left) => {
+            let dragging = app.diff_selection.is_some_and(|s| s.sel.dragging);
+            if !dragging {
+                return false;
+            }
+            let Some(hit) = app.last_diff_hit.as_ref() else {
+                return true;
+            };
+            let side = app.diff_selection.unwrap().side;
+            // Clamp the cursor column back into the anchor's side before
+            // translating — this is the SBS side-lock. In Unified the
+            // clamp is a no-op (no divider).
+            let clamped_col = clamp_col_to_side(hit, mouse.column, side);
+            if let Some(pos) = hit.coord_for(clamped_col, mouse.row, side) {
+                if let Some(s) = app.diff_selection.as_mut() {
+                    s.sel.active = pos;
+                }
+            }
+            true
+        }
+        MouseEventKind::Up(MouseButton::Left) => {
+            let Some(sel) = app.diff_selection.as_mut() else {
+                return false;
+            };
+            if !sel.sel.dragging {
+                return false;
+            }
+            sel.sel.dragging = false;
+            let snap = *sel;
+            if !snap.sel.is_empty() {
+                if let Some(hit) = app.last_diff_hit.as_ref() {
+                    let text = collect_diff_selected_text(hit, &snap);
+                    if !text.is_empty() {
+                        match clipboard::copy_to_clipboard(&text) {
+                            Ok(()) => app.toasts.push(Toast::info(t(Msg::ClipboardCopied))),
+                            Err(_) => app.toasts.push(Toast::error(t(Msg::ClipboardCopyFailed))),
+                        }
+                    }
+                }
+            }
+            true
+        }
+        _ => false,
+    }
+}
+
+/// Clamp `col` into the content range of the given SBS side so drag-
+/// through-divider doesn't bleed the selection onto the other half.
+/// In Unified layout there's nothing to clamp and `col` passes through.
+fn clamp_col_to_side(
+    hit: &crate::ui::selection::DiffHit,
+    col: u16,
+    side: DiffSide,
+) -> u16 {
+    match (hit.layout, side) {
+        (crate::app::DiffLayout::Unified, _) => col,
+        (crate::app::DiffLayout::SideBySide, DiffSide::Unified) => col,
+        (crate::app::DiffLayout::SideBySide, DiffSide::SbsLeft) => {
+            // Right edge of the left half is just before `right_start_x`
+            // (which is the divider column). `saturating_sub(1)` keeps us
+            // on the left half's last content column.
+            col.min(hit.right_start_x.saturating_sub(1))
+        }
+        (crate::app::DiffLayout::SideBySide, DiffSide::SbsRight) => {
+            col.max(hit.right_start_x)
+        }
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -948,7 +948,12 @@ fn handle_key_git(key: KeyEvent, app: &mut App) {
             } else {
                 1
             };
+            // SBS mode: keyboard pans both halves in lockstep — the user
+            // has no mouse-column to disambiguate. Mouse scroll keeps the
+            // per-side route from `apply_horizontal_scroll`.
             app.diff_h_scroll = app.diff_h_scroll.saturating_sub(step);
+            app.sbs_left_h_scroll = app.sbs_left_h_scroll.saturating_sub(step);
+            app.sbs_right_h_scroll = app.sbs_right_h_scroll.saturating_sub(step);
         }
         KeyCode::Right if app.active_panel == Panel::Diff => {
             let step = if key.modifiers.contains(KeyModifiers::SHIFT) {
@@ -957,12 +962,19 @@ fn handle_key_git(key: KeyEvent, app: &mut App) {
                 1
             };
             app.diff_h_scroll = app.diff_h_scroll.saturating_add(step);
+            app.sbs_left_h_scroll = app.sbs_left_h_scroll.saturating_add(step);
+            app.sbs_right_h_scroll = app.sbs_right_h_scroll.saturating_add(step);
         }
         KeyCode::Home if app.active_panel == Panel::Diff => {
             app.diff_h_scroll = 0;
+            app.sbs_left_h_scroll = 0;
+            app.sbs_right_h_scroll = 0;
         }
         KeyCode::End if app.active_panel == Panel::Diff => {
-            app.diff_h_scroll = usize::MAX; // render 自动钳到实际最大值
+            // render 自动钳到实际最大值
+            app.diff_h_scroll = usize::MAX;
+            app.sbs_left_h_scroll = usize::MAX;
+            app.sbs_right_h_scroll = usize::MAX;
         }
         KeyCode::Char('s') => {
             ui::git_status_panel::handle_key(app, "s");
@@ -1766,7 +1778,23 @@ fn apply_horizontal_scroll(app: &mut App, column: u16, total_width: u16, delta: 
         (Tab::Search, true) => Some(&mut app.global_search.results_h_scroll),
         (_, true) => None,
         (Tab::Files, false) => Some(&mut app.preview_h_scroll),
-        (Tab::Git, false) => Some(&mut app.diff_h_scroll),
+        (Tab::Git, false) => match app.diff_layout {
+            // Unified: one h_scroll applies to the whole content column.
+            crate::app::DiffLayout::Unified => Some(&mut app.diff_h_scroll),
+            // SBS: each half scrolls independently (old vs new version
+            // line widths often diverge — rename, large rewrite). Route
+            // to whichever side the cursor sits over.
+            crate::app::DiffLayout::SideBySide => {
+                let panel_start = split_x;
+                let panel_w = total_width.saturating_sub(panel_start);
+                let panel_mid = panel_start.saturating_add(panel_w / 2);
+                if column < panel_mid {
+                    Some(&mut app.sbs_left_h_scroll)
+                } else {
+                    Some(&mut app.sbs_right_h_scroll)
+                }
+            }
+        },
         (Tab::Search, false) => Some(&mut app.preview_h_scroll),
         (Tab::Graph, false) => {
             // Graph's right panel is the commit detail. SBS layout splits

--- a/src/search.rs
+++ b/src/search.rs
@@ -23,6 +23,11 @@ pub enum SearchTarget {
     FilePreview,
     Diff,
     CommitDetail,
+    /// Graph tab 三列布局下右侧 diff 栏的 `/` 搜索目标。行索引对齐
+    /// `unified_display_rows(&file_diff.diff)`——和 Git tab 的
+    /// `SearchTarget::Diff` 同款 —— 这样渲染层的 `ranges_on_row` 直接拿
+    /// 到匹配区间,跟 `diff_panel::render_diff` 的行号系统无缝对接。
+    GraphDiff,
 }
 
 #[derive(Debug, Clone)]
@@ -39,6 +44,8 @@ pub struct Snapshot {
     pub diff_scroll: usize,
     pub diff_h_scroll: usize,
     pub commit_detail_scroll: usize,
+    /// Pre-search scroll for the Graph-tab 3-col diff column (restored on Esc).
+    pub graph_diff_scroll: usize,
     pub file_tree_selected: usize,
     pub tree_scroll: usize,
     pub git_status_scroll: usize,
@@ -310,7 +317,25 @@ fn resolve_target(app: &App) -> Option<SearchTarget> {
         (Tab::Git, Panel::Files) => Some(SearchTarget::GitStatus),
         (Tab::Git, Panel::Diff) => Some(SearchTarget::Diff),
         (Tab::Graph, Panel::Files) => Some(SearchTarget::CommitGraph),
-        (Tab::Graph, Panel::Diff) => Some(SearchTarget::CommitDetail),
+        // Graph middle column (3-col only) = commit metadata + file tree.
+        // Same target as the 2-col fallback; `collect_rows` decides whether
+        // inline diff rows are included based on `app.graph_uses_three_col`.
+        (Tab::Graph, Panel::Commit) => Some(SearchTarget::CommitDetail),
+        (Tab::Graph, Panel::Diff) => {
+            // In 3-col mode, the diff owns its own column with its own
+            // row indexing (matches `unified_display_rows(&file_diff.diff)`).
+            // In 2-col fallback the diff is inline so we fall through to
+            // CommitDetail, which already covers it.
+            if app.graph_uses_three_col() {
+                Some(SearchTarget::GraphDiff)
+            } else {
+                Some(SearchTarget::CommitDetail)
+            }
+        }
+        // `Panel::Commit` outside Graph tab should never happen (only Graph
+        // sets it, and `normalize_active_panel` demotes it otherwise). Treat
+        // it defensively as "no search" rather than panicking.
+        (_, Panel::Commit) => None,
         // Left panel of the Search tab is already a search input — `/` there
         // would be ambiguous, so it's a no-op for now. Right panel mirrors
         // Files-tab preview.
@@ -365,10 +390,20 @@ fn collect_rows(app: &App, target: SearchTarget) -> Vec<String> {
             Some(d) => unified_display_rows(&d.diff),
             None => Vec::new(),
         },
+        SearchTarget::GraphDiff => match &app.commit_detail.file_diff {
+            // Graph tab 3-col diff column — same row layout as the Git tab's
+            // diff panel, just sourced from `commit_detail.file_diff` instead
+            // of `app.diff_content`.
+            Some(d) => unified_display_rows(&d.diff),
+            None => Vec::new(),
+        },
         SearchTarget::CommitDetail => {
             // Delegate to the panel so row indices line up 1:1 with what the
-            // panel renders (header rows, message lines, file rows, diff rows,
-            // …). This keeps scroll-jump and match-highlight coordinates in sync.
+            // panel renders (header rows, message lines, file rows, and — in
+            // 2-col fallback only — inline diff rows). The panel's
+            // `searchable_rows` consults `graph_uses_three_col` and skips
+            // inline diff rows in 3-col mode so match coordinates stay
+            // aligned with what's actually rendered under Panel::Commit.
             crate::ui::commit_detail_panel::searchable_rows(app)
         }
     }
@@ -495,6 +530,7 @@ fn baseline_row(target: SearchTarget, snap: &Snapshot) -> usize {
         SearchTarget::CommitGraph => snap.git_graph_selected_idx,
         SearchTarget::FilePreview => snap.preview_scroll,
         SearchTarget::Diff => snap.diff_scroll,
+        SearchTarget::GraphDiff => snap.graph_diff_scroll,
         SearchTarget::CommitDetail => snap.commit_detail_scroll,
     }
 }
@@ -508,6 +544,7 @@ fn take_snapshot(app: &App) -> Snapshot {
         diff_scroll: app.diff_scroll,
         diff_h_scroll: app.diff_h_scroll,
         commit_detail_scroll: app.commit_detail.scroll,
+        graph_diff_scroll: app.commit_detail.file_diff_scroll,
         file_tree_selected: app.file_tree.selected,
         tree_scroll: app.tree_scroll,
         git_status_scroll: app.git_status.scroll,
@@ -523,6 +560,7 @@ fn restore_snapshot(app: &mut App, snap: &Snapshot) {
     app.diff_scroll = snap.diff_scroll;
     app.diff_h_scroll = snap.diff_h_scroll;
     app.commit_detail.scroll = snap.commit_detail_scroll;
+    app.commit_detail.file_diff_scroll = snap.graph_diff_scroll;
     app.file_tree.selected = snap.file_tree_selected;
     app.tree_scroll = snap.tree_scroll;
     app.git_status.scroll = snap.git_status_scroll;
@@ -602,6 +640,13 @@ fn jump_to_current(app: &mut App) {
         SearchTarget::Diff => {
             let view_h = app.last_diff_view_h as usize;
             app.diff_scroll = center_scroll(m.row, view_h);
+        }
+        SearchTarget::GraphDiff => {
+            // The 3-col diff column writes its own view height to the shared
+            // `last_diff_view_h` slot at render time (same field the Git tab
+            // uses — only one of the two panels is visible at once).
+            let view_h = app.last_diff_view_h as usize;
+            app.commit_detail.file_diff_scroll = center_scroll(m.row, view_h);
         }
         SearchTarget::CommitDetail => {
             let view_h = app.last_commit_detail_view_h as usize;

--- a/src/ui/commit_detail_panel.rs
+++ b/src/ui/commit_detail_panel.rs
@@ -680,7 +680,14 @@ fn build_rows(app: &App, width: u16, display_w: u16, theme: &Theme) -> Vec<Row> 
         }
     }
 
-    if let Some(file_diff) = &cd.file_diff {
+    // Inline diff section: only rendered in the 2-col fallback. When the
+    // Graph tab is in 3-col mode the diff lives in its own right column
+    // (rendered by `ui::mod::render_graph_diff_column`), so skipping it
+    // here avoids a stale duplicate row list and shrinks `scroll`'s clamp
+    // back to just metadata + files.
+    if !app.graph_uses_three_col()
+        && let Some(file_diff) = &cd.file_diff
+    {
         rows.push(Row::blank());
         rows.push(diff_header_row(
             &file_diff.path,

--- a/src/ui/commit_detail_panel.rs
+++ b/src/ui/commit_detail_panel.rs
@@ -680,11 +680,8 @@ fn build_rows(app: &App, width: u16, display_w: u16, theme: &Theme) -> Vec<Row> 
         }
     }
 
-    // Inline diff section: only rendered in the 2-col fallback. When the
-    // Graph tab is in 3-col mode the diff lives in its own right column
-    // (rendered by `ui::mod::render_graph_diff_column`), so skipping it
-    // here avoids a stale duplicate row list and shrinks `scroll`'s clamp
-    // back to just metadata + files.
+    // 3-col mode owns the diff in its standalone column — skipping here
+    // keeps `scroll`'s clamp tight and avoids a stale duplicate row list.
     if !app.graph_uses_three_col()
         && let Some(file_diff) = &cd.file_diff
     {

--- a/src/ui/diff_panel.rs
+++ b/src/ui/diff_panel.rs
@@ -3,7 +3,10 @@ use crate::git::{DiffContent, DiffHunk, LineTag};
 use crate::i18n::{Msg, t};
 use crate::search::{SearchState, SearchTarget};
 use crate::ui::highlight::StyledToken;
-use crate::ui::text::{clip_spans, overlay_match_highlight, truncate_to_width};
+use crate::ui::selection::{DiffHit, DiffRowText, DiffSelection, DiffSide};
+use crate::ui::text::{
+    clip_spans, overlay_match_highlight, overlay_selection_highlight, truncate_to_width,
+};
 use crate::ui::theme::Theme;
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -33,11 +36,18 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default().padding(Padding::new(1, 1, 0, 0));
     let inner = block.inner(area);
     f.render_widget(block, area);
+    // Cache the panel rect for the mouse-selection handler's point-in-rect
+    // gate. Both Git-tab Diff and Graph-tab 3-col Diff call `render_diff`,
+    // but only Git-tab enters through this wrapper; the Graph wrapper in
+    // `ui::mod.rs` caches its own rect the same way. One cache slot serves
+    // both since at most one tab renders Diff at a time.
+    app.last_diff_rect = Some(inner);
 
     let Some(d) = app.diff_content.take() else {
         render_empty(f, inner, &app.theme);
         return;
     };
+    let selection = app.diff_selection;
     render_diff(
         f,
         inner,
@@ -48,6 +58,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
         app.theme,
         &app.search,
         SearchTarget::Diff,
+        selection.as_ref(),
         &mut DiffView {
             scroll: &mut app.diff_scroll,
             h_scroll: &mut app.diff_h_scroll,
@@ -55,6 +66,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
             sbs_right_h_scroll: &mut app.sbs_right_h_scroll,
             last_view_h: &mut app.last_diff_view_h,
         },
+        &mut app.last_diff_hit,
     );
     app.diff_content = Some(d);
 }
@@ -77,12 +89,24 @@ pub fn render_diff(
     theme: Theme,
     search: &SearchState,
     search_target: SearchTarget,
+    selection: Option<&DiffSelection>,
     view: &mut DiffView<'_>,
+    hit_slot: &mut Option<DiffHit>,
 ) {
     match layout {
-        DiffLayout::Unified => {
-            render_unified(f, area, diff, highlighted, mode, theme, search, search_target, view)
-        }
+        DiffLayout::Unified => render_unified(
+            f,
+            area,
+            diff,
+            highlighted,
+            mode,
+            theme,
+            search,
+            search_target,
+            selection,
+            view,
+            hit_slot,
+        ),
         DiffLayout::SideBySide => render_side_by_side(
             f,
             area,
@@ -92,7 +116,9 @@ pub fn render_diff(
             theme,
             search,
             search_target,
+            selection,
             view,
+            hit_slot,
         ),
     }
 }
@@ -122,7 +148,9 @@ fn render_unified(
     theme: Theme,
     search: &SearchState,
     search_target: SearchTarget,
+    selection: Option<&DiffSelection>,
     view: &mut DiffView<'_>,
+    hit_slot: &mut Option<DiffHit>,
 ) {
     let mut y = area.y;
     let max_y = area.y + area.height;
@@ -150,7 +178,12 @@ fn render_unified(
         }
     }
 
-    let gutter_width = 15usize; // " XXXXX  XXXXX  "
+    // ` XXXXX  XXXXX ` (14 cols line-number gutter) + `+ ` (2 cols prefix)
+    // = 16 cols before body. Constants here match the span math in
+    // `render_unified_line`; update both together if the gutter layout
+    // changes.
+    const GUTTER_AND_PREFIX: usize = 16;
+    let gutter_width = 15usize; // legacy clamp target (body starts 1 col earlier than math says — preserved)
     let content_w = (area.width as usize).saturating_sub(gutter_width);
     let visible_rows = max_y.saturating_sub(y) as usize;
     // Remember viewport height for search-jump centering.
@@ -177,6 +210,34 @@ fn render_unified(
     let max_h = max_visible_w.saturating_sub(content_w);
     *view.h_scroll = (*view.h_scroll).min(max_h);
     let h = *view.h_scroll;
+    let content_y = y;
+
+    // Snapshot rows + geometry so the mouse-selection handler can translate
+    // a terminal `(col, row)` hit into `(side, row_idx, byte_offset)` without
+    // touching the diff data structure. Rebuilt every frame.
+    let diff_rows: Vec<DiffRowText> = all_lines
+        .iter()
+        .map(|dl| match dl {
+            UnifiedLine::Separator => DiffRowText::Separator,
+            UnifiedLine::HunkHeader(h) => DiffRowText::Header(h.clone()),
+            UnifiedLine::Content { text, .. } => DiffRowText::Unified(text.clone()),
+        })
+        .collect();
+    *hit_slot = Some(DiffHit {
+        layout: DiffLayout::Unified,
+        panel: area,
+        content_y,
+        view_h: visible_rows as u16,
+        content_x_unified: area.x.saturating_add(GUTTER_AND_PREFIX as u16),
+        content_x_left: 0,
+        content_x_right: 0,
+        right_start_x: 0,
+        scroll: *view.scroll,
+        h_scroll: h,
+        sbs_left_h_scroll: 0,
+        sbs_right_h_scroll: 0,
+        rows: diff_rows,
+    });
 
     let scroll = *view.scroll;
     for (offset, dl) in all_lines.iter().skip(scroll).enumerate() {
@@ -187,7 +248,17 @@ fn render_unified(
         // `collect_rows(Diff)` in `search.rs` uses the exact same
         // `UnifiedLine` order, so row_idx matches 1:1 with match row indices.
         let (ranges, cur) = search.ranges_on_row(search_target, row_idx);
-        render_unified_line(f, area, y, dl, h, &theme, &ranges, cur);
+        let sel_range = selection
+            .filter(|s| s.side == DiffSide::Unified)
+            .and_then(|s| {
+                let txt = match dl {
+                    UnifiedLine::Separator => "",
+                    UnifiedLine::HunkHeader(h) => h.as_str(),
+                    UnifiedLine::Content { text, .. } => text.as_str(),
+                };
+                s.sel.line_byte_range(row_idx, txt)
+            });
+        render_unified_line(f, area, y, dl, h, &theme, &ranges, cur, sel_range);
         y += 1;
     }
 }
@@ -202,6 +273,7 @@ fn render_unified_line(
     theme: &Theme,
     match_ranges: &[Range<usize>],
     current_range: Option<Range<usize>>,
+    selection_range: Option<Range<usize>>,
 ) {
     match dl {
         UnifiedLine::Separator => {
@@ -230,6 +302,10 @@ fn render_unified_line(
                     theme.search_match,
                     theme.search_current,
                 )
+            };
+            let tokens = match selection_range {
+                Some(r) if r.start < r.end => overlay_selection_highlight(tokens, r),
+                _ => tokens,
             };
             let mut spans = vec![prefix];
             for (style, text) in tokens {
@@ -272,6 +348,13 @@ fn render_unified_line(
                     theme.search_match,
                     theme.search_current,
                 )
+            };
+            // Selection overlay stacks on top of search overlay — both use
+            // `overlay_selection_highlight`'s REVERSED trick so the colors
+            // compose cleanly with the per-tag background.
+            let tokens = match selection_range {
+                Some(r) if r.start < r.end => overlay_selection_highlight(tokens, r),
+                _ => tokens,
             };
             let body_spans = clip_spans(&tokens, h_scroll, max_text);
             let body_w: usize = body_spans
@@ -436,7 +519,9 @@ fn render_side_by_side(
     theme: Theme,
     search: &SearchState,
     _search_target: SearchTarget,
+    selection: Option<&DiffSelection>,
     view: &mut DiffView<'_>,
+    hit_slot: &mut Option<DiffHit>,
 ) {
     let mut y = area.y;
     let max_y = area.y + area.height;
@@ -512,12 +597,77 @@ fn render_side_by_side(
     *view.sbs_right_h_scroll = (*view.sbs_right_h_scroll).min(max_h_right);
     let h_left = *view.sbs_left_h_scroll;
     let h_right = *view.sbs_right_h_scroll;
+    let content_y = y;
+
+    // Snapshot rows + geometry for the selection handler. Each SBS row
+    // carries both halves so `DiffRowText::text_for(side)` can pick the
+    // right one at copy time. Separator + HunkHeader rows don't have a
+    // per-side split — the mouse handler treats them as neutral.
+    let diff_rows: Vec<DiffRowText> = all_lines
+        .iter()
+        .map(|dl| match dl {
+            SbsDisplayLine::Separator => DiffRowText::Separator,
+            SbsDisplayLine::HunkHeader(h) => DiffRowText::Header(h.clone()),
+            SbsDisplayLine::Row(r) => DiffRowText::Sbs {
+                left: r.left_text.clone(),
+                right: r.right_text.clone(),
+            },
+        })
+        .collect();
+    let gutter = 7u16;
+    *hit_slot = Some(DiffHit {
+        layout: DiffLayout::SideBySide,
+        panel: area,
+        content_y,
+        view_h: visible_rows as u16,
+        content_x_unified: 0,
+        content_x_left: area.x.saturating_add(gutter),
+        // Right half starts 1 col after the divider; content starts another
+        // gutter in. `right_start_x` marks the divider/right-half boundary
+        // for `DiffHit::side_for_column`.
+        right_start_x: area.x.saturating_add(half_w + 1),
+        content_x_right: area.x.saturating_add(half_w + 1 + gutter),
+        scroll: *view.scroll,
+        h_scroll: 0,
+        sbs_left_h_scroll: h_left,
+        sbs_right_h_scroll: h_right,
+        rows: diff_rows,
+    });
 
     let scroll = *view.scroll;
-    for dl in all_lines.iter().skip(scroll) {
+    for (offset, dl) in all_lines.iter().skip(scroll).enumerate() {
         if y >= max_y {
             break;
         }
+        let row_idx = scroll + offset;
+        // Per-half selection range: only light up the half that owns the
+        // selection's anchor side; the other half renders untouched.
+        let (sel_left, sel_right) = match selection {
+            Some(s) => match s.side {
+                DiffSide::SbsLeft => {
+                    if let SbsDisplayLine::Row(row) = dl {
+                        (
+                            s.sel.line_byte_range(row_idx, row.left_text.as_str()),
+                            None,
+                        )
+                    } else {
+                        (None, None)
+                    }
+                }
+                DiffSide::SbsRight => {
+                    if let SbsDisplayLine::Row(row) = dl {
+                        (
+                            None,
+                            s.sel.line_byte_range(row_idx, row.right_text.as_str()),
+                        )
+                    } else {
+                        (None, None)
+                    }
+                }
+                DiffSide::Unified => (None, None),
+            },
+            None => (None, None),
+        };
         match dl {
             SbsDisplayLine::Separator => {
                 let line = Line::from(Span::styled(
@@ -540,7 +690,9 @@ fn render_side_by_side(
                 f.render_widget(line, Rect::new(area.x, y, area.width, 1));
             }
             SbsDisplayLine::Row(row) => {
-                render_sbs_row(f, area, y, row, half_w, right_w, h_left, h_right, &theme);
+                render_sbs_row(
+                    f, area, y, row, half_w, right_w, h_left, h_right, &theme, sel_left, sel_right,
+                );
             }
         }
         y += 1;
@@ -558,6 +710,8 @@ fn render_sbs_row(
     h_scroll_left: usize,
     h_scroll_right: usize,
     theme: &Theme,
+    sel_left: Option<Range<usize>>,
+    sel_right: Option<Range<usize>>,
 ) {
     // Gutter: " XXXXX " = 7 cols
     let gutter = 7usize;
@@ -568,6 +722,10 @@ fn render_sbs_row(
     let left_no = fmt_lineno(row.left_no);
     let left_body =
         build_sbs_body_tokens(&row.left_text, row.left_tokens.as_ref(), left_fg, left_bg);
+    let left_body = match sel_left {
+        Some(r) if r.start < r.end => overlay_selection_highlight(left_body, r),
+        _ => left_body,
+    };
     let left_spans = clip_spans(&left_body, h_scroll_left, left_content_w);
     let left_used: usize = left_spans
         .iter()
@@ -601,6 +759,10 @@ fn render_sbs_row(
         right_fg,
         right_bg,
     );
+    let right_body = match sel_right {
+        Some(r) if r.start < r.end => overlay_selection_highlight(right_body, r),
+        _ => right_body,
+    };
     let right_spans = clip_spans(&right_body, h_scroll_right, right_content_w);
     let right_used: usize = right_spans
         .iter()

--- a/src/ui/diff_panel.rs
+++ b/src/ui/diff_panel.rs
@@ -1,7 +1,7 @@
-use crate::app::{App, DiffHighlighted, DiffLayout, LineTokens};
+use crate::app::{App, DiffHighlighted, DiffLayout, DiffMode, LineTokens};
 use crate::git::{DiffContent, DiffHunk, LineTag};
 use crate::i18n::{Msg, t};
-use crate::search::SearchTarget;
+use crate::search::{SearchState, SearchTarget};
 use crate::ui::highlight::StyledToken;
 use crate::ui::text::{clip_spans, overlay_match_highlight, truncate_to_width};
 use crate::ui::theme::Theme;
@@ -13,36 +13,97 @@ use ratatui::widgets::{Block, Padding};
 use std::ops::Range;
 use unicode_width::UnicodeWidthStr;
 
+/// Scroll + viewport state held by whichever layer owns a diff panel
+/// instance. Git tab stores these at App top level; Graph tab's 3-col
+/// layout will use its own copy inside `commit_detail`. Passed in by
+/// mutable ref so the render's clamping reaches back through to the
+/// owner, and the next frame sees the pinned values.
+pub struct DiffView<'a> {
+    pub scroll: &'a mut usize,
+    pub h_scroll: &'a mut usize,
+    pub sbs_left_h_scroll: &'a mut usize,
+    pub sbs_right_h_scroll: &'a mut usize,
+    pub last_view_h: &'a mut u16,
+}
+
+/// Git-tab entry point. Thin wrapper around `render_diff` that sources
+/// everything from `App`. Graph tab will call `render_diff` directly
+/// with its own scroll fields once the 3-column layout lands.
 pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default().padding(Padding::new(1, 1, 0, 0));
     let inner = block.inner(area);
     f.render_widget(block, area);
 
-    match app.diff_content.take() {
-        None => {
-            render_empty(f, app, inner);
+    let Some(d) = app.diff_content.take() else {
+        render_empty(f, inner, &app.theme);
+        return;
+    };
+    render_diff(
+        f,
+        inner,
+        &d.diff,
+        d.highlighted.as_ref(),
+        app.diff_layout,
+        app.diff_mode,
+        app.theme,
+        &app.search,
+        SearchTarget::Diff,
+        &mut DiffView {
+            scroll: &mut app.diff_scroll,
+            h_scroll: &mut app.diff_h_scroll,
+            sbs_left_h_scroll: &mut app.sbs_left_h_scroll,
+            sbs_right_h_scroll: &mut app.sbs_right_h_scroll,
+            last_view_h: &mut app.last_diff_view_h,
+        },
+    );
+    app.diff_content = Some(d);
+}
+
+/// Pure diff renderer — no `App` dependency. Callers own the scroll state
+/// and pass search + theme by reference. Both Git tab (via `render`) and
+/// Graph tab's future 3-col right column use this.
+///
+/// `search_target` decides which of the caller's `/` matches the renderer
+/// will overlay on the content; pass `SearchTarget::Diff` for the Git tab
+/// and `SearchTarget::GraphDiff` once that variant lands.
+#[allow(clippy::too_many_arguments)]
+pub fn render_diff(
+    f: &mut Frame,
+    area: Rect,
+    diff: &DiffContent,
+    highlighted: Option<&DiffHighlighted>,
+    layout: DiffLayout,
+    mode: DiffMode,
+    theme: Theme,
+    search: &SearchState,
+    search_target: SearchTarget,
+    view: &mut DiffView<'_>,
+) {
+    match layout {
+        DiffLayout::Unified => {
+            render_unified(f, area, diff, highlighted, mode, theme, search, search_target, view)
         }
-        Some(d) => {
-            match app.diff_layout {
-                DiffLayout::Unified => {
-                    render_unified(f, app, inner, &d.diff, d.highlighted.as_ref())
-                }
-                DiffLayout::SideBySide => {
-                    render_side_by_side(f, app, inner, &d.diff, d.highlighted.as_ref())
-                }
-            }
-            app.diff_content = Some(d);
-        }
+        DiffLayout::SideBySide => render_side_by_side(
+            f,
+            area,
+            diff,
+            highlighted,
+            mode,
+            theme,
+            search,
+            search_target,
+            view,
+        ),
     }
 }
 
-fn render_empty(f: &mut Frame, app: &App, area: Rect) {
+fn render_empty(f: &mut Frame, area: Rect, theme: &Theme) {
     if area.height < 1 {
         return;
     }
     let msg = Line::from(Span::styled(
         t(Msg::DiffEmpty),
-        Style::default().fg(app.theme.fg_secondary),
+        Style::default().fg(theme.fg_secondary),
     ));
     let y = area.y + area.height / 2;
     let x = area.x + area.width.saturating_sub(22) / 2;
@@ -51,18 +112,22 @@ fn render_empty(f: &mut Frame, app: &App, area: Rect) {
 
 // ─── Unified view ────────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_arguments)]
 fn render_unified(
     f: &mut Frame,
-    app: &mut App,
     area: Rect,
     diff: &DiffContent,
     highlighted: Option<&DiffHighlighted>,
+    mode: DiffMode,
+    theme: Theme,
+    search: &SearchState,
+    search_target: SearchTarget,
+    view: &mut DiffView<'_>,
 ) {
     let mut y = area.y;
     let max_y = area.y + area.height;
-    let theme = app.theme;
 
-    render_file_header(f, app, area, diff, &mut y, max_y);
+    render_file_header(f, area, diff, DiffLayout::Unified, mode, &theme, &mut y, max_y);
 
     // Build all display lines. Content rows pick up per-line syntect tokens
     // when available so the render path can emit syntax-colored spans
@@ -89,19 +154,19 @@ fn render_unified(
     let content_w = (area.width as usize).saturating_sub(gutter_width);
     let visible_rows = max_y.saturating_sub(y) as usize;
     // Remember viewport height for search-jump centering.
-    app.last_diff_view_h = visible_rows as u16;
+    *view.last_view_h = visible_rows as u16;
 
     // Clamp vertical scroll so we can't scroll past the last displayable row.
     // Must come before the horizontal max-width calc below, which itself
-    // uses `skip(app.diff_scroll)` and would see an empty slice if we let
+    // uses `skip(*view.scroll)` and would see an empty slice if we let
     // the offset run past the end.
     let max_scroll = all_lines.len().saturating_sub(visible_rows);
-    app.diff_scroll = app.diff_scroll.min(max_scroll);
+    *view.scroll = (*view.scroll).min(max_scroll);
 
     // Clamp horizontal scroll against the widest Content line currently in view.
     let max_visible_w: usize = all_lines
         .iter()
-        .skip(app.diff_scroll)
+        .skip(*view.scroll)
         .take(visible_rows)
         .filter_map(|dl| match dl {
             UnifiedLine::Content { text, .. } => Some(UnicodeWidthStr::width(text.as_str())),
@@ -110,10 +175,10 @@ fn render_unified(
         .max()
         .unwrap_or(0);
     let max_h = max_visible_w.saturating_sub(content_w);
-    app.diff_h_scroll = app.diff_h_scroll.min(max_h);
-    let h = app.diff_h_scroll;
+    *view.h_scroll = (*view.h_scroll).min(max_h);
+    let h = *view.h_scroll;
 
-    let scroll = app.diff_scroll;
+    let scroll = *view.scroll;
     for (offset, dl) in all_lines.iter().skip(scroll).enumerate() {
         if y >= max_y {
             break;
@@ -121,7 +186,7 @@ fn render_unified(
         let row_idx = scroll + offset;
         // `collect_rows(Diff)` in `search.rs` uses the exact same
         // `UnifiedLine` order, so row_idx matches 1:1 with match row indices.
-        let (ranges, cur) = app.search.ranges_on_row(SearchTarget::Diff, row_idx);
+        let (ranges, cur) = search.ranges_on_row(search_target, row_idx);
         render_unified_line(f, area, y, dl, h, &theme, &ranges, cur);
         y += 1;
     }
@@ -361,18 +426,36 @@ fn build_sbs_lines(hunk: &DiffHunk, hunk_tokens: Option<&Vec<LineTokens>>) -> Ve
     rows
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_side_by_side(
     f: &mut Frame,
-    app: &mut App,
     area: Rect,
     diff: &DiffContent,
     highlighted: Option<&DiffHighlighted>,
+    mode: DiffMode,
+    theme: Theme,
+    search: &SearchState,
+    _search_target: SearchTarget,
+    view: &mut DiffView<'_>,
 ) {
     let mut y = area.y;
     let max_y = area.y + area.height;
-    let theme = app.theme;
 
-    render_file_header(f, app, area, diff, &mut y, max_y);
+    render_file_header(
+        f,
+        area,
+        diff,
+        DiffLayout::SideBySide,
+        mode,
+        &theme,
+        &mut y,
+        max_y,
+    );
+    // SBS has no per-row search overlay plumbing yet — the pre-split
+    // `render_unified` path is what feeds `SearchTarget::Diff` rows. Leave
+    // `search` threaded through the signature so SBS can light up matches
+    // when we add that overlay; today it's here for API symmetry.
+    let _ = search;
 
     // Build all display lines
     let mut all_lines: Vec<SbsDisplayLine> = Vec::new();
@@ -393,32 +476,44 @@ fn render_side_by_side(
     let left_content_w = (half_w as usize).saturating_sub(gutter);
     let right_content_w = (right_w as usize).saturating_sub(gutter);
     let visible_rows = max_y.saturating_sub(y) as usize;
-    app.last_diff_view_h = visible_rows as u16;
+    *view.last_view_h = visible_rows as u16;
 
     // Clamp vertical scroll so we can't scroll past the last displayable row.
     let max_scroll = all_lines.len().saturating_sub(visible_rows);
-    app.diff_scroll = app.diff_scroll.min(max_scroll);
+    *view.scroll = (*view.scroll).min(max_scroll);
 
-    // Clamp horizontal scroll against the widest text column in view (either side).
-    let max_visible_w: usize = all_lines
+    // Clamp each side's horizontal scroll against that side's widest text
+    // in view. Using a shared scroll would force both halves to pan in
+    // lockstep — rarely what you want when the two versions have very
+    // different line widths (think rename / large rewrite).
+    let max_left_w: usize = all_lines
         .iter()
-        .skip(app.diff_scroll)
+        .skip(*view.scroll)
         .take(visible_rows)
         .filter_map(|dl| match dl {
-            SbsDisplayLine::Row(row) => Some(
-                UnicodeWidthStr::width(row.left_text.as_str())
-                    .max(UnicodeWidthStr::width(row.right_text.as_str())),
-            ),
+            SbsDisplayLine::Row(row) => Some(UnicodeWidthStr::width(row.left_text.as_str())),
             _ => None,
         })
         .max()
         .unwrap_or(0);
-    let side_content_w = left_content_w.min(right_content_w);
-    let max_h = max_visible_w.saturating_sub(side_content_w);
-    app.diff_h_scroll = app.diff_h_scroll.min(max_h);
-    let h = app.diff_h_scroll;
+    let max_right_w: usize = all_lines
+        .iter()
+        .skip(*view.scroll)
+        .take(visible_rows)
+        .filter_map(|dl| match dl {
+            SbsDisplayLine::Row(row) => Some(UnicodeWidthStr::width(row.right_text.as_str())),
+            _ => None,
+        })
+        .max()
+        .unwrap_or(0);
+    let max_h_left = max_left_w.saturating_sub(left_content_w);
+    let max_h_right = max_right_w.saturating_sub(right_content_w);
+    *view.sbs_left_h_scroll = (*view.sbs_left_h_scroll).min(max_h_left);
+    *view.sbs_right_h_scroll = (*view.sbs_right_h_scroll).min(max_h_right);
+    let h_left = *view.sbs_left_h_scroll;
+    let h_right = *view.sbs_right_h_scroll;
 
-    let scroll = app.diff_scroll;
+    let scroll = *view.scroll;
     for dl in all_lines.iter().skip(scroll) {
         if y >= max_y {
             break;
@@ -445,7 +540,7 @@ fn render_side_by_side(
                 f.render_widget(line, Rect::new(area.x, y, area.width, 1));
             }
             SbsDisplayLine::Row(row) => {
-                render_sbs_row(f, area, y, row, half_w, right_w, h, &theme);
+                render_sbs_row(f, area, y, row, half_w, right_w, h_left, h_right, &theme);
             }
         }
         y += 1;
@@ -460,7 +555,8 @@ fn render_sbs_row(
     row: &SbsRow,
     half_w: u16,
     right_w: u16,
-    h_scroll: usize,
+    h_scroll_left: usize,
+    h_scroll_right: usize,
     theme: &Theme,
 ) {
     // Gutter: " XXXXX " = 7 cols
@@ -472,7 +568,7 @@ fn render_sbs_row(
     let left_no = fmt_lineno(row.left_no);
     let left_body =
         build_sbs_body_tokens(&row.left_text, row.left_tokens.as_ref(), left_fg, left_bg);
-    let left_spans = clip_spans(&left_body, h_scroll, left_content_w);
+    let left_spans = clip_spans(&left_body, h_scroll_left, left_content_w);
     let left_used: usize = left_spans
         .iter()
         .map(|s| UnicodeWidthStr::width(s.content.as_ref()))
@@ -505,7 +601,7 @@ fn render_sbs_row(
         right_fg,
         right_bg,
     );
-    let right_spans = clip_spans(&right_body, h_scroll, right_content_w);
+    let right_spans = clip_spans(&right_body, h_scroll_right, right_content_w);
     let right_used: usize = right_spans
         .iter()
         .map(|s| UnicodeWidthStr::width(s.content.as_ref()))
@@ -544,11 +640,14 @@ fn build_sbs_body_tokens(
 
 // ─── Shared helpers ──────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_arguments)]
 fn render_file_header(
     f: &mut Frame,
-    app: &App,
     area: Rect,
     diff: &DiffContent,
+    layout: DiffLayout,
+    mode: DiffMode,
+    theme: &Theme,
     y: &mut u16,
     max_y: u16,
 ) {
@@ -556,14 +655,13 @@ fn render_file_header(
         return;
     }
 
-    let th = app.theme;
-    let layout_label = match app.diff_layout {
+    let layout_label = match layout {
         DiffLayout::Unified => t(Msg::LayoutUnified),
         DiffLayout::SideBySide => t(Msg::LayoutSideBySide),
     };
-    let mode_label = match app.diff_mode {
-        crate::app::DiffMode::Compact => t(Msg::ModeCompact),
-        crate::app::DiffMode::FullFile => t(Msg::ModeFullFile),
+    let mode_label = match mode {
+        DiffMode::Compact => t(Msg::ModeCompact),
+        DiffMode::FullFile => t(Msg::ModeFullFile),
     };
 
     let tag_str = crate::i18n::diff_mode_hint(layout_label, mode_label);
@@ -575,10 +673,10 @@ fn render_file_header(
         Span::styled(
             path_display.to_string(),
             Style::default()
-                .fg(th.fg_primary)
+                .fg(theme.fg_primary)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(tag_str, Style::default().fg(th.fg_secondary)),
+        Span::styled(tag_str, Style::default().fg(theme.fg_secondary)),
     ]);
     f.render_widget(header, Rect::new(area.x, *y, area.width, 1));
     *y += 1;
@@ -589,7 +687,7 @@ fn render_file_header(
     }
     let sep = Line::from(Span::styled(
         "─".repeat(area.width as usize),
-        Style::default().fg(th.fg_secondary),
+        Style::default().fg(theme.fg_secondary),
     ));
     f.render_widget(sep, Rect::new(area.x, *y, area.width, 1));
     *y += 1;

--- a/src/ui/diff_panel.rs
+++ b/src/ui/diff_panel.rs
@@ -155,7 +155,16 @@ fn render_unified(
     let mut y = area.y;
     let max_y = area.y + area.height;
 
-    render_file_header(f, area, diff, DiffLayout::Unified, mode, &theme, &mut y, max_y);
+    render_file_header(
+        f,
+        area,
+        diff,
+        DiffLayout::Unified,
+        mode,
+        &theme,
+        &mut y,
+        max_y,
+    );
 
     // Build all display lines. Content rows pick up per-line syntect tokens
     // when available so the render path can emit syntax-colored spans
@@ -637,10 +646,7 @@ fn render_side_by_side(
             Some(s) => match s.side {
                 DiffSide::SbsLeft => {
                     if let SbsDisplayLine::Row(row) = dl {
-                        (
-                            s.sel.line_byte_range(row_idx, row.left_text.as_str()),
-                            None,
-                        )
+                        (s.sel.line_byte_range(row_idx, row.left_text.as_str()), None)
                     } else {
                         (None, None)
                     }

--- a/src/ui/diff_panel.rs
+++ b/src/ui/diff_panel.rs
@@ -570,27 +570,20 @@ fn render_side_by_side(
     // Clamp each side's horizontal scroll against that side's widest text
     // in view. Using a shared scroll would force both halves to pan in
     // lockstep — rarely what you want when the two versions have very
-    // different line widths (think rename / large rewrite).
-    let max_left_w: usize = all_lines
+    // different line widths (think rename / large rewrite). Single fold
+    // over the visible window computes both maxes — one iteration
+    // instead of two over the same slice.
+    let (max_left_w, max_right_w): (usize, usize) = all_lines
         .iter()
         .skip(*view.scroll)
         .take(visible_rows)
-        .filter_map(|dl| match dl {
-            SbsDisplayLine::Row(row) => Some(UnicodeWidthStr::width(row.left_text.as_str())),
-            _ => None,
-        })
-        .max()
-        .unwrap_or(0);
-    let max_right_w: usize = all_lines
-        .iter()
-        .skip(*view.scroll)
-        .take(visible_rows)
-        .filter_map(|dl| match dl {
-            SbsDisplayLine::Row(row) => Some(UnicodeWidthStr::width(row.right_text.as_str())),
-            _ => None,
-        })
-        .max()
-        .unwrap_or(0);
+        .fold((0, 0), |(ml, mr), dl| match dl {
+            SbsDisplayLine::Row(row) => (
+                ml.max(UnicodeWidthStr::width(row.left_text.as_str())),
+                mr.max(UnicodeWidthStr::width(row.right_text.as_str())),
+            ),
+            _ => (ml, mr),
+        });
     let max_h_left = max_left_w.saturating_sub(left_content_w);
     let max_h_right = max_right_w.saturating_sub(right_content_w);
     *view.sbs_left_h_scroll = (*view.sbs_left_h_scroll).min(max_h_left);

--- a/src/ui/diff_panel.rs
+++ b/src/ui/diff_panel.rs
@@ -225,9 +225,7 @@ fn render_unified(
         .collect();
     *hit_slot = Some(DiffHit {
         layout: DiffLayout::Unified,
-        panel: area,
         content_y,
-        view_h: visible_rows as u16,
         content_x_unified: area.x.saturating_add(GUTTER_AND_PREFIX as u16),
         content_x_left: 0,
         content_x_right: 0,
@@ -536,10 +534,12 @@ fn render_side_by_side(
         &mut y,
         max_y,
     );
-    // SBS has no per-row search overlay plumbing yet — the pre-split
-    // `render_unified` path is what feeds `SearchTarget::Diff` rows. Leave
-    // `search` threaded through the signature so SBS can light up matches
-    // when we add that overlay; today it's here for API symmetry.
+    // TODO(search-sbs): SBS layout doesn't overlay `/` match highlights
+    // on its rows — only Unified does. Row index inside `build_sbs_lines`
+    // diverges from `unified_display_rows` (it pairs Removed/Added into
+    // single rows), so wiring search in needs a parallel row collector
+    // before the renderer can light up matches. `search` is threaded
+    // through to keep the signature honest once that lands.
     let _ = search;
 
     // Build all display lines
@@ -617,9 +617,7 @@ fn render_side_by_side(
     let gutter = 7u16;
     *hit_slot = Some(DiffHit {
         layout: DiffLayout::SideBySide,
-        panel: area,
         content_y,
-        view_h: visible_rows as u16,
         content_x_unified: 0,
         content_x_left: area.x.saturating_add(gutter),
         // Right half starts 1 col after the divider; content starts another

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -39,6 +39,12 @@ pub fn render(f: &mut Frame, app: &mut App) {
     // handler would treat clicks on other panels as selection gestures.
     app.last_preview_rect = None;
     app.last_preview_content_origin = None;
+    // Same story for the diff panel — both Git tab Diff and Graph tab's
+    // 3-col diff column write into these slots during their own render.
+    // If the active tab renders neither, wiping here keeps a stale rect
+    // from steering mouse selection toward a hidden region.
+    app.last_diff_rect = None;
+    app.last_diff_hit = None;
 
     let main_layout = Layout::default()
         .direction(Direction::Vertical)
@@ -264,6 +270,10 @@ fn render_graph_diff_column(f: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default().padding(Padding::new(1, 1, 0, 0));
     let inner = block.inner(area);
     f.render_widget(block, area);
+    // Cache the panel rect for mouse selection, parallel to the Git-tab
+    // wrapper. Both tabs write into the same `last_diff_rect` slot — only
+    // one of them renders Diff at a time.
+    app.last_diff_rect = Some(inner);
 
     let Some(d) = app.commit_detail.file_diff.take() else {
         // In 3-col mode this only fires when `commit_file_diff_load.loading`
@@ -279,6 +289,7 @@ fn render_graph_diff_column(f: &mut Frame, app: &mut App, area: Rect) {
         }
         return;
     };
+    let selection = app.diff_selection;
     diff_panel::render_diff(
         f,
         inner,
@@ -289,6 +300,7 @@ fn render_graph_diff_column(f: &mut Frame, app: &mut App, area: Rect) {
         app.theme,
         &app.search,
         crate::search::SearchTarget::GraphDiff,
+        selection.as_ref(),
         &mut diff_panel::DiffView {
             scroll: &mut app.commit_detail.file_diff_scroll,
             h_scroll: &mut app.commit_detail.file_diff_h_scroll,
@@ -296,6 +308,7 @@ fn render_graph_diff_column(f: &mut Frame, app: &mut App, area: Rect) {
             sbs_right_h_scroll: &mut app.commit_detail.file_diff_sbs_right_h_scroll,
             last_view_h: &mut app.last_diff_view_h,
         },
+        &mut app.last_diff_hit,
     );
     app.commit_detail.file_diff = Some(d);
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -66,32 +66,25 @@ pub fn render(f: &mut Frame, app: &mut App) {
     app.last_total_width = main_layout[2].width;
     app.normalize_active_panel();
 
-    // Body: left + right (+ optional diff column for Graph tab 3-col mode)
-    let left_width = (main_layout[2].width as u32 * app.split_percent as u32 / 100) as u16;
-    let left_width = left_width
-        .max(10)
-        .min(main_layout[2].width.saturating_sub(20));
-
+    // Body: left + right (+ optional diff column for Graph tab 3-col mode).
+    // Width math goes through `App::graph_sidebar_width` /
+    // `graph_three_col_widths` so `input::*` and `ui::render` agree on
+    // where column boundaries fall — important for hit-testing and
+    // h-scroll routing to land in the right column.
+    let total_w = main_layout[2].width;
     let three_col = app.graph_uses_three_col();
     let body_layout = if three_col {
-        // Graph 3-col: graph | commit | diff. Split the non-graph remainder
-        // between commit and diff by `graph_diff_split_percent` (% of the
-        // remainder that goes to the diff column, counted from the right).
-        let remainder = main_layout[2].width.saturating_sub(left_width);
-        let diff_w = (remainder as u32 * app.graph_diff_split_percent as u32 / 100) as u16;
-        // Keep both right-side columns usable — diff gets a floor so a
-        // really narrow `graph_diff_split_percent` doesn't squish it away.
-        let diff_w = diff_w.max(20).min(remainder.saturating_sub(20));
-        let commit_w = remainder.saturating_sub(diff_w);
+        let (graph_w, commit_w, _) = app.graph_three_col_widths(total_w);
         Layout::default()
             .direction(Direction::Horizontal)
             .constraints([
-                Constraint::Length(left_width),
+                Constraint::Length(graph_w),
                 Constraint::Length(commit_w),
                 Constraint::Min(20),
             ])
             .split(main_layout[2])
     } else {
+        let left_width = app.graph_sidebar_width(total_w);
         Layout::default()
             .direction(Direction::Horizontal)
             .constraints([Constraint::Length(left_width), Constraint::Min(20)])

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -53,23 +53,59 @@ pub fn render(f: &mut Frame, app: &mut App) {
     render_title_bar(f, app, main_layout[0]);
     render_tab_bar(f, app, main_layout[1]);
 
-    // Body: left + right
+    // Cache body width before layout math so `graph_uses_three_col` and
+    // `normalize_active_panel` can see the current frame's geometry. The
+    // title/tab/status bars are fixed-width siblings, so the body width
+    // equals the frame width here.
+    app.last_total_width = main_layout[2].width;
+    app.normalize_active_panel();
+
+    // Body: left + right (+ optional diff column for Graph tab 3-col mode)
     let left_width = (main_layout[2].width as u32 * app.split_percent as u32 / 100) as u16;
     let left_width = left_width
         .max(10)
         .min(main_layout[2].width.saturating_sub(20));
 
-    let body_layout = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(left_width), Constraint::Min(20)])
-        .split(main_layout[2]);
+    let three_col = app.graph_uses_three_col();
+    let body_layout = if three_col {
+        // Graph 3-col: graph | commit | diff. Split the non-graph remainder
+        // between commit and diff by `graph_diff_split_percent` (% of the
+        // remainder that goes to the diff column, counted from the right).
+        let remainder = main_layout[2].width.saturating_sub(left_width);
+        let diff_w = (remainder as u32 * app.graph_diff_split_percent as u32 / 100) as u16;
+        // Keep both right-side columns usable — diff gets a floor so a
+        // really narrow `graph_diff_split_percent` doesn't squish it away.
+        let diff_w = diff_w.max(20).min(remainder.saturating_sub(20));
+        let commit_w = remainder.saturating_sub(diff_w);
+        Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Length(left_width),
+                Constraint::Length(commit_w),
+                Constraint::Min(20),
+            ])
+            .split(main_layout[2])
+    } else {
+        Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Length(left_width), Constraint::Min(20)])
+            .split(main_layout[2])
+    };
 
-    // Drag zone on the split border
+    // Drag zone on the graph | right split border
     let split_x = body_layout[0].x + body_layout[0].width.saturating_sub(1);
     app.hit_registry.register(
         Rect::new(split_x, body_layout[0].y, 2, body_layout[0].height),
         ClickAction::StartDragSplit,
     );
+    // Second drag zone for the commit | diff boundary in 3-col mode.
+    if three_col && body_layout.len() >= 3 {
+        let mid_split_x = body_layout[1].x + body_layout[1].width.saturating_sub(1);
+        app.hit_registry.register(
+            Rect::new(mid_split_x, body_layout[1].y, 2, body_layout[1].height),
+            ClickAction::StartDragGraphDiffSplit,
+        );
+    }
 
     match app.active_tab {
         Tab::Git => {
@@ -86,7 +122,12 @@ pub fn render(f: &mut Frame, app: &mut App) {
         }
         Tab::Graph => {
             render_graph_sidebar(f, app, body_layout[0]);
-            render_graph_editor(f, app, body_layout[1]);
+            if three_col {
+                render_graph_editor(f, app, body_layout[1]);
+                render_graph_diff_column(f, app, body_layout[2]);
+            } else {
+                render_graph_editor(f, app, body_layout[1]);
+            }
         }
         Tab::Search => {
             search_tab::render_sidebar(f, app, body_layout[0]);
@@ -194,7 +235,10 @@ fn render_graph_sidebar(f: &mut Frame, app: &mut App, area: Rect) {
     git_graph_panel::render(f, app, padded, focused);
 }
 
-/// Graph tab's right editor — inline commit-detail panel.
+/// Graph tab's middle column — commit metadata + file tree. In 2-col
+/// fallback this is the whole right pane and renders the inline diff
+/// too (the `commit_detail_panel` consults `graph_uses_three_col` to
+/// decide whether to append diff rows).
 fn render_graph_editor(f: &mut Frame, app: &mut App, area: Rect) {
     let inner = Rect::new(
         area.x + 1,
@@ -202,8 +246,58 @@ fn render_graph_editor(f: &mut Frame, app: &mut App, area: Rect) {
         area.width.saturating_sub(1),
         area.height,
     );
-    let focused = matches!(app.active_panel, crate::app::Panel::Diff);
+    let focused = if app.graph_uses_three_col() {
+        // In 3-col mode Panel::Commit owns the middle column.
+        matches!(app.active_panel, crate::app::Panel::Commit)
+    } else {
+        matches!(app.active_panel, crate::app::Panel::Diff)
+    };
     commit_detail_panel::render(f, app, inner, focused);
+}
+
+/// Graph tab's right column (3-col mode only) — the diff viewport for
+/// the file selected inside the middle column. Delegates to the shared
+/// `diff_panel::render_diff` so Git-tab Diff and this column share
+/// rendering, search integration, and (after Stage 3) mouse selection.
+fn render_graph_diff_column(f: &mut Frame, app: &mut App, area: Rect) {
+    use ratatui::widgets::{Block, Padding};
+    let block = Block::default().padding(Padding::new(1, 1, 0, 0));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let Some(d) = app.commit_detail.file_diff.take() else {
+        // In 3-col mode this only fires when `commit_file_diff_load.loading`
+        // is still true. Show a quiet "loading…" banner so the column is
+        // never blank between the click and the async result landing.
+        if area.height >= 1 {
+            let msg = Line::from(Span::styled(
+                t(Msg::DiffLoading),
+                Style::default().fg(app.theme.fg_secondary),
+            ));
+            let y = area.y + area.height / 2;
+            f.render_widget(msg, Rect::new(area.x, y, area.width, 1));
+        }
+        return;
+    };
+    diff_panel::render_diff(
+        f,
+        inner,
+        &d.diff,
+        d.highlighted.as_ref(),
+        app.commit_detail.diff_layout,
+        app.commit_detail.diff_mode,
+        app.theme,
+        &app.search,
+        crate::search::SearchTarget::GraphDiff,
+        &mut diff_panel::DiffView {
+            scroll: &mut app.commit_detail.file_diff_scroll,
+            h_scroll: &mut app.commit_detail.file_diff_h_scroll,
+            sbs_left_h_scroll: &mut app.commit_detail.file_diff_sbs_left_h_scroll,
+            sbs_right_h_scroll: &mut app.commit_detail.file_diff_sbs_right_h_scroll,
+            last_view_h: &mut app.last_diff_view_h,
+        },
+    );
+    app.commit_detail.file_diff = Some(d);
 }
 
 fn render_tab_bar(f: &mut Frame, app: &mut App, area: Rect) {

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -13,6 +13,9 @@ pub enum ClickAction {
     ToggleStaged,
     ToggleUnstaged,
     StartDragSplit,
+    /// Graph tab 3-col 布局下,中间 commit 列与右侧 diff 列之间的拖拽
+    /// 分界。跟 `StartDragSplit` 互不干扰。
+    StartDragGraphDiffSplit,
     SwitchTab(Tab),
     TreeClick(usize),
     /// Click on a row in the quick-open palette. The `usize` indexes

--- a/src/ui/selection.rs
+++ b/src/ui/selection.rs
@@ -7,7 +7,6 @@
 //! 滚动后选中范围仍然指向文件里原来的同一段文本。
 
 use crate::app::DiffLayout;
-use ratatui::layout::Rect;
 use std::ops::Range;
 use unicode_width::UnicodeWidthChar;
 
@@ -218,16 +217,9 @@ impl DiffRowText {
 #[derive(Debug, Clone)]
 pub struct DiffHit {
     pub layout: DiffLayout,
-    /// Panel-level rect, used for point-in-rect gating. Renderer caches
-    /// it separately too (`last_diff_rect`); kept here so a hit-test can
-    /// stay self-contained if needed.
-    pub panel: Rect,
     /// First content row's absolute y. Rows above this are the file
     /// header / separator line.
     pub content_y: u16,
-    /// Last-rendered viewport height in rows. Used to clamp drag past the
-    /// bottom of the panel.
-    pub view_h: u16,
 
     // Unified layout
     pub content_x_unified: u16,
@@ -581,9 +573,7 @@ mod tests {
     fn make_unified_hit(rows: Vec<DiffRowText>, scroll: usize) -> DiffHit {
         DiffHit {
             layout: DiffLayout::Unified,
-            panel: Rect::new(0, 0, 80, 20),
             content_y: 2,
-            view_h: 18,
             content_x_unified: 16,
             content_x_left: 0,
             content_x_right: 0,
@@ -600,9 +590,7 @@ mod tests {
         // Half width 40, divider at col 40, right half content starts at 48.
         DiffHit {
             layout: DiffLayout::SideBySide,
-            panel: Rect::new(0, 0, 81, 20),
             content_y: 2,
-            view_h: 18,
             content_x_unified: 0,
             content_x_left: 7,
             content_x_right: 48,

--- a/src/ui/selection.rs
+++ b/src/ui/selection.rs
@@ -653,15 +653,17 @@ mod tests {
         let hit = make_unified_hit(rows, 0);
         // content_x_unified = 16, content_y = 2. Click at col 20 row 2 →
         // visible_col = 4, byte_offset = 4 ('o' of "hello").
-        let (row_idx, byte_offset) =
-            hit.coord_for(20, 2, DiffSide::Unified).expect("coord");
+        let (row_idx, byte_offset) = hit.coord_for(20, 2, DiffSide::Unified).expect("coord");
         assert_eq!(row_idx, 0);
         assert_eq!(byte_offset, 4);
     }
 
     #[test]
     fn diff_hit_coord_for_past_row_clamps_to_last() {
-        let rows = vec![DiffRowText::Unified("x".into()), DiffRowText::Unified("y".into())];
+        let rows = vec![
+            DiffRowText::Unified("x".into()),
+            DiffRowText::Unified("y".into()),
+        ];
         let hit = make_unified_hit(rows, 0);
         // Row 50 way past end → clamps to last row (1).
         let (row_idx, _byte) = hit.coord_for(16, 50, DiffSide::Unified).unwrap();

--- a/src/ui/selection.rs
+++ b/src/ui/selection.rs
@@ -6,6 +6,8 @@
 //! 显示列)。这样选中与 `preview_scroll` / `preview_h_scroll` 解耦——
 //! 滚动后选中范围仍然指向文件里原来的同一段文本。
 
+use crate::app::DiffLayout;
+use ratatui::layout::Rect;
 use std::ops::Range;
 use unicode_width::UnicodeWidthChar;
 
@@ -146,6 +148,180 @@ pub fn col_to_byte_offset(line: &str, col: usize) -> usize {
         acc += cw;
     }
     line.len()
+}
+
+// ─── Diff-panel selection ────────────────────────────────────────────────
+//
+// Same `(row, byte)` coord model as `PreviewSelection`, but `row` indexes
+// into the diff's *display* row list (separator / hunk header / content),
+// not a file. A second `side` field disambiguates SBS layout — a gesture
+// that starts on the left (old version) stays on the left even if the
+// cursor crosses the divider, matching VSCode's diff editor. In Unified
+// layout `side` is always `Unified`.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffSide {
+    Unified,
+    SbsLeft,
+    SbsRight,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DiffSelection {
+    pub sel: PreviewSelection,
+    pub side: DiffSide,
+}
+
+/// Snapshot of what a single display row carried at the time of render.
+/// Mouse-selection handlers read this to know how to extract the side-
+/// specific text for the row that was hit — without walking back into
+/// the diff hunks themselves.
+#[derive(Debug, Clone)]
+pub enum DiffRowText {
+    /// `⋯` separator between hunks. Contributes an empty string to the
+    /// copied text so drag-selections span seamlessly across it.
+    Separator,
+    /// `@@ -1,5 +2,7 @@` hunk header. Copy includes the full header text.
+    Header(String),
+    /// Unified content row — left/right don't apply.
+    Unified(String),
+    /// SBS paired content row. Each half is its own selectable string,
+    /// picked by the selection's `side`.
+    Sbs { left: String, right: String },
+}
+
+impl DiffRowText {
+    pub fn text_for(&self, side: DiffSide) -> &str {
+        match self {
+            DiffRowText::Separator => "",
+            DiffRowText::Header(h) => h.as_str(),
+            DiffRowText::Unified(s) => s.as_str(),
+            DiffRowText::Sbs { left, right } => match side {
+                DiffSide::SbsLeft => left.as_str(),
+                // SBS content row requested through the unified side (rare —
+                // would mean a stale selection from a layout change): fall
+                // through to right like a context row.
+                DiffSide::SbsRight | DiffSide::Unified => right.as_str(),
+            },
+        }
+    }
+}
+
+/// Layout + per-frame snapshot needed to translate a terminal `(col, row)`
+/// hit inside the diff panel into `(side, display_row, byte_offset)`.
+/// Written on every render of `diff_panel::render_diff`; the mouse handler
+/// consults it on Down / Drag / Up to drive selection.
+///
+/// Storing the scroll values here (instead of looking them up on the live
+/// `App`) keeps the mouse handler panel-agnostic — both Git-tab Diff and
+/// Graph-tab 3-col diff write their own scroll fields into this struct.
+#[derive(Debug, Clone)]
+pub struct DiffHit {
+    pub layout: DiffLayout,
+    /// Panel-level rect, used for point-in-rect gating. Renderer caches
+    /// it separately too (`last_diff_rect`); kept here so a hit-test can
+    /// stay self-contained if needed.
+    pub panel: Rect,
+    /// First content row's absolute y. Rows above this are the file
+    /// header / separator line.
+    pub content_y: u16,
+    /// Last-rendered viewport height in rows. Used to clamp drag past the
+    /// bottom of the panel.
+    pub view_h: u16,
+
+    // Unified layout
+    pub content_x_unified: u16,
+
+    // SBS layout
+    pub content_x_left: u16,
+    pub content_x_right: u16,
+    pub right_start_x: u16,
+
+    // Scroll snapshot (for col → byte translation)
+    pub scroll: usize,
+    pub h_scroll: usize,
+    pub sbs_left_h_scroll: usize,
+    pub sbs_right_h_scroll: usize,
+
+    /// Flattened display rows in the same order `render_*` produces them.
+    /// Index into this vec is what `PreviewSelection.anchor.0` points at.
+    pub rows: Vec<DiffRowText>,
+}
+
+impl DiffHit {
+    /// Decide which side the hit column lands on in SBS layout. In Unified
+    /// it always returns `DiffSide::Unified`. The result is the side the
+    /// anchor binds to on a Down gesture; Drag keeps the side stable and
+    /// clamps the column to that side's range.
+    pub fn side_for_column(&self, col: u16) -> DiffSide {
+        match self.layout {
+            DiffLayout::Unified => DiffSide::Unified,
+            DiffLayout::SideBySide => {
+                if col >= self.right_start_x {
+                    DiffSide::SbsRight
+                } else {
+                    DiffSide::SbsLeft
+                }
+            }
+        }
+    }
+
+    /// Translate a terminal `(col, row)` hit into
+    /// `(display_row_index, byte_offset_in_row_text)` for the given side.
+    /// Returns `None` when the panel has no selectable rows (empty diff).
+    ///
+    /// `row` is clamped into `[0, rows.len()-1]` so dragging past the top
+    /// or bottom of the viewport extends the selection cleanly. Columns
+    /// left of the row's gutter collapse to byte 0; past end clamps to
+    /// `text.len()` — same "drag past line end" semantics as the text
+    /// preview's `mouse_to_file_coord`.
+    pub fn coord_for(&self, col: u16, row: u16, side: DiffSide) -> Option<(usize, usize)> {
+        if self.rows.is_empty() {
+            return None;
+        }
+        let visible_row = row.saturating_sub(self.content_y) as usize;
+        let row_idx = (self.scroll + visible_row).min(self.rows.len() - 1);
+        let text = self.rows[row_idx].text_for(side);
+        let (content_x, h_scroll) = match side {
+            DiffSide::Unified => (self.content_x_unified, self.h_scroll),
+            DiffSide::SbsLeft => (self.content_x_left, self.sbs_left_h_scroll),
+            DiffSide::SbsRight => (self.content_x_right, self.sbs_right_h_scroll),
+        };
+        let visible_col = (col.saturating_sub(content_x) as usize) + h_scroll;
+        let byte_offset = col_to_byte_offset(text, visible_col);
+        Some((row_idx, byte_offset))
+    }
+}
+
+/// Extract the selected text from a `DiffHit`'s cached rows using the
+/// selection's `side`. Separator rows contribute `""`, headers contribute
+/// their full text, content rows contribute the appropriate side. Lines
+/// joined with `\n`.
+pub fn collect_diff_selected_text(hit: &DiffHit, sel: &DiffSelection) -> String {
+    if sel.sel.is_empty() {
+        return String::new();
+    }
+    let (start, end) = sel.sel.normalized();
+    let last = end.0.min(hit.rows.len().saturating_sub(1));
+    let mut out = String::new();
+    for row in start.0..=last {
+        let Some(raw_text) = hit.rows.get(row) else {
+            continue;
+        };
+        let text = raw_text.text_for(sel.side);
+        let range = match sel.sel.line_byte_range(row, text) {
+            Some(r) => r,
+            None => continue,
+        };
+        if range.start < text.len() {
+            let end_clamped = range.end.min(text.len());
+            out.push_str(&text[range.start..end_clamped]);
+        }
+        if row < last {
+            out.push('\n');
+        }
+    }
+    out
 }
 
 /// 把选中范围从 `lines` 提取成一段纯文本。多行之间用 `\n` 连接。
@@ -398,5 +574,222 @@ mod tests {
     fn word_underscore_is_alnum() {
         let line = "_foo_bar";
         assert_eq!(word_at_byte(line, 0), 0..8); // whole "_foo_bar"
+    }
+
+    // ── DiffRowText / DiffHit / collect_diff_selected_text ───────────────
+
+    fn make_unified_hit(rows: Vec<DiffRowText>, scroll: usize) -> DiffHit {
+        DiffHit {
+            layout: DiffLayout::Unified,
+            panel: Rect::new(0, 0, 80, 20),
+            content_y: 2,
+            view_h: 18,
+            content_x_unified: 16,
+            content_x_left: 0,
+            content_x_right: 0,
+            right_start_x: 0,
+            scroll,
+            h_scroll: 0,
+            sbs_left_h_scroll: 0,
+            sbs_right_h_scroll: 0,
+            rows,
+        }
+    }
+
+    fn make_sbs_hit(rows: Vec<DiffRowText>) -> DiffHit {
+        // Half width 40, divider at col 40, right half content starts at 48.
+        DiffHit {
+            layout: DiffLayout::SideBySide,
+            panel: Rect::new(0, 0, 81, 20),
+            content_y: 2,
+            view_h: 18,
+            content_x_unified: 0,
+            content_x_left: 7,
+            content_x_right: 48,
+            right_start_x: 41,
+            scroll: 0,
+            h_scroll: 0,
+            sbs_left_h_scroll: 0,
+            sbs_right_h_scroll: 0,
+            rows,
+        }
+    }
+
+    #[test]
+    fn diff_row_text_unified_returns_body() {
+        let row = DiffRowText::Unified("hello".into());
+        assert_eq!(row.text_for(DiffSide::Unified), "hello");
+    }
+
+    #[test]
+    fn diff_row_text_sbs_picks_side() {
+        let row = DiffRowText::Sbs {
+            left: "old".into(),
+            right: "new".into(),
+        };
+        assert_eq!(row.text_for(DiffSide::SbsLeft), "old");
+        assert_eq!(row.text_for(DiffSide::SbsRight), "new");
+    }
+
+    #[test]
+    fn diff_row_text_header_ignores_side() {
+        let row = DiffRowText::Header("@@ -1 +1 @@".into());
+        assert_eq!(row.text_for(DiffSide::Unified), "@@ -1 +1 @@");
+        assert_eq!(row.text_for(DiffSide::SbsLeft), "@@ -1 +1 @@");
+        assert_eq!(row.text_for(DiffSide::SbsRight), "@@ -1 +1 @@");
+    }
+
+    #[test]
+    fn diff_hit_side_for_column_unified_is_always_unified() {
+        let hit = make_unified_hit(vec![DiffRowText::Unified("x".into())], 0);
+        assert_eq!(hit.side_for_column(0), DiffSide::Unified);
+        assert_eq!(hit.side_for_column(200), DiffSide::Unified);
+    }
+
+    #[test]
+    fn diff_hit_side_for_column_sbs_splits_on_right_start() {
+        let hit = make_sbs_hit(vec![DiffRowText::Sbs {
+            left: "l".into(),
+            right: "r".into(),
+        }]);
+        assert_eq!(hit.side_for_column(10), DiffSide::SbsLeft);
+        // right_start_x = 41 → col 40 is still left (divider), col 41 is right
+        assert_eq!(hit.side_for_column(40), DiffSide::SbsLeft);
+        assert_eq!(hit.side_for_column(41), DiffSide::SbsRight);
+        assert_eq!(hit.side_for_column(70), DiffSide::SbsRight);
+    }
+
+    #[test]
+    fn diff_hit_coord_for_unified_translates_col_to_byte() {
+        let rows = vec![DiffRowText::Unified("hello world".into())];
+        let hit = make_unified_hit(rows, 0);
+        // content_x_unified = 16, content_y = 2. Click at col 20 row 2 →
+        // visible_col = 4, byte_offset = 4 ('o' of "hello").
+        let (row_idx, byte_offset) =
+            hit.coord_for(20, 2, DiffSide::Unified).expect("coord");
+        assert_eq!(row_idx, 0);
+        assert_eq!(byte_offset, 4);
+    }
+
+    #[test]
+    fn diff_hit_coord_for_past_row_clamps_to_last() {
+        let rows = vec![DiffRowText::Unified("x".into()), DiffRowText::Unified("y".into())];
+        let hit = make_unified_hit(rows, 0);
+        // Row 50 way past end → clamps to last row (1).
+        let (row_idx, _byte) = hit.coord_for(16, 50, DiffSide::Unified).unwrap();
+        assert_eq!(row_idx, 1);
+    }
+
+    #[test]
+    fn diff_hit_coord_for_left_of_gutter_collapses_to_zero() {
+        let rows = vec![DiffRowText::Unified("hello".into())];
+        let hit = make_unified_hit(rows, 0);
+        // col 5 is inside gutter (< content_x_unified=16) → byte 0
+        let (_, byte) = hit.coord_for(5, 2, DiffSide::Unified).unwrap();
+        assert_eq!(byte, 0);
+    }
+
+    #[test]
+    fn diff_hit_coord_for_scrolled() {
+        let rows = vec![
+            DiffRowText::Unified("row0".into()),
+            DiffRowText::Unified("row1".into()),
+            DiffRowText::Unified("row2".into()),
+        ];
+        let hit = make_unified_hit(rows, 1);
+        // With scroll=1, visible row 0 is file row 1.
+        let (row_idx, _) = hit.coord_for(16, 2, DiffSide::Unified).unwrap();
+        assert_eq!(row_idx, 1);
+    }
+
+    #[test]
+    fn collect_diff_selected_text_unified_single_row() {
+        let rows = vec![DiffRowText::Unified("hello world".into())];
+        let hit = make_unified_hit(rows, 0);
+        let sel = DiffSelection {
+            sel: PreviewSelection {
+                anchor: (0, 6),
+                active: (0, 11),
+                dragging: false,
+            },
+            side: DiffSide::Unified,
+        };
+        assert_eq!(collect_diff_selected_text(&hit, &sel), "world");
+    }
+
+    #[test]
+    fn collect_diff_selected_text_unified_multi_row_includes_separator_as_blank() {
+        let rows = vec![
+            DiffRowText::Unified("first".into()),
+            DiffRowText::Separator,
+            DiffRowText::Unified("third".into()),
+        ];
+        let hit = make_unified_hit(rows, 0);
+        let sel = DiffSelection {
+            sel: PreviewSelection {
+                anchor: (0, 2),
+                active: (2, 3),
+                dragging: false,
+            },
+            side: DiffSide::Unified,
+        };
+        // "rst" + "\n" + "" + "\n" + "thi"
+        assert_eq!(collect_diff_selected_text(&hit, &sel), "rst\n\nthi");
+    }
+
+    #[test]
+    fn collect_diff_selected_text_unified_includes_header() {
+        let rows = vec![
+            DiffRowText::Unified("before".into()),
+            DiffRowText::Header("@@ -1 +1 @@".into()),
+            DiffRowText::Unified("after".into()),
+        ];
+        let hit = make_unified_hit(rows, 0);
+        let sel = DiffSelection {
+            sel: PreviewSelection {
+                anchor: (0, 0),
+                active: (2, 5),
+                dragging: false,
+            },
+            side: DiffSide::Unified,
+        };
+        assert_eq!(
+            collect_diff_selected_text(&hit, &sel),
+            "before\n@@ -1 +1 @@\nafter"
+        );
+    }
+
+    #[test]
+    fn collect_diff_selected_text_sbs_picks_side() {
+        let rows = vec![
+            DiffRowText::Sbs {
+                left: "old1".into(),
+                right: "new1".into(),
+            },
+            DiffRowText::Sbs {
+                left: "old2".into(),
+                right: "new2".into(),
+            },
+        ];
+        let hit = make_sbs_hit(rows);
+        let sel_left = DiffSelection {
+            sel: PreviewSelection {
+                anchor: (0, 0),
+                active: (1, 4),
+                dragging: false,
+            },
+            side: DiffSide::SbsLeft,
+        };
+        assert_eq!(collect_diff_selected_text(&hit, &sel_left), "old1\nold2");
+
+        let sel_right = DiffSelection {
+            sel: PreviewSelection {
+                anchor: (0, 0),
+                active: (1, 4),
+                dragging: false,
+            },
+            side: DiffSide::SbsRight,
+        };
+        assert_eq!(collect_diff_selected_text(&hit, &sel_right), "new1\nnew2");
     }
 }


### PR DESCRIPTION
## Summary

- **Diff panels now support in-TUI text selection** — click / drag, double-click a word, triple-click a line, MouseUp copies to clipboard. Same handful of gestures the text preview panel has had; works on Git-tab Diff and Graph-tab's new Diff column.
- **Graph tab grows a third column when a file diff is loaded** — `graph | commit metadata+files | diff`. Falls back to the previous 2-col inline layout on terminals < 100 cols. Both sub-column splits are draggable.
- **Shared `diff_panel::render_diff`** lets both tabs drive the same renderer, search integration, and selection handler. Before, the Graph tab had its own inline-diff renderer baked into `commit_detail_panel`; now it's one code path.

## User-facing changes

- Git tab Diff + Graph tab Diff (3-col only): drag-to-select / double-click word / triple-click line / MouseUp copy → toast.
- SBS mode: selection locks to the side the drag anchored on — crossing the divider extends vertically, doesn't flip. VSCode behavior.
- Graph tab: picking a file auto-focuses the Diff column (next arrow pans the diff viewport).
- Click-to-focus: clicking inside a column sets focus there — no more Shift+Tab before your arrow keys "aim" at the right panel.
- Shift+Tab cycles Files → Commit → Diff → Files in Graph 3-col (two-way elsewhere).
- Graph tab SBS: per-side horizontal scroll preserved from old behaviour; Git tab SBS now also gets per-side h_scroll (mouse routes per cursor side, keyboard pans both in lockstep).

## Implementation notes

Structured as 5 commits you can review in order:

1. `65863f5` **refactor**: extract `render_diff` as a pure renderer — zero behaviour change, sets up reuse.
2. `3ead11d` **feat(graph)**: 3-col layout, new `Panel::Commit` variant, draggable split, narrow-terminal fallback, focus + scroll routing per column.
3. `c260dcd` **feat(diff)**: `DiffSelection`/`DiffHit`/`DiffRowText` in `ui/selection.rs`, `handle_diff_selection` in `input.rs`, selection-overlay on row renderers, SBS side-lock via `clamp_col_to_side`.
4. `b7d408b` **refactor(follow-up)**: consolidate layout math so `ui::render` and `input::*` can't drift; fix focus-on-click; drop two dead `DiffHit` fields; add unit tests for layout + `graph_uses_three_col` switch matrix (12 new tests).
5. `5e1ad0a` **refactor(simplify)**: `App::clear_diff_selection()` helper replacing 6 copies; single-pass SBS width-max scan (was 2x); `sbs_cursor_on_left()` helper.

### Trade-offs documented in commits / comments
- `DiffHit.rows: Vec<DiffRowText>` clones row text per frame. ~80 KB/frame on a 1000-line diff. Fixing properly means plumbing `Arc<str>` through the hunk data model — deferred.
- SBS search-match overlay is still not wired (pre-existing). Row indices in `build_sbs_lines` don't match `unified_display_rows` — noted with `TODO(search-sbs)`.
- 2-col fallback's inline diff in `commit_detail_panel` doesn't go through `render_diff`, so mouse selection is unavailable there. Users on narrow terminals still have the `v` visual-mode → terminal-native selection path.

## Test plan

- [x] `cargo test --lib` → 391 passing (was 366 before this branch; +25 new)
- [x] `cargo clippy --lib` clean
- [x] `cargo build --release` clean
- [ ] Manual: Git tab diff — click+drag across unified + SBS, double/triple-click, copy lands in clipboard, SBS side-lock works
- [ ] Manual: Graph tab — pick file → 3-col activates, diff column shows content, click+drag works there too, middle↔diff split drag works
- [ ] Manual: narrow terminal (<100 cols) — falls back to 2-col, selection unavailable there (expected), layout doesn't glitch
- [ ] Manual: file switch / layout toggle / mode toggle / tab switch all reset selection cleanly
- [ ] Manual: search (`/`) still works on Git-tab Diff and lands on the Graph middle column + new `GraphDiff` target

🤖 Generated with [Claude Code](https://claude.com/claude-code)