### PR TITLE
feat(sidebar): toggle left sidebar via Ctrl+B and tab-bar button

### DIFF
--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -120,6 +120,26 @@ impl Drop for CwdGuard {
     }
 }
 
+/// Pin the UI language to English so test output stays deterministic
+/// across developer locales. i18n's `lang()` caches the choice in a
+/// process-wide `OnceLock` on first call, so callers should invoke this
+/// before any code path that reads `lang()`. Idempotent across calls
+/// within the same test binary.
+///
+/// Same serialisation warning as `HomeGuard`/`CwdGuard`: `set_var` is
+/// process-global, so callers must hold a test-file-local `Mutex<()>`.
+pub fn force_en_lang() {
+    if std::env::var_os("REEF_LANG").as_deref() == Some(std::ffi::OsStr::new("en")) {
+        return;
+    }
+    // SAFETY: callers hold a test-file-local mutex, and no other test
+    // touches `REEF_LANG` concurrently. Must precede any `t(Msg::*)` so
+    // the OnceLock seats with the English variant.
+    unsafe {
+        std::env::set_var("REEF_LANG", "en");
+    }
+}
+
 /// Initialize a real git repository in a temp directory. Sets the required
 /// `user.name` and `user.email` config so commits don't depend on the caller's
 /// global git config (critical for CI).

--- a/src/app.rs
+++ b/src/app.rs
@@ -450,6 +450,14 @@ pub struct App {
 
     // Layout
     pub split_percent: u16,
+    /// 侧边栏是否可见。关闭后左列(Panel::Files)不参与渲染,也不占宽度;
+    /// `graph_sidebar_width` 在 hidden 时短路返回 0,让所有共享宽度计算
+    /// (hit-testing、h-scroll 路由、drag zone 注册)自然跟随。Graph tab
+    /// 3-col 模式下关闭侧边栏会退化为 [Commit | Diff] 双列。
+    pub sidebar_visible: bool,
+    /// 第一次 hide 弹一条 Toast 帮用户找回入口,后续保持安静。不持久化:
+    /// Ctrl+B 在每个新会话里都允许让人迷茫一次。
+    pub sidebar_hide_hint_shown: bool,
     pub dragging_split: bool,
     /// Graph tab 三列布局下,中间 commit 列与右侧 diff 列的分割位置,用
     /// "非 graph 区域的百分比" 表示,从左向右计:中间列占 `100 -
@@ -671,20 +679,23 @@ pub(crate) fn compute_sidebar_width(total_width: u16, split_percent: u16) -> u16
 }
 
 /// Pure layout: 3-col widths `(graph, commit, diff)` summing to
-/// `total_width`. See `App::graph_three_col_widths` for caller rules.
+/// `total_width`. Callers pass an already-clamped `sidebar_w` (from
+/// `compute_sidebar_width` or `App::graph_sidebar_width`); when the
+/// sidebar is hidden it's 0 and the full width is redistributed
+/// between commit and diff using `graph_diff_split_percent`. See
+/// `App::graph_three_col_widths` for caller rules.
 pub(crate) fn compute_three_col_widths(
     total_width: u16,
-    split_percent: u16,
+    sidebar_w: u16,
     graph_diff_split_percent: u16,
 ) -> (u16, u16, u16) {
-    let graph_w = compute_sidebar_width(total_width, split_percent);
-    let remainder = total_width.saturating_sub(graph_w);
+    let remainder = total_width.saturating_sub(sidebar_w);
     let diff_w_raw = (remainder as u32 * graph_diff_split_percent as u32 / 100) as u16;
     // `.max(20)` + `.min(remainder - 20)` keeps both sub-columns usable
     // even when `graph_diff_split_percent` hits its drag clamp edges.
     let diff_w = diff_w_raw.max(20).min(remainder.saturating_sub(20));
     let commit_w = remainder.saturating_sub(diff_w);
-    (graph_w, commit_w, diff_w)
+    (sidebar_w, commit_w, diff_w)
 }
 
 impl App {
@@ -800,6 +811,8 @@ impl App {
             last_diff_hit: None,
             diff_click_state: None,
             split_percent: 30,
+            sidebar_visible: true,
+            sidebar_hide_hint_shown: false,
             dragging_split: false,
             graph_diff_split_percent: 60,
             dragging_graph_diff_split: false,
@@ -886,6 +899,9 @@ impl App {
     /// v0 — factored here so `input::*` and the render stay aligned
     /// even when `split_percent` lands near the extremes.
     pub fn graph_sidebar_width(&self, total_width: u16) -> u16 {
+        if !self.sidebar_visible {
+            return 0;
+        }
         compute_sidebar_width(total_width, self.split_percent)
     }
 
@@ -898,7 +914,7 @@ impl App {
     pub fn graph_three_col_widths(&self, total_width: u16) -> (u16, u16, u16) {
         compute_three_col_widths(
             total_width,
-            self.split_percent,
+            self.graph_sidebar_width(total_width),
             self.graph_diff_split_percent,
         )
     }
@@ -945,6 +961,13 @@ impl App {
         if self.active_panel == Panel::Commit && !self.graph_uses_three_col() {
             self.active_panel = Panel::Diff;
         }
+        // Sidebar hidden → Panel::Files has no rendered column. Demote here
+        // as a safety net even though `toggle_sidebar` already does it; a
+        // future code path that flips `sidebar_visible` without going through
+        // the toggle can't leave focus stranded.
+        if !self.sidebar_visible && self.active_panel == Panel::Files {
+            self.active_panel = Panel::Diff;
+        }
         // If we're on Graph and the 3-col diff column isn't visible anymore,
         // any selection was anchored into rows that no panel will render.
         if self.active_tab == Tab::Graph
@@ -952,6 +975,35 @@ impl App {
             && !self.graph_uses_three_col()
         {
             self.clear_diff_selection();
+        }
+    }
+
+    /// Toggle the left sidebar's visibility. Hiding collapses the left
+    /// column to 0 width (via `graph_sidebar_width`'s short-circuit); all
+    /// mouse hit-testing, h-scroll routing, and drag-zone registration key
+    /// off that same value so they stay consistent. Focus on `Panel::Files`
+    /// gets moved to `Panel::Diff` — the sidebar panel wouldn't render
+    /// otherwise and keyboard nav would aim at nothing. Any in-flight
+    /// column drag is cancelled so releasing the mouse after the hide
+    /// doesn't snap a phantom split_percent.
+    pub fn toggle_sidebar(&mut self) {
+        self.sidebar_visible = !self.sidebar_visible;
+        if !self.sidebar_visible {
+            if self.active_panel == Panel::Files {
+                self.active_panel = Panel::Diff;
+            }
+            self.dragging_split = false;
+            self.dragging_graph_diff_split = false;
+            // First-time-per-session hint so the user can find the way
+            // back without scanning the help popup. Subsequent hides
+            // stay quiet — the tab-bar button glyph already telegraphs
+            // the state.
+            if !self.sidebar_hide_hint_shown {
+                self.sidebar_hide_hint_shown = true;
+                self.toasts.push(Toast::info(crate::i18n::t(
+                    crate::i18n::Msg::SidebarHiddenHint,
+                )));
+            }
         }
     }
 
@@ -2908,6 +2960,9 @@ impl App {
             ClickAction::SwitchTab(tab) => {
                 self.set_active_tab(tab);
             }
+            ClickAction::ToggleSidebar => {
+                self.toggle_sidebar();
+            }
             ClickAction::TreeClick(index) => {
                 self.file_tree.selected = index;
                 if let Some(entry) = self.file_tree.entries.get(index) {
@@ -3593,7 +3648,7 @@ mod tests {
         // Regression guard: if the rounding ever changes, the assert below
         // pins the invariant `graph + commit + diff == total_width`. Hit-
         // testing + h-scroll routing rely on this exactly.
-        let (g, c, d) = compute_three_col_widths(200, 30, 60);
+        let (g, c, d) = compute_three_col_widths(200, 60, 60);
         assert_eq!(g + c + d, 200);
     }
 
@@ -3601,7 +3656,7 @@ mod tests {
     fn three_col_widths_diff_floor_20() {
         // graph_diff_split_percent = 0 shouldn't squeeze diff to 0 —
         // `.max(20)` keeps it usable.
-        let (_, _, d) = compute_three_col_widths(200, 30, 0);
+        let (_, _, d) = compute_three_col_widths(200, 60, 0);
         assert!(d >= 20, "diff col floored at 20, got {d}");
     }
 
@@ -3609,15 +3664,15 @@ mod tests {
     fn three_col_widths_commit_floor_20() {
         // graph_diff_split_percent = 100 shouldn't squeeze commit to 0 —
         // `.min(remainder - 20)` leaves commit at least 20 cols.
-        let (_, c, _) = compute_three_col_widths(200, 30, 100);
+        let (_, c, _) = compute_three_col_widths(200, 60, 100);
         assert!(c >= 20, "commit col floored at 20, got {c}");
     }
 
     #[test]
     fn three_col_widths_default_proportions() {
-        // Default tuning: split_percent=30, graph_diff_split_percent=60
+        // Default tuning: sidebar_w=60 (30% of 200), graph_diff_split_percent=60
         // on a 200-wide terminal. Sanity-check the split feels right.
-        let (g, c, d) = compute_three_col_widths(200, 30, 60);
+        let (g, c, d) = compute_three_col_widths(200, 60, 60);
         assert_eq!(g, 60);
         // remainder = 140, diff = 60% of 140 = 84, commit = 56.
         assert_eq!(d, 84);
@@ -3640,7 +3695,20 @@ mod tests {
         // width is the same value. `graph_diff_column_start` and
         // `focus_panel_under_cursor` depend on this.
         let sidebar_2 = compute_sidebar_width(150, 30);
-        let (graph_3, _, _) = compute_three_col_widths(150, 30, 60);
+        let (graph_3, _, _) = compute_three_col_widths(150, sidebar_2, 60);
         assert_eq!(sidebar_2, graph_3);
+    }
+
+    #[test]
+    fn three_col_widths_redistribute_when_sidebar_zero() {
+        // Sidebar hidden → sidebar_w=0; commit and diff fill the full
+        // width using `graph_diff_split_percent`. Diff stays 60% of 200
+        // and commit takes the rest, instead of inheriting the narrow
+        // commit_w computed off the (now nonexistent) sidebar slot.
+        let (g, c, d) = compute_three_col_widths(200, 0, 60);
+        assert_eq!(g, 0);
+        assert_eq!(g + c + d, 200);
+        assert_eq!(d, 120);
+        assert_eq!(c, 80);
     }
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -177,6 +177,8 @@ pub enum Msg {
     HelpDeleteEntry,
     HelpHardDeleteEntry,
     HelpRightClickMenu,
+    HelpToggleSidebar,
+    SidebarHiddenHint,
     HelpAnyKey,
 }
 
@@ -299,6 +301,8 @@ fn t_zh(m: Msg) -> &'static str {
         HelpDeleteEntry => "移动到废纸篓（带确认）",
         HelpHardDeleteEntry => "永久删除（不可撤销）",
         HelpRightClickMenu => "打开文件树右键菜单",
+        HelpToggleSidebar => "切换侧边栏显示",
+        SidebarHiddenHint => "侧边栏已隐藏 — Ctrl+B 可恢复",
         HelpAnyKey => "关闭帮助",
     }
 }
@@ -417,6 +421,8 @@ fn t_en(m: Msg) -> &'static str {
         HelpDeleteEntry => "Move to Trash (with confirm)",
         HelpHardDeleteEntry => "Delete permanently (cannot be undone)",
         HelpRightClickMenu => "Open file-tree context menu",
+        HelpToggleSidebar => "Toggle sidebar",
+        SidebarHiddenHint => "Sidebar hidden — Ctrl+B to restore",
         HelpAnyKey => "Close help",
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -184,15 +184,25 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
     // binding. Context: we're already past the palette / search / place
     // gates, so the leader is only in play during normal tab navigation.
     //
-    // Exception: when the Tab::Search search input is focused (modal
-    // `tab_input_focused`), bare Space is a literal separator in a
-    // multi-word query. We gate arming off so "foo bar" just types. An
-    // empty query is fine to arm anyway — there's no char to accidentally
-    // swallow yet.
-    let in_input_mode = app.active_tab == Tab::Search
+    // Exception: when a text input is focused — the Tab::Search query or
+    // the Tab::Git commit box — bare Space is a literal character the user
+    // is typing. We gate arming off so "foo bar" / "fix: the thing" just
+    // types. An empty buffer is fine to arm anyway — there's no char to
+    // accidentally swallow yet.
+    let search_input_focused = app.active_tab == Tab::Search
         && app.active_panel == Panel::Files
         && app.global_search.tab_input_focused;
-    let leader_allow_arm = !in_input_mode || app.global_search.query.is_empty();
+    let commit_input_focused = app.active_tab == Tab::Git
+        && app.active_panel == Panel::Files
+        && app.git_status.commit_editing;
+    let in_input_mode = search_input_focused || commit_input_focused;
+    let leader_allow_arm = if search_input_focused {
+        app.global_search.query.is_empty()
+    } else if commit_input_focused {
+        app.git_status.commit_message.is_empty()
+    } else {
+        true
+    };
     match leader_decision(
         &key,
         leader_allow_arm,
@@ -240,6 +250,14 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
             app.open_hosts_picker();
             return;
         }
+        // Ctrl+B toggles the left sidebar — VSCode muscle memory. Sits in
+        // the always-on block so it works regardless of which tab or panel
+        // owns focus; overlays (quick-open, global-search, hosts picker)
+        // return earlier so they're unaffected.
+        KeyCode::Char('b') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.toggle_sidebar();
+            return;
+        }
         KeyCode::Tab => {
             let tabs = Tab::ALL;
             let cur = tabs.iter().position(|&t| t == app.active_tab).unwrap_or(0);
@@ -269,11 +287,10 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         _ => {}
     }
 
-    // Bare-character global shortcuts — stolen from the query when the
-    // Tab::Search input is focused. Otherwise `h` = help, `q` = quit,
-    // `/` = in-panel search, `n`/`N` = step matches, `1`-`9` = jump tab —
-    // all of which the user is likely to want as literal chars inside a
-    // search query.
+    // Bare-character global shortcuts — suppressed whenever a text input
+    // is focused (Tab::Search query or Tab::Git commit box) so they don't
+    // steal literal keystrokes mid-typing. Otherwise `h` = help, `q` = quit,
+    // `/` = in-panel search, `n`/`N` = step matches, `1`-`9` = jump tab.
     //
     // `/` has a context-aware override: in Tab::Search list mode it focuses
     // the search input instead of firing in-panel search. The in-panel
@@ -1622,7 +1639,10 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
                 apply_horizontal_scroll(app, mouse.column, total_width, -3);
                 return;
             }
-            let split_x = total_width * app.split_percent / 100;
+            // Use the shared clamp + sidebar-hidden short-circuit so wheel
+            // routing lines up with hit-testing. With sidebar hidden
+            // `graph_sidebar_width` returns 0 and `is_left` never fires.
+            let split_x = app.graph_sidebar_width(total_width);
             let is_left = mouse.column < split_x;
             match app.active_tab {
                 Tab::Git => {
@@ -1671,7 +1691,7 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
                 apply_horizontal_scroll(app, mouse.column, total_width, 3);
                 return;
             }
-            let split_x = total_width * app.split_percent / 100;
+            let split_x = app.graph_sidebar_width(total_width);
             let is_left = mouse.column < split_x;
             match app.active_tab {
                 Tab::Git => {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -29,6 +29,13 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph};
 use unicode_width::UnicodeWidthStr;
 
+/// Tab-bar sidebar-toggle button glyphs. `⊟` (squared minus) renders
+/// when the sidebar is visible; clicking collapses. `⊞` (squared plus)
+/// renders when hidden; clicking expands. Exposed `pub` so tests scan
+/// for the rendered glyph against this single source of truth.
+pub const SIDEBAR_TOGGLE_GLYPH_VISIBLE: &str = "⊟";
+pub const SIDEBAR_TOGGLE_GLYPH_HIDDEN: &str = "⊞";
+
 pub fn render(f: &mut Frame, app: &mut App) {
     let size = f.area();
     app.hit_registry.clear();
@@ -66,42 +73,68 @@ pub fn render(f: &mut Frame, app: &mut App) {
     app.last_total_width = main_layout[2].width;
     app.normalize_active_panel();
 
-    // Body: left + right (+ optional diff column for Graph tab 3-col mode).
+    // Body: left (+ optional commit column for Graph 3-col) + right.
     // Width math goes through `App::graph_sidebar_width` /
     // `graph_three_col_widths` so `input::*` and `ui::render` agree on
     // where column boundaries fall — important for hit-testing and
-    // h-scroll routing to land in the right column.
+    // h-scroll routing to land in the right column. When the sidebar is
+    // hidden, `graph_sidebar_width` returns 0 and the left column drops
+    // out of the layout entirely (no 0-width rect, no StartDragSplit zone
+    // anchored at the screen edge). Graph 3-col mode without sidebar
+    // degrades to [Commit | Diff] so the commit metadata column stays.
     let total_w = main_layout[2].width;
     let three_col = app.graph_uses_three_col();
+    let sidebar_w = app.graph_sidebar_width(total_w);
+    let has_sidebar = sidebar_w > 0;
     let body_layout = if three_col {
-        let (graph_w, commit_w, _) = app.graph_three_col_widths(total_w);
+        let (_, commit_w, _) = app.graph_three_col_widths(total_w);
+        if has_sidebar {
+            Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([
+                    Constraint::Length(sidebar_w),
+                    Constraint::Length(commit_w),
+                    Constraint::Min(20),
+                ])
+                .split(main_layout[2])
+        } else {
+            Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Length(commit_w), Constraint::Min(20)])
+                .split(main_layout[2])
+        }
+    } else if has_sidebar {
         Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([
-                Constraint::Length(graph_w),
-                Constraint::Length(commit_w),
-                Constraint::Min(20),
-            ])
+            .constraints([Constraint::Length(sidebar_w), Constraint::Min(20)])
             .split(main_layout[2])
     } else {
-        let left_width = app.graph_sidebar_width(total_w);
         Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Length(left_width), Constraint::Min(20)])
+            .constraints([Constraint::Min(20)])
             .split(main_layout[2])
     };
 
-    // Drag zone on the graph | right split border
-    let split_x = body_layout[0].x + body_layout[0].width.saturating_sub(1);
-    app.hit_registry.register(
-        Rect::new(split_x, body_layout[0].y, 2, body_layout[0].height),
-        ClickAction::StartDragSplit,
-    );
-    // Second drag zone for the commit | diff boundary in 3-col mode.
-    if three_col && body_layout.len() >= 3 {
-        let mid_split_x = body_layout[1].x + body_layout[1].width.saturating_sub(1);
+    // Index of the editor column in `body_layout`. With sidebar hidden the
+    // sidebar slot is absent so the editor slides left by one.
+    let editor_idx = if has_sidebar { 1 } else { 0 };
+
+    // Drag zone on the sidebar | right split border — only meaningful when
+    // the sidebar actually occupies a column.
+    if has_sidebar {
+        let split_x = body_layout[0].x + body_layout[0].width.saturating_sub(1);
         app.hit_registry.register(
-            Rect::new(mid_split_x, body_layout[1].y, 2, body_layout[1].height),
+            Rect::new(split_x, body_layout[0].y, 2, body_layout[0].height),
+            ClickAction::StartDragSplit,
+        );
+    }
+    // Second drag zone for the commit | diff boundary in 3-col mode. The
+    // commit column sits right after the (optional) sidebar.
+    if three_col {
+        let commit_rect = body_layout[editor_idx];
+        let mid_split_x = commit_rect.x + commit_rect.width.saturating_sub(1);
+        app.hit_registry.register(
+            Rect::new(mid_split_x, commit_rect.y, 2, commit_rect.height),
             ClickAction::StartDragGraphDiffSplit,
         );
     }
@@ -111,26 +144,32 @@ pub fn render(f: &mut Frame, app: &mut App) {
             if !app.backend.has_repo() {
                 render_no_repo(f, app, body_layout[0]);
             } else {
-                render_git_sidebar(f, app, body_layout[0]);
-                render_git_editor(f, app, body_layout[1]);
+                if has_sidebar {
+                    render_git_sidebar(f, app, body_layout[0]);
+                }
+                render_git_editor(f, app, body_layout[editor_idx]);
             }
         }
         Tab::Files => {
-            file_tree_panel::render(f, app, body_layout[0]);
-            file_preview_panel::render(f, app, body_layout[1]);
+            if has_sidebar {
+                file_tree_panel::render(f, app, body_layout[0]);
+            }
+            file_preview_panel::render(f, app, body_layout[editor_idx]);
         }
         Tab::Graph => {
-            render_graph_sidebar(f, app, body_layout[0]);
+            if has_sidebar {
+                render_graph_sidebar(f, app, body_layout[0]);
+            }
+            render_graph_editor(f, app, body_layout[editor_idx]);
             if three_col {
-                render_graph_editor(f, app, body_layout[1]);
-                render_graph_diff_column(f, app, body_layout[2]);
-            } else {
-                render_graph_editor(f, app, body_layout[1]);
+                render_graph_diff_column(f, app, body_layout[editor_idx + 1]);
             }
         }
         Tab::Search => {
-            search_tab::render_sidebar(f, app, body_layout[0]);
-            file_preview_panel::render(f, app, body_layout[1]);
+            if has_sidebar {
+                search_tab::render_sidebar(f, app, body_layout[0]);
+            }
+            file_preview_panel::render(f, app, body_layout[editor_idx]);
         }
     }
 
@@ -346,11 +385,33 @@ fn render_tab_bar(f: &mut Frame, app: &mut App, area: Rect) {
         }
     }
 
-    // Fill rest of row
-    let remaining = (area.width as usize).saturating_sub(x.saturating_sub(area.x) as usize);
+    // Glyph mirrors current state so the icon doubles as state readout
+    // (⊟ when visible, ⊞ when hidden). The click target is registered
+    // tight to the glyph's columns so clicks on the surrounding hint
+    // don't accidentally toggle.
     let keys_hint = t(Msg::TabBarHint);
-    let pad = remaining.saturating_sub(UnicodeWidthStr::width(keys_hint));
+    let button_text = if app.sidebar_visible {
+        " ⊟ "
+    } else {
+        " ⊞ "
+    };
+    let button_w = UnicodeWidthStr::width(button_text) as u16;
+    let consumed = x.saturating_sub(area.x) as usize;
+    let right_chrome = button_w as usize + UnicodeWidthStr::width(keys_hint);
+    let pad = (area.width as usize)
+        .saturating_sub(consumed)
+        .saturating_sub(right_chrome);
     spans.push(Span::styled(" ".repeat(pad), Style::default().bg(bg)));
+    let button_x = x + pad as u16;
+    app.hit_registry
+        .register_row(button_x, area.y, button_w, ClickAction::ToggleSidebar);
+    spans.push(Span::styled(
+        button_text,
+        Style::default()
+            .fg(th.chrome_muted_fg)
+            .bg(bg)
+            .add_modifier(Modifier::BOLD),
+    ));
     spans.push(Span::styled(
         keys_hint,
         Style::default().fg(th.chrome_muted_fg).bg(bg),
@@ -684,6 +745,7 @@ fn render_help(f: &mut Frame, app: &App, screen: Rect) {
         ("r", t(Msg::HelpRefresh)),
         ("v", t(Msg::HelpSelectMode)),
         ("h", t(Msg::HelpShowHelp)),
+        ("Ctrl+B", t(Msg::HelpToggleSidebar)),
         ("Space p", t(Msg::HelpQuickOpen)),
         ("Space f", t(Msg::HelpGlobalSearch)),
         (t(Msg::HelpKeyDragDrop), t(Msg::HelpDragDrop)),

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -16,6 +16,8 @@ pub enum ClickAction {
     /// Graph tab 3-col 布局下,中间 commit 列与右侧 diff 列之间的拖拽
     /// 分界。跟 `StartDragSplit` 互不干扰。
     StartDragGraphDiffSplit,
+    /// 标签栏右侧的侧边栏可见性切换按钮。等价于 Ctrl+B,但鼠标可点。
+    ToggleSidebar,
     SwitchTab(Tab),
     TreeClick(usize),
     /// Click on a row in the quick-open palette. The `usize` indexes

--- a/tests/sidebar_toggle.rs
+++ b/tests/sidebar_toggle.rs
@@ -1,0 +1,184 @@
+//! Toggle-sidebar behaviour. Verifies the flag flips, width math
+//! collapses to 0 on hide, and focus demotes off the hidden sidebar
+//! panel so keyboard nav doesn't aim at a column no one renders.
+//! Also pins the tab-bar toggle button's hit-registry registration
+//! so a refactor of `render_tab_bar` can't silently mis-place it.
+
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use reef::app::{App, Panel};
+use reef::ui::mouse::ClickAction;
+use reef::ui::theme::Theme;
+use reef::ui::{self, SIDEBAR_TOGGLE_GLYPH_HIDDEN, SIDEBAR_TOGGLE_GLYPH_VISIBLE};
+use std::sync::Mutex;
+use tempfile::TempDir;
+use test_support::{CwdGuard, force_en_lang};
+
+static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+/// Render a single frame at the given size and return both the buffer
+/// (for cell inspection) and the hit-registry mutations the render
+/// path produced (which now lives on `app` as a side effect).
+fn render_once(app: &mut App, width: u16, height: u16) -> Buffer {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(|f| ui::render(f, app)).unwrap();
+    terminal.backend().buffer().clone()
+}
+
+/// Scan the tab-bar row (y=1) for the first cell whose glyph matches
+/// `needle`. Used to locate the toggle button column without hardcoding
+/// a position that depends on tab-label widths.
+fn find_tab_bar_glyph(buf: &Buffer, needle: &str) -> Option<u16> {
+    (0..buf.area().width).find(|&x| buf.cell((x, 1)).map(|c| c.symbol()) == Some(needle))
+}
+
+#[test]
+fn sidebar_visible_by_default() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let app = App::new(Theme::dark(), None);
+    assert!(app.sidebar_visible);
+    assert!(app.graph_sidebar_width(200) > 0);
+}
+
+#[test]
+fn toggle_hides_sidebar_and_zeroes_width() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.toggle_sidebar();
+    assert!(!app.sidebar_visible);
+    assert_eq!(app.graph_sidebar_width(200), 0);
+}
+
+#[test]
+fn toggle_restores_sidebar() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.toggle_sidebar();
+    app.toggle_sidebar();
+    assert!(app.sidebar_visible);
+    assert!(app.graph_sidebar_width(200) > 0);
+}
+
+#[test]
+fn hiding_demotes_files_focus_to_diff() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.active_panel = Panel::Files;
+    app.toggle_sidebar();
+    assert_eq!(app.active_panel, Panel::Diff);
+}
+
+#[test]
+fn hiding_preserves_non_files_focus() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.active_panel = Panel::Diff;
+    app.toggle_sidebar();
+    assert_eq!(app.active_panel, Panel::Diff);
+}
+
+#[test]
+fn hiding_cancels_in_flight_drags() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.dragging_split = true;
+    app.dragging_graph_diff_split = true;
+    app.toggle_sidebar();
+    assert!(!app.dragging_split);
+    assert!(!app.dragging_graph_diff_split);
+}
+
+#[test]
+fn normalize_panel_catches_stranded_files_focus() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    // Direct field write bypasses `toggle_sidebar`'s focus demotion —
+    // `normalize_active_panel` must catch it on the next render.
+    let mut app = App::new(Theme::dark(), None);
+    app.sidebar_visible = false;
+    app.active_panel = Panel::Files;
+    app.normalize_active_panel();
+    assert_eq!(app.active_panel, Panel::Diff);
+}
+
+#[test]
+fn first_hide_pushes_toast_subsequent_dont() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    let before = app.toasts.len();
+    app.toggle_sidebar(); // hide → expect one new toast
+    assert_eq!(app.toasts.len(), before + 1);
+    assert!(app.toasts.last().unwrap().message.contains("Ctrl+B"));
+
+    app.toggle_sidebar(); // show
+    app.toggle_sidebar(); // hide again
+    // Hint flag stays set for the session; second hide must stay quiet.
+    assert_eq!(app.toasts.len(), before + 1);
+}
+
+#[test]
+fn render_registers_toggle_button_at_glyph_column_when_visible() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    force_en_lang();
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    let buf = render_once(&mut app, 80, 20);
+
+    let x = find_tab_bar_glyph(&buf, SIDEBAR_TOGGLE_GLYPH_VISIBLE)
+        .expect("collapse button must render in tab bar when sidebar visible");
+    assert!(
+        matches!(
+            app.hit_registry.hit_test(x, 1),
+            Some(ClickAction::ToggleSidebar)
+        ),
+        "hit-test on the rendered glyph column must dispatch ToggleSidebar",
+    );
+    assert!(find_tab_bar_glyph(&buf, SIDEBAR_TOGGLE_GLYPH_HIDDEN).is_none());
+}
+
+#[test]
+fn render_registers_toggle_button_at_glyph_column_when_hidden() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    force_en_lang();
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.toggle_sidebar();
+    let buf = render_once(&mut app, 80, 20);
+
+    let x = find_tab_bar_glyph(&buf, SIDEBAR_TOGGLE_GLYPH_HIDDEN)
+        .expect("expand button must render in tab bar when sidebar hidden");
+    assert!(matches!(
+        app.hit_registry.hit_test(x, 1),
+        Some(ClickAction::ToggleSidebar)
+    ));
+    assert!(find_tab_bar_glyph(&buf, SIDEBAR_TOGGLE_GLYPH_VISIBLE).is_none());
+}

--- a/tests/snapshots/ui_snapshots__binary_info_pdf.snap
+++ b/tests/snapshots/ui_snapshots__binary_info_pdf.snap
@@ -3,7 +3,7 @@ source: tests/ui_snapshots.rs
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
- 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph           1:Files 2:Search 3:Git 4:Graph
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph        ⊟  1:Files 2:Search 3:Git 4:Graph
  +   📁    ↻   ⊟        │ doc.pdf
    doc.pdf U           │ ──────────────────────────────────────────────────────
                        │ application/pdf · 14 B

--- a/tests/snapshots/ui_snapshots__empty_repo.snap
+++ b/tests/snapshots/ui_snapshots__empty_repo.snap
@@ -3,7 +3,7 @@ source: tests/ui_snapshots.rs
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
- 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph           1:Files 2:Search 3:Git 4:Graph
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph        ⊟  1:Files 2:Search 3:Git 4:Graph
  +   📁    ↻   ⊟        │
  (empty)               │
                        │

--- a/tests/snapshots/ui_snapshots__graph_range_mode.snap
+++ b/tests/snapshots/ui_snapshots__graph_range_mode.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 325
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
- 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph           1:Files 2:Search 3:Git 4:Graph
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph        ⊟  1:Files 2:Search 3:Git 4:Graph
  ▌● [OID]  HEAD   mas│ Range · 3 commits [OID]..[OID]
  ● [OID] second      │ Click any commit below to collapse back to single-selec
  ● [OID] first       │

--- a/tests/snapshots/ui_snapshots__hosts_picker_empty.snap
+++ b/tests/snapshots/ui_snapshots__hosts_picker_empty.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 274
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
- 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph           1:Files 2:Search 3:Git 4:Graph
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph        ⊟  1:Files 2:Search 3:Git 4:Graph
  +   📁  Connect to · filter ─────────────────────────────────────────────┐
  (empt│ ›                                                                │
       │ ──────────────────────────────────────────────────────────────── │

--- a/tests/snapshots/ui_snapshots__hosts_picker_path_mode.snap
+++ b/tests/snapshots/ui_snapshots__hosts_picker_path_mode.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 345
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
- 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph           1:Files 2:Search 3:Git 4:Graph
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph        ⊟  1:Files 2:Search 3:Git 4:Graph
  +   📁  Connect to · [user@]host[:path] ─────────────────────────────────┐
  (empt│ ➜ root@47.101.167.85:/tmp/work                                   │
       │ ──────────────────────────────────────────────────────────────── │

--- a/tests/snapshots/ui_snapshots__hosts_picker_populated.snap
+++ b/tests/snapshots/ui_snapshots__hosts_picker_populated.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 316
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
- 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph           1:Files 2:Search 3:Git 4:Graph
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph        ⊟  1:Files 2:Search 3:Git 4:Graph
  +   📁  Connect to · filter ─────────────────────────────────────────────┐
  (empt│ ›                                                                │
       │ ──────────────────────────────────────────────────────────────── │

--- a/tests/snapshots/ui_snapshots__image_preview_halfblocks.snap
+++ b/tests/snapshots/ui_snapshots__image_preview_halfblocks.snap
@@ -3,7 +3,7 @@ source: tests/ui_snapshots.rs
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
- 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph           1:Files 2:Search 3:Git 4:Graph
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph        ⊟  1:Files 2:Search 3:Git 4:Graph
  +   📁    ↻   ⊟        │ striped.png
    striped.png U       │ ──────────────────────────────────────────────────────
                        │ 40×40 · PNG · 257 B

--- a/tests/snapshots/ui_snapshots__place_mode.snap
+++ b/tests/snapshots/ui_snapshots__place_mode.snap
@@ -3,7 +3,7 @@ source: tests/ui_snapshots.rs
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
- 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph           1:Files 2:Search 3:Git 4:Graph
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph        ⊟  1:Files 2:Search 3:Git 4:Graph
 ╔══════════════════════╗
 ║ 📋  Placing README.md ║
 ║ ▸ src                ║

--- a/tests/snapshots/ui_snapshots__tree_context_menu.snap
+++ b/tests/snapshots/ui_snapshots__tree_context_menu.snap
@@ -3,7 +3,7 @@ source: tests/ui_snapshots.rs
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
- 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph           1:Files 2:Search 3:Git 4:Graph
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph        ⊟  1:Files 2:Search 3:Git 4:Graph
  +   📁    ↻   ⊟        │
  ▸ src ●               │
    README.md           │

--- a/tests/snapshots/ui_snapshots__tree_edit_row_new_file.snap
+++ b/tests/snapshots/ui_snapshots__tree_edit_row_new_file.snap
@@ -3,7 +3,7 @@ source: tests/ui_snapshots.rs
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
- 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph           1:Files 2:Search 3:Git 4:Graph
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph        ⊟  1:Files 2:Search 3:Git 4:Graph
  +   📁    ↻   ⊟        │
  ▸ src ●               │
       New file name…   │

--- a/tests/snapshots/ui_snapshots__with_staged_and_unstaged.snap
+++ b/tests/snapshots/ui_snapshots__with_staged_and_unstaged.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 136
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
- 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph           1:Files 2:Search 3:Git 4:Graph
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph        ⊟  1:Files 2:Search 3:Git 4:Graph
   ┌ Message (commit sta│
   │                    │
   └                    │

--- a/tests/snapshots/ui_snapshots__with_staged_and_unstaged_light.snap
+++ b/tests/snapshots/ui_snapshots__with_staged_and_unstaged_light.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 454
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
- 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph           1:Files 2:Search 3:Git 4:Graph
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph        ⊟  1:Files 2:Search 3:Git 4:Graph
   ┌ Message (commit sta│
   │                    │
   └                    │

--- a/tests/space_leader_input.rs
+++ b/tests/space_leader_input.rs
@@ -1,0 +1,107 @@
+//! Space-leader chord arming behaviour around text-input contexts.
+//!
+//! The leader is `bare Space` followed by `p` / `f`. The arm step must
+//! NOT fire while the user is mid-typing in a text input — otherwise
+//! the Space they meant as a literal separator vanishes into the chord
+//! state machine. Two input contexts qualify: the Tab::Search query
+//! and the Tab::Git commit box. Empty buffers stay armable (no char
+//! to swallow yet).
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use reef::app::{App, Panel, Tab};
+use reef::input;
+use reef::ui::theme::Theme;
+use std::sync::Mutex;
+use tempfile::TempDir;
+use test_support::CwdGuard;
+
+static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+fn space_key() -> KeyEvent {
+    KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE)
+}
+
+#[test]
+fn bare_space_arms_leader_in_normal_context() {
+    // Sanity check: when no text input is focused, bare Space arms
+    // the leader as expected — guards against a regression in the
+    // input-mode gate accidentally suppressing the normal path.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    assert!(app.space_leader_at.is_none());
+    input::handle_key(space_key(), &mut app);
+    assert!(
+        app.space_leader_at.is_some(),
+        "bare Space should arm in normal context"
+    );
+}
+
+#[test]
+fn space_does_not_arm_while_typing_in_commit_box() {
+    // Git tab + commit_editing=true + commit_message non-empty: the
+    // user is mid-message ("fix: " ...), and bare Space must stay a
+    // literal char rather than priming a chord that would swallow
+    // the next `p`/`f` they type.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+    app.active_panel = Panel::Files;
+    app.git_status.commit_editing = true;
+    app.git_status.commit_message = "fix:".to_string();
+
+    input::handle_key(space_key(), &mut app);
+    assert!(
+        app.space_leader_at.is_none(),
+        "Space inside a non-empty commit message must not arm the chord",
+    );
+}
+
+#[test]
+fn space_arms_when_commit_box_empty() {
+    // Empty buffer is the arming-friendly edge case: there's no char
+    // to clobber, and a chord that immediately fires is just as
+    // useful here as anywhere else. Mirrors the global-search query
+    // gate's `query.is_empty()` branch.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+    app.active_panel = Panel::Files;
+    app.git_status.commit_editing = true;
+    app.git_status.commit_message.clear();
+
+    input::handle_key(space_key(), &mut app);
+    assert!(
+        app.space_leader_at.is_some(),
+        "Space with empty commit buffer should still arm",
+    );
+}
+
+#[test]
+fn space_does_not_arm_while_typing_in_search_query() {
+    // Mirror test for the older Tab::Search input mode — the same
+    // gate covers it, so a regression in either branch fails here.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Search);
+    app.active_panel = Panel::Files;
+    app.global_search.tab_input_focused = true;
+    app.global_search.query = "foo".to_string();
+
+    input::handle_key(space_key(), &mut app);
+    assert!(
+        app.space_leader_at.is_none(),
+        "Space inside a non-empty search query must not arm the chord",
+    );
+}

--- a/tests/ui_snapshots.rs
+++ b/tests/ui_snapshots.rs
@@ -16,21 +16,11 @@ use reef::ui::theme::Theme;
 use std::sync::Mutex;
 use std::thread;
 use std::time::{Duration, Instant};
-use test_support::{CwdGuard, HomeGuard, commit_file, tempdir_repo, write_file, write_striped_png};
+use test_support::{
+    CwdGuard, HomeGuard, commit_file, force_en_lang, tempdir_repo, write_file, write_striped_png,
+};
 
 static CWD_LOCK: Mutex<()> = Mutex::new(());
-
-/// Pin the UI language so the snapshot is stable regardless of the test
-/// host's system locale. Called under `CWD_LOCK`; the first call seeds
-/// i18n's OnceLock cache for the process so all three snapshot tests
-/// render in the same language.
-fn force_en_lang() {
-    // SAFETY: test-only; `CWD_LOCK` serialises the three snapshot tests
-    // and no other test in this binary touches env vars.
-    unsafe {
-        std::env::set_var("REEF_LANG", "en");
-    }
-}
 
 // `HomeGuard` and `CwdGuard` — redirect $HOME / cwd for the snapshot — live in `test-support`.
 // The local `CWD_LOCK` doubles as the HOME_LOCK here because every test in


### PR DESCRIPTION
## Summary
- New `Ctrl+B` keybinding and a tab-bar `⊟`/`⊞` button that hide/show the left sidebar (Files panel column).
- `App.sidebar_visible` flows through `graph_sidebar_width`'s 0-width short-circuit, so hit-testing, h-scroll routing, drag-zone registration, and Graph 3-col layout all follow consistently — no scattered `if sidebar_visible` checks across input dispatch.
- Graph 3-col without sidebar degrades to `[Commit | Diff]` over the full width, redistributing via `graph_diff_split_percent` so the user's drag-tuned ratio still applies.
- First hide pushes a one-shot Toast (`Ctrl+B to restore`) so users find the way back.

## Bundled fix
Bare `Space` no longer arms the leader chord while typing in the Git-tab commit box (mirrors the existing Tab::Search query gate). Without this, typing `fix: ` in the commit message would swallow the next `p`/`f` as a chord target.

## Test plan
- [ ] Open reef → press `Ctrl+B` → sidebar collapses; first hide shows the toast hint
- [ ] Click the `⊟` glyph in the tab bar → collapses; click `⊞` → restores
- [ ] On Graph tab with a file diff loaded, hide sidebar → `Commit | Diff` fill the row using the configured split
- [ ] In Git tab, start typing a multi-word commit message (`fix: foo bar`) → `Space` stays a literal char, no `p`/`f` follow-up fires the leader chord
- [ ] `cargo test --test sidebar_toggle --test space_leader_input --test ui_snapshots --test app_error_paths`

🤖 Generated with [Claude Code](https://claude.com/claude-code)