### PR TITLE
feat(ui): visible panel focus + Ctrl+F preview search

### DIFF
--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -193,8 +193,22 @@ pub enum Msg {
     HelpHardDeleteEntry,
     HelpRightClickMenu,
     HelpToggleSidebar,
+    /// `Esc` row in the help popup — describes the general two-step
+    /// back-out behaviour (clear dormant search, then return panel
+    /// focus to the list/tree column). The Graph-visual-mode row
+    /// keeps its own description because that Esc fires earlier.
+    HelpEscBackOut,
     SidebarHiddenHint,
     HelpAnyKey,
+
+    // Status bar panel-focus chip — short labels for the right-aligned
+    // indicator showing which panel currently owns focus.
+    PanelFiles,
+    PanelPreview,
+    PanelCommit,
+    PanelDiff,
+    PanelSearch,
+    PanelGraph,
 }
 
 pub fn t(m: Msg) -> &'static str {
@@ -321,8 +335,15 @@ fn t_zh(m: Msg) -> &'static str {
         HelpHardDeleteEntry => "永久删除（不可撤销）",
         HelpRightClickMenu => "打开文件树右键菜单",
         HelpToggleSidebar => "切换侧边栏显示",
+        HelpEscBackOut => "退出焦点 / 清除搜索",
         SidebarHiddenHint => "侧边栏已隐藏 — Ctrl+B 可恢复",
         HelpAnyKey => "关闭帮助",
+        PanelFiles => "文件",
+        PanelPreview => "预览",
+        PanelCommit => "提交",
+        PanelDiff => "Diff",
+        PanelSearch => "搜索",
+        PanelGraph => "图表",
     }
 }
 
@@ -445,8 +466,15 @@ fn t_en(m: Msg) -> &'static str {
         HelpHardDeleteEntry => "Delete permanently (cannot be undone)",
         HelpRightClickMenu => "Open file-tree context menu",
         HelpToggleSidebar => "Toggle sidebar",
+        HelpEscBackOut => "Exit focus / clear search",
         SidebarHiddenHint => "Sidebar hidden — Ctrl+B to restore",
         HelpAnyKey => "Close help",
+        PanelFiles => "Files",
+        PanelPreview => "Preview",
+        PanelCommit => "Commit",
+        PanelDiff => "Diff",
+        PanelSearch => "Search",
+        PanelGraph => "Graph",
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -338,14 +338,20 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
             return;
         }
         KeyCode::Tab => {
-            app.active_panel =
-                next_panel(app.active_panel, app.graph_uses_three_col(), /* reverse= */ false);
+            app.active_panel = next_panel(
+                app.active_panel,
+                app.graph_uses_three_col(),
+                /* reverse= */ false,
+            );
             app.search.clear();
             return;
         }
         KeyCode::BackTab => {
-            app.active_panel =
-                next_panel(app.active_panel, app.graph_uses_three_col(), /* reverse= */ true);
+            app.active_panel = next_panel(
+                app.active_panel,
+                app.graph_uses_three_col(),
+                /* reverse= */ true,
+            );
             app.search.clear();
             return;
         }

--- a/src/input.rs
+++ b/src/input.rs
@@ -310,29 +310,68 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
             app.toggle_sidebar();
             return;
         }
-        KeyCode::Tab => {
+        // Ctrl+F: VSCode-style find-in-file. Forces focus onto the
+        // preview so `search::begin`'s `resolve_target` picks
+        // `SearchTarget::FilePreview` regardless of where focus was.
+        // Suppressed in text-input modes so it doesn't yank the user
+        // out of a half-typed commit message or global-search query.
+        KeyCode::Char('f')
+            if key.modifiers.contains(KeyModifiers::CONTROL)
+                && !in_input_mode
+                && matches!(app.active_tab, Tab::Files | Tab::Search) =>
+        {
+            if app.active_panel != Panel::Diff {
+                app.active_panel = Panel::Diff;
+            }
+            search::begin(app, false);
+            return;
+        }
+        // Ctrl+Tab: best-effort "next tab" alias. Many legacy terminals
+        // (Terminal.app) collapse Ctrl+Tab into plain Tab, in which
+        // case the bare-Tab arm below catches it and number keys
+        // remain the reliable tab-switch path.
+        KeyCode::Tab if key.modifiers.contains(KeyModifiers::CONTROL) => {
             let tabs = Tab::ALL;
             let cur = tabs.iter().position(|&t| t == app.active_tab).unwrap_or(0);
             app.set_active_tab(tabs[(cur + 1) % tabs.len()]);
             app.search.clear();
             return;
         }
+        KeyCode::Tab => {
+            app.active_panel =
+                next_panel(app.active_panel, app.graph_uses_three_col(), /* reverse= */ false);
+            app.search.clear();
+            return;
+        }
         KeyCode::BackTab => {
-            // Graph tab 3-col cycles Files → Commit → Diff → Files so
-            // Shift+Tab reaches the new middle column. Other tabs (and the
-            // Graph 2-col fallback) keep the two-way toggle.
-            app.active_panel = if app.graph_uses_three_col() {
-                match app.active_panel {
-                    Panel::Files => Panel::Commit,
-                    Panel::Commit => Panel::Diff,
-                    Panel::Diff => Panel::Files,
-                }
-            } else {
-                match app.active_panel {
-                    Panel::Files | Panel::Commit => Panel::Diff,
-                    Panel::Diff => Panel::Files,
-                }
-            };
+            app.active_panel =
+                next_panel(app.active_panel, app.graph_uses_three_col(), /* reverse= */ true);
+            app.search.clear();
+            return;
+        }
+        // Esc back-out, two-step. Active search input and modal Esc
+        // handlers (place mode, tree-edit, paste-conflict, …) run
+        // earlier via top-of-`handle_key` early-returns, so this
+        // block only fires for the "no specific modal owns Esc" case.
+        //   1. Clear dormant `/` highlights — but only when the
+        //      current panel owns them. If the user Tab'd to a
+        //      different panel the highlights aren't on screen, so
+        //      Esc passes through to that panel's own handler
+        //      (commit-box exit, multi-select clear, …) instead of
+        //      being silently swallowed.
+        //   2. Otherwise, return panel focus to `Panel::Files`. Both
+        //      arms use guards so Graph visual-mode exit and other
+        //      per-tab Esc semantics still fall through when neither
+        //      applies.
+        KeyCode::Esc
+            if !app.search.matches.is_empty()
+                && search::resolve_target(app) == app.search.target =>
+        {
+            app.search.clear();
+            return;
+        }
+        KeyCode::Esc if app.active_panel != Panel::Files => {
+            app.active_panel = Panel::Files;
             app.search.clear();
             return;
         }
@@ -419,6 +458,32 @@ fn has_pending_confirm(app: &App) -> bool {
     app.git_status.confirm_discard.is_some()
         || app.git_status.confirm_push
         || app.git_status.confirm_force_push
+}
+
+/// Step a `Panel` one position forward (or backward if `reverse`). The
+/// 3-col Graph layout has its own ordering — Files → Commit → Diff —
+/// that the 2-col fallback collapses to a Files↔Diff toggle. Used by
+/// the bare-Tab and Shift+Tab handlers; pulled out as a pure fn (no
+/// `&App` parameter) so the state machine is unit-testable.
+fn next_panel(current: Panel, three_col: bool, reverse: bool) -> Panel {
+    if three_col {
+        match (current, reverse) {
+            (Panel::Files, false) => Panel::Commit,
+            (Panel::Commit, false) => Panel::Diff,
+            (Panel::Diff, false) => Panel::Files,
+            (Panel::Files, true) => Panel::Diff,
+            (Panel::Commit, true) => Panel::Files,
+            (Panel::Diff, true) => Panel::Commit,
+        }
+    } else {
+        // 2-col fallback. Reverse direction is a no-op (it's a toggle).
+        // `Panel::Commit` only appears in 3-col Graph, but normalise
+        // defensively in case state lingered across a layout switch.
+        match current {
+            Panel::Files | Panel::Commit => Panel::Diff,
+            Panel::Diff => Panel::Files,
+        }
+    }
 }
 
 /// SQLite preview page-jump input. While `app.db_goto_input` is
@@ -2264,6 +2329,12 @@ fn handle_preview_selection(mouse: &MouseEvent, app: &mut App) -> bool {
             if !point_in_rect(rect, mouse.column, mouse.row) {
                 return false;
             }
+            // Focus follows the click — this handler returns `true` and
+            // short-circuits the main dispatcher's `focus_panel_under_cursor`
+            // call, so we have to promote the panel ourselves. Mirror of
+            // the same line in `handle_diff_selection`.
+            app.active_panel = Panel::Diff;
+
             let Some(origin) = content_origin else {
                 return false;
             };
@@ -3365,5 +3436,60 @@ mod paste_parser_tests {
         let paste = format!("'{}'", file.to_string_lossy());
         let got = parse_dropped_paths(&paste);
         assert_eq!(got, vec![file]);
+    }
+}
+
+#[cfg(test)]
+mod next_panel_tests {
+    use super::*;
+
+    // 3-col Graph forward cycle: Files → Commit → Diff → Files.
+    #[test]
+    fn three_col_forward_cycles_through_all_three() {
+        assert_eq!(next_panel(Panel::Files, true, false), Panel::Commit);
+        assert_eq!(next_panel(Panel::Commit, true, false), Panel::Diff);
+        assert_eq!(next_panel(Panel::Diff, true, false), Panel::Files);
+    }
+
+    // Reverse direction in 3-col walks Files → Diff → Commit → Files.
+    #[test]
+    fn three_col_reverse_cycles_in_opposite_order() {
+        assert_eq!(next_panel(Panel::Files, true, true), Panel::Diff);
+        assert_eq!(next_panel(Panel::Diff, true, true), Panel::Commit);
+        assert_eq!(next_panel(Panel::Commit, true, true), Panel::Files);
+    }
+
+    // Forward + reverse must compose back to the original panel.
+    #[test]
+    fn three_col_round_trip_returns_origin() {
+        for &p in &[Panel::Files, Panel::Commit, Panel::Diff] {
+            let one_step = next_panel(p, true, false);
+            let back = next_panel(one_step, true, true);
+            assert_eq!(back, p, "round-trip from {:?} must return self", p);
+        }
+    }
+
+    // 2-col layout collapses to a Files↔Diff toggle. Commit (which only
+    // exists in 3-col Graph) is normalised onto Files.
+    #[test]
+    fn two_col_toggles_files_and_diff() {
+        assert_eq!(next_panel(Panel::Files, false, false), Panel::Diff);
+        assert_eq!(next_panel(Panel::Diff, false, false), Panel::Files);
+        // Defensive: stale Panel::Commit from a recent layout change
+        // routes to Diff instead of panicking or hanging.
+        assert_eq!(next_panel(Panel::Commit, false, false), Panel::Diff);
+    }
+
+    // 2-col reverse must match forward (it's a toggle either way).
+    #[test]
+    fn two_col_reverse_equals_forward() {
+        for &p in &[Panel::Files, Panel::Commit, Panel::Diff] {
+            assert_eq!(
+                next_panel(p, false, false),
+                next_panel(p, false, true),
+                "2-col toggle is direction-agnostic at {:?}",
+                p
+            );
+        }
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -310,7 +310,7 @@ pub fn step(app: &mut App, reverse: bool) {
 
 // ─── Target resolution ────────────────────────────────────────────────────────
 
-fn resolve_target(app: &App) -> Option<SearchTarget> {
+pub(crate) fn resolve_target(app: &App) -> Option<SearchTarget> {
     match (app.active_tab, app.active_panel) {
         (Tab::Files, Panel::Files) => Some(SearchTarget::FileTree),
         (Tab::Files, Panel::Diff) => Some(SearchTarget::FilePreview),

--- a/src/ui/db_preview.rs
+++ b/src/ui/db_preview.rs
@@ -64,13 +64,15 @@ pub(in crate::ui) fn render(
     area: Rect,
     path: &str,
     info: &DatabaseInfo,
+    focused: bool,
 ) {
     if area.height < 1 {
         return;
     }
     let th = app.theme;
     let max_y = area.y + area.height;
-    let mut y = crate::ui::file_preview_panel::render_card_header(f, area, path, &th);
+    let mut y =
+        crate::ui::file_preview_panel::render_card_header(f, area, path, &th, focused, None);
 
     // Meta line — same shape as the binary card's `application/x · N B`
     // so the eye picks it up in the same place across formats.

--- a/src/ui/file_preview_panel.rs
+++ b/src/ui/file_preview_panel.rs
@@ -59,9 +59,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, focused: bool) {
 
     match &preview.body {
         PreviewBody::Text { .. } => render_text(f, app, inner, &preview, focused),
-        PreviewBody::Image(img) => {
-            render_image(f, app, inner, &preview.file_path, img, focused)
-        }
+        PreviewBody::Image(img) => render_image(f, app, inner, &preview.file_path, img, focused),
         PreviewBody::Binary(info) => {
             render_binary_info(f, app, inner, &preview.file_path, info, focused)
         }
@@ -141,7 +139,9 @@ pub(in crate::ui) fn render_card_header(
 
     let title_style = header_title_style(theme, focused);
     let count_text = match_count.map(|(cur, total)| format!("[{}/{}]", cur, total));
-    let count_style = Style::default().fg(theme.accent).add_modifier(Modifier::BOLD);
+    let count_style = Style::default()
+        .fg(theme.accent)
+        .add_modifier(Modifier::BOLD);
 
     // Right-align the [i/N] counter when present and there's room. Falls
     // back to a plain title when the panel is too narrow to fit both.
@@ -325,13 +325,7 @@ fn binary_reason_text(info: &BinaryInfo) -> String {
     }
 }
 
-fn render_text(
-    f: &mut Frame,
-    app: &mut App,
-    area: Rect,
-    preview: &PreviewContent,
-    focused: bool,
-) {
+fn render_text(f: &mut Frame, app: &mut App, area: Rect, preview: &PreviewContent, focused: bool) {
     let (lines, highlighted) = match &preview.body {
         PreviewBody::Text { lines, highlighted } => (lines, highlighted),
         _ => return,
@@ -343,15 +337,14 @@ fn render_text(
     // committed matches against this preview. Cleared automatically on tab
     // / panel switch by `SearchState::clear`, so cross-target leakage isn't
     // possible here.
-    let match_count = if app.search.target == Some(SearchTarget::FilePreview)
-        && !app.search.matches.is_empty()
-    {
-        let total = app.search.matches.len();
-        let cur = app.search.current.map(|i| i + 1).unwrap_or(0);
-        Some((cur, total))
-    } else {
-        None
-    };
+    let match_count =
+        if app.search.target == Some(SearchTarget::FilePreview) && !app.search.matches.is_empty() {
+            let total = app.search.matches.len();
+            let cur = app.search.current.map(|i| i + 1).unwrap_or(0);
+            Some((cur, total))
+        } else {
+            None
+        };
     let y = render_card_header(f, area, &preview.file_path, &th, focused, match_count);
 
     let content_height = (max_y - y) as usize;

--- a/src/ui/file_preview_panel.rs
+++ b/src/ui/file_preview_panel.rs
@@ -2,6 +2,7 @@ use crate::app::App;
 use crate::file_tree::{BinaryInfo, BinaryReason, ImagePreview, PreviewBody, PreviewContent};
 use crate::i18n::{Msg, t};
 use crate::search::SearchTarget;
+use crate::ui::focus::header_title_style;
 use crate::ui::text::{clip_spans, overlay_match_highlight, overlay_selection_highlight};
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -18,7 +19,7 @@ use unicode_width::UnicodeWidthStr;
 /// image row still fits.
 const MIN_META_HEIGHT: u16 = 5;
 
-pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
+pub fn render(f: &mut Frame, app: &mut App, area: Rect, focused: bool) {
     let block = Block::default().padding(Padding::new(1, 1, 0, 0));
     let inner = block.inner(area);
     f.render_widget(block, area);
@@ -44,7 +45,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
         _ => false,
     };
     if show_loading {
-        render_loading(f, app, inner, loading_target.as_ref().unwrap());
+        render_loading(f, app, inner, loading_target.as_ref().unwrap(), focused);
         return;
     }
 
@@ -57,11 +58,15 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
     };
 
     match &preview.body {
-        PreviewBody::Text { .. } => render_text(f, app, inner, &preview),
-        PreviewBody::Image(img) => render_image(f, app, inner, &preview.file_path, img),
-        PreviewBody::Binary(info) => render_binary_info(f, app, inner, &preview.file_path, info),
+        PreviewBody::Text { .. } => render_text(f, app, inner, &preview, focused),
+        PreviewBody::Image(img) => {
+            render_image(f, app, inner, &preview.file_path, img, focused)
+        }
+        PreviewBody::Binary(info) => {
+            render_binary_info(f, app, inner, &preview.file_path, info, focused)
+        }
         PreviewBody::Database(info) => {
-            crate::ui::db_preview::render(f, app, inner, &preview.file_path, info)
+            crate::ui::db_preview::render(f, app, inner, &preview.file_path, info, focused)
         }
     }
 
@@ -74,13 +79,13 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
 /// instead of the previous file's content. Body is a centred "loading…"
 /// label; we don't show a spinner because the typical decode window
 /// (~100-200 ms) is too short to animate meaningfully.
-fn render_loading(f: &mut Frame, app: &App, area: Rect, target: &Path) {
+fn render_loading(f: &mut Frame, app: &App, area: Rect, target: &Path, focused: bool) {
     if area.height < 1 {
         return;
     }
     let th = app.theme;
     let max_y = area.y + area.height;
-    let y = render_card_header(f, area, &target.to_string_lossy(), &th);
+    let y = render_card_header(f, area, &target.to_string_lossy(), &th, focused, None);
     if y >= max_y {
         return;
     }
@@ -114,32 +119,70 @@ fn render_empty(f: &mut Frame, app: &App, area: Rect) {
 /// call this; we clamp internally so a single-row panel shows at
 /// least the filename. Visible to the sibling `db_preview` module
 /// so it can share the same chrome.
+///
+/// `focused` decides accent vs. muted color for the title. `match_count`
+/// is `Some((current_1based, total))` when an in-panel `/` search has
+/// committed matches against this preview — it renders right-aligned in
+/// the title row as `[3/12]`. Pass `None` for body variants that don't
+/// participate in preview-content search (image / binary / database).
 pub(in crate::ui) fn render_card_header(
     f: &mut Frame,
     area: Rect,
     path: &str,
     theme: &crate::ui::theme::Theme,
+    focused: bool,
+    match_count: Option<(usize, usize)>,
 ) -> u16 {
     let mut y = area.y;
     let max_y = area.y + area.height;
     if y >= max_y {
         return y;
     }
-    f.render_widget(
-        Line::from(Span::styled(
-            path,
-            Style::default()
-                .fg(theme.fg_primary)
-                .add_modifier(Modifier::BOLD),
-        )),
-        Rect::new(area.x, y, area.width, 1),
-    );
+
+    let title_style = header_title_style(theme, focused);
+    let count_text = match_count.map(|(cur, total)| format!("[{}/{}]", cur, total));
+    let count_style = Style::default().fg(theme.accent).add_modifier(Modifier::BOLD);
+
+    // Right-align the [i/N] counter when present and there's room. Falls
+    // back to a plain title when the panel is too narrow to fit both.
+    let path_w = UnicodeWidthStr::width(path) as u16;
+    let count_w = count_text
+        .as_deref()
+        .map(|c| UnicodeWidthStr::width(c) as u16)
+        .unwrap_or(0);
+    let fits_counter = count_text.is_some()
+        // 1-col gap between path and counter.
+        && path_w.saturating_add(1).saturating_add(count_w) <= area.width;
+
+    let title_rect = Rect::new(area.x, y, area.width, 1);
+    if fits_counter {
+        let count = count_text.as_deref().unwrap();
+        let pad_w = area.width.saturating_sub(path_w).saturating_sub(count_w);
+        let pad = " ".repeat(pad_w as usize);
+        f.render_widget(
+            Line::from(vec![
+                Span::styled(path, title_style),
+                Span::raw(pad),
+                Span::styled(count, count_style),
+            ]),
+            title_rect,
+        );
+    } else {
+        // Either no counter, or not enough room — drop the counter to keep
+        // the filename readable.
+        f.render_widget(Line::from(Span::styled(path, title_style)), title_rect);
+    }
     y += 1;
     if y < max_y {
+        let sep_color = if focused {
+            theme.accent
+        } else {
+            theme.fg_secondary
+        };
         f.render_widget(
             Line::from(Span::styled(
                 "─".repeat(area.width as usize),
-                Style::default().fg(theme.fg_secondary),
+                Style::default().fg(sep_color),
             )),
             Rect::new(area.x, y, area.width, 1),
         );
@@ -152,13 +195,20 @@ pub(in crate::ui) fn render_card_header(
 /// `StatefulProtocol` lives on `App` (not on `PreviewContent`) because it
 /// holds non-`Send` state and is constructed on the main thread when the
 /// worker's `DynamicImage` lands. See `App::apply_worker_result`.
-fn render_image(f: &mut Frame, app: &mut App, area: Rect, path: &str, img: &ImagePreview) {
+fn render_image(
+    f: &mut Frame,
+    app: &mut App,
+    area: Rect,
+    path: &str,
+    img: &ImagePreview,
+    focused: bool,
+) {
     if area.height < 1 {
         return;
     }
     let th = app.theme;
     let max_y = area.y + area.height;
-    let mut y = render_card_header(f, area, path, &th);
+    let mut y = render_card_header(f, area, path, &th, focused, None);
 
     // Metadata line. Skipped when the panel is too short — in that case
     // we'd rather reclaim the row for actual pixels than spend it on text.
@@ -216,13 +266,20 @@ fn render_image(f: &mut Frame, app: &mut App, area: Rect, path: &str, img: &Imag
 /// formats (SVG/AVIF/HEIC), corrupt files, and the 0-byte case. The
 /// `reason` decides the one-line message; the header carries the filename
 /// and the metadata line carries MIME + size.
-fn render_binary_info(f: &mut Frame, app: &App, area: Rect, path: &str, info: &BinaryInfo) {
+fn render_binary_info(
+    f: &mut Frame,
+    app: &App,
+    area: Rect,
+    path: &str,
+    info: &BinaryInfo,
+    focused: bool,
+) {
     if area.height < 1 {
         return;
     }
     let th = app.theme;
     let max_y = area.y + area.height;
-    let mut y = render_card_header(f, area, path, &th);
+    let mut y = render_card_header(f, area, path, &th, focused, None);
 
     // MIME + size line (e.g. "application/pdf · 2.4 MB"). Pre-rendered
     // at load time on `BinaryInfo::new`; empty when we have neither a
@@ -268,14 +325,34 @@ fn binary_reason_text(info: &BinaryInfo) -> String {
     }
 }
 
-fn render_text(f: &mut Frame, app: &mut App, area: Rect, preview: &PreviewContent) {
+fn render_text(
+    f: &mut Frame,
+    app: &mut App,
+    area: Rect,
+    preview: &PreviewContent,
+    focused: bool,
+) {
     let (lines, highlighted) = match &preview.body {
         PreviewBody::Text { lines, highlighted } => (lines, highlighted),
         _ => return,
     };
     let th = app.theme;
     let max_y = area.y + area.height;
-    let y = render_card_header(f, area, &preview.file_path, &th);
+
+    // [i/N] match counter — shown only when an in-panel `/` search has
+    // committed matches against this preview. Cleared automatically on tab
+    // / panel switch by `SearchState::clear`, so cross-target leakage isn't
+    // possible here.
+    let match_count = if app.search.target == Some(SearchTarget::FilePreview)
+        && !app.search.matches.is_empty()
+    {
+        let total = app.search.matches.len();
+        let cur = app.search.current.map(|i| i + 1).unwrap_or(0);
+        Some((cur, total))
+    } else {
+        None
+    };
+    let y = render_card_header(f, area, &preview.file_path, &th, focused, match_count);
 
     let content_height = (max_y - y) as usize;
     // Cache the content viewport height so search-jump can center matches.

--- a/src/ui/file_tree_panel.rs
+++ b/src/ui/file_tree_panel.rs
@@ -10,19 +10,20 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders};
 
-pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
+pub fn render(f: &mut Frame, app: &mut App, area: Rect, focused: bool) {
     if app.place_mode.active {
-        render_place_mode(f, app, area);
+        render_place_mode(f, app, area, focused);
     } else {
-        render_normal(f, app, area);
+        render_normal(f, app, area, focused);
     }
 }
 
-fn render_normal(f: &mut Frame, app: &mut App, area: Rect) {
+fn render_normal(f: &mut Frame, app: &mut App, area: Rect, focused: bool) {
     let th = app.theme;
+    let border_color = if focused { th.accent } else { th.border };
     let block = Block::default()
         .borders(Borders::RIGHT)
-        .border_style(Style::default().fg(th.border));
+        .border_style(Style::default().fg(border_color));
     let inner = block.inner(area);
     f.render_widget(block, area);
 
@@ -568,7 +569,7 @@ fn render_edit_error(f: &mut Frame, app: &App, x: u16, y: u16, width: u16) {
 // returns the last-registered match, so folder rows shadow the root zone
 // cleanly.
 
-fn render_place_mode(f: &mut Frame, app: &mut App, area: Rect) {
+fn render_place_mode(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
     use crate::place_mode::{HoverTarget, resolve_hover_target};
     let th = app.theme;
 

--- a/src/ui/focus.rs
+++ b/src/ui/focus.rs
@@ -1,0 +1,57 @@
+//! Convention: focused → `theme.accent`; unfocused → `theme.fg_secondary`.
+//! Title rows keep `BOLD` in both states so the typographic weight doesn't
+//! jiggle when focus moves.
+
+use crate::ui::theme::Theme;
+use ratatui::style::{Modifier, Style};
+
+pub fn header_title_style(theme: &Theme, focused: bool) -> Style {
+    let fg = if focused {
+        theme.accent
+    } else {
+        theme.fg_secondary
+    };
+    Style::default().fg(fg).add_modifier(Modifier::BOLD)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_title_style_changes_color_with_focus() {
+        let th = Theme::dark();
+        let f = header_title_style(&th, true);
+        let u = header_title_style(&th, false);
+        // The whole point of the helper: focused must be visually distinct.
+        // We assert via the resolved fg color, not the Style struct, because
+        // ratatui's Style has more fields (bg, modifiers) we don't care about.
+        assert_ne!(f.fg, u.fg, "focused/unfocused titles must differ");
+        assert_eq!(f.fg, Some(th.accent));
+        assert_eq!(u.fg, Some(th.fg_secondary));
+    }
+
+    #[test]
+    fn header_title_style_keeps_bold_in_both_states() {
+        let th = Theme::dark();
+        // BOLD is preserved across focus state so the row weight doesn't
+        // jiggle when the user Tab/Shift+Tabs between panels.
+        for focused in [true, false] {
+            let s = header_title_style(&th, focused);
+            assert!(
+                s.add_modifier.contains(Modifier::BOLD),
+                "BOLD must be set when focused={focused}"
+            );
+        }
+    }
+
+    #[test]
+    fn header_title_style_works_for_light_theme_too() {
+        // Light theme uses different RGB but the same focused/unfocused
+        // contract; guarding against accidental theme drift.
+        let th = Theme::light();
+        let f = header_title_style(&th, true);
+        let u = header_title_style(&th, false);
+        assert_ne!(f.fg, u.fg);
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,6 +4,7 @@ pub mod db_preview;
 pub mod diff_panel;
 pub mod file_preview_panel;
 pub mod file_tree_panel;
+pub mod focus;
 pub mod git_graph_panel;
 pub mod git_status_panel;
 pub mod global_search_panel;
@@ -153,9 +154,11 @@ pub fn render(f: &mut Frame, app: &mut App) {
         }
         Tab::Files => {
             if has_sidebar {
-                file_tree_panel::render(f, app, body_layout[0]);
+                let focused = matches!(app.active_panel, crate::app::Panel::Files);
+                file_tree_panel::render(f, app, body_layout[0], focused);
             }
-            file_preview_panel::render(f, app, body_layout[editor_idx]);
+            let focused = matches!(app.active_panel, crate::app::Panel::Diff);
+            file_preview_panel::render(f, app, body_layout[editor_idx], focused);
         }
         Tab::Graph => {
             if has_sidebar {
@@ -170,7 +173,8 @@ pub fn render(f: &mut Frame, app: &mut App) {
             if has_sidebar {
                 search_tab::render_sidebar(f, app, body_layout[0]);
             }
-            file_preview_panel::render(f, app, body_layout[editor_idx]);
+            let focused = matches!(app.active_panel, crate::app::Panel::Diff);
+            file_preview_panel::render(f, app, body_layout[editor_idx], focused);
         }
     }
 
@@ -656,18 +660,131 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
         },
     };
 
+    // Right-aligned panel chip showing which pane currently owns focus.
+    // Always rendered in `accent` since it is by definition the focused
+    // panel — the visual cue is the chip's presence and color, not its
+    // change of state. Drops automatically when the row is too narrow.
+    let chip = format!(" [{}] ", panel_chip_text(app.active_tab, app.active_panel));
+    let chip_style = Style::default()
+        .fg(th.accent)
+        .bg(th.chrome_bg)
+        .add_modifier(Modifier::BOLD);
+
+    let hint_text = t(Msg::StatusBarHint);
+    let hint_w = UnicodeWidthStr::width(hint_text) as u16;
+    let chip_w = UnicodeWidthStr::width(chip.as_str()) as u16;
+    let notif_w = UnicodeWidthStr::width(notif.as_str()) as u16;
+
+    let pad_w = area
+        .width
+        .saturating_sub(notif_w)
+        .saturating_sub(hint_w)
+        .saturating_sub(chip_w);
+
     let status = Line::from(vec![
         Span::styled(notif, Style::default().fg(notif_color).bg(th.chrome_bg)),
         Span::styled(
-            " ".repeat(area.width.saturating_sub(60) as usize),
+            " ".repeat(pad_w as usize),
             Style::default().bg(th.chrome_bg),
         ),
         Span::styled(
-            t(Msg::StatusBarHint),
+            hint_text,
             Style::default().fg(th.chrome_muted_fg).bg(th.chrome_bg),
         ),
+        Span::styled(chip, chip_style),
     ]);
     f.render_widget(status, area);
+}
+
+/// i18n short label for the currently-focused panel — drives the
+/// status-bar chip. Derived from `(tab, panel)` so the label reflects
+/// what the panel actually shows in this tab (e.g., `Panel::Files` is
+/// "Files" in the Files/Git tabs but "Search" in the Search tab where
+/// the left column is the query input). Pulled out as a pure fn (no
+/// `&App` parameter) so the mapping is unit-testable.
+fn panel_chip_text(tab: crate::app::Tab, panel: crate::app::Panel) -> &'static str {
+    use crate::app::{Panel, Tab};
+    match (tab, panel) {
+        (Tab::Files, Panel::Files) => t(Msg::PanelFiles),
+        (Tab::Files, Panel::Diff | Panel::Commit) => t(Msg::PanelPreview),
+        (Tab::Search, Panel::Files) => t(Msg::PanelSearch),
+        (Tab::Search, Panel::Diff | Panel::Commit) => t(Msg::PanelPreview),
+        (Tab::Git, Panel::Files) => t(Msg::PanelFiles),
+        (Tab::Git, Panel::Diff | Panel::Commit) => t(Msg::PanelDiff),
+        (Tab::Graph, Panel::Files) => t(Msg::PanelGraph),
+        (Tab::Graph, Panel::Commit) => t(Msg::PanelCommit),
+        (Tab::Graph, Panel::Diff) => t(Msg::PanelDiff),
+    }
+}
+
+#[cfg(test)]
+mod panel_chip_tests {
+    use super::*;
+    use crate::app::{Panel, Tab};
+
+    // Files tab → file tree on the left, preview on the right.
+    #[test]
+    fn files_tab_panels_match_their_role() {
+        assert_eq!(panel_chip_text(Tab::Files, Panel::Files), t(Msg::PanelFiles));
+        assert_eq!(panel_chip_text(Tab::Files, Panel::Diff), t(Msg::PanelPreview));
+    }
+
+    // Search tab → query input on the left, preview on the right.
+    // Critical: Panel::Files in Search tab is NOT "Files" — it's the
+    // search query column.
+    #[test]
+    fn search_tab_left_panel_labels_as_search_not_files() {
+        assert_eq!(
+            panel_chip_text(Tab::Search, Panel::Files),
+            t(Msg::PanelSearch)
+        );
+        assert_eq!(
+            panel_chip_text(Tab::Search, Panel::Diff),
+            t(Msg::PanelPreview)
+        );
+    }
+
+    // Git tab → file list on the left, diff (not preview) on the right.
+    #[test]
+    fn git_tab_right_panel_labels_as_diff_not_preview() {
+        assert_eq!(panel_chip_text(Tab::Git, Panel::Files), t(Msg::PanelFiles));
+        assert_eq!(panel_chip_text(Tab::Git, Panel::Diff), t(Msg::PanelDiff));
+    }
+
+    // Graph tab in 3-col mode is the only place all three Panels are
+    // distinct — sidebar/middle/diff each get their own label.
+    #[test]
+    fn graph_tab_distinguishes_all_three_panels() {
+        let g = panel_chip_text(Tab::Graph, Panel::Files);
+        let c = panel_chip_text(Tab::Graph, Panel::Commit);
+        let d = panel_chip_text(Tab::Graph, Panel::Diff);
+        assert_eq!(g, t(Msg::PanelGraph));
+        assert_eq!(c, t(Msg::PanelCommit));
+        assert_eq!(d, t(Msg::PanelDiff));
+        // And those three labels must be pairwise distinct so the chip
+        // is actually informative across the cycle.
+        assert_ne!(g, c);
+        assert_ne!(c, d);
+        assert_ne!(g, d);
+    }
+
+    // Defensive: Panel::Commit only legitimately appears in Graph 3-col,
+    // but if it leaked into another tab via stale state, the label
+    // should still resolve sensibly without panicking.
+    #[test]
+    fn stale_commit_panel_falls_back_per_tab() {
+        // Files / Search treat it as preview (the right column).
+        assert_eq!(
+            panel_chip_text(Tab::Files, Panel::Commit),
+            t(Msg::PanelPreview)
+        );
+        assert_eq!(
+            panel_chip_text(Tab::Search, Panel::Commit),
+            t(Msg::PanelPreview)
+        );
+        // Git treats it as diff.
+        assert_eq!(panel_chip_text(Tab::Git, Panel::Commit), t(Msg::PanelDiff));
+    }
 }
 
 fn render_search_prompt(f: &mut Frame, app: &App, area: Rect) {
@@ -757,8 +874,9 @@ fn render_help(f: &mut Frame, app: &App, screen: Rect) {
     let th = app.theme;
     let core_entries: &[(&str, &str)] = &[
         ("q / Ctrl+C", t(Msg::HelpQuit)),
-        ("Tab", t(Msg::HelpSwitchTab)),
-        ("Shift+Tab", t(Msg::HelpSwitchPanel)),
+        ("Tab / Shift+Tab", t(Msg::HelpSwitchPanel)),
+        ("Ctrl+Tab", t(Msg::HelpSwitchTab)),
+        ("Esc", t(Msg::HelpEscBackOut)),
         ("1 … 9", t(Msg::HelpJumpTab)),
         ("↑ / k / Ctrl+P", t(Msg::HelpNavUp)),
         ("↓ / j / Ctrl+N", t(Msg::HelpNavDown)),
@@ -770,7 +888,7 @@ fn render_help(f: &mut Frame, app: &App, screen: Rect) {
         ("↑ / ↓ (visual)", t(Msg::HelpGraphRangeExtend)),
         ("PgUp / PgDn (visual)", t(Msg::HelpGraphRangeExtendFast)),
         ("Click (visual)", t(Msg::HelpGraphVisualClick)),
-        ("Esc", t(Msg::HelpGraphRangeClear)),
+        ("Esc (visual)", t(Msg::HelpGraphRangeClear)),
         ("Shift+↑ / Shift+↓", t(Msg::HelpGraphShiftExtend)),
         ("Shift+Click", t(Msg::HelpGraphShiftClick)),
         ("Home / End", t(Msg::HelpHomeEnd)),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -717,76 +717,6 @@ fn panel_chip_text(tab: crate::app::Tab, panel: crate::app::Panel) -> &'static s
     }
 }
 
-#[cfg(test)]
-mod panel_chip_tests {
-    use super::*;
-    use crate::app::{Panel, Tab};
-
-    // Files tab → file tree on the left, preview on the right.
-    #[test]
-    fn files_tab_panels_match_their_role() {
-        assert_eq!(panel_chip_text(Tab::Files, Panel::Files), t(Msg::PanelFiles));
-        assert_eq!(panel_chip_text(Tab::Files, Panel::Diff), t(Msg::PanelPreview));
-    }
-
-    // Search tab → query input on the left, preview on the right.
-    // Critical: Panel::Files in Search tab is NOT "Files" — it's the
-    // search query column.
-    #[test]
-    fn search_tab_left_panel_labels_as_search_not_files() {
-        assert_eq!(
-            panel_chip_text(Tab::Search, Panel::Files),
-            t(Msg::PanelSearch)
-        );
-        assert_eq!(
-            panel_chip_text(Tab::Search, Panel::Diff),
-            t(Msg::PanelPreview)
-        );
-    }
-
-    // Git tab → file list on the left, diff (not preview) on the right.
-    #[test]
-    fn git_tab_right_panel_labels_as_diff_not_preview() {
-        assert_eq!(panel_chip_text(Tab::Git, Panel::Files), t(Msg::PanelFiles));
-        assert_eq!(panel_chip_text(Tab::Git, Panel::Diff), t(Msg::PanelDiff));
-    }
-
-    // Graph tab in 3-col mode is the only place all three Panels are
-    // distinct — sidebar/middle/diff each get their own label.
-    #[test]
-    fn graph_tab_distinguishes_all_three_panels() {
-        let g = panel_chip_text(Tab::Graph, Panel::Files);
-        let c = panel_chip_text(Tab::Graph, Panel::Commit);
-        let d = panel_chip_text(Tab::Graph, Panel::Diff);
-        assert_eq!(g, t(Msg::PanelGraph));
-        assert_eq!(c, t(Msg::PanelCommit));
-        assert_eq!(d, t(Msg::PanelDiff));
-        // And those three labels must be pairwise distinct so the chip
-        // is actually informative across the cycle.
-        assert_ne!(g, c);
-        assert_ne!(c, d);
-        assert_ne!(g, d);
-    }
-
-    // Defensive: Panel::Commit only legitimately appears in Graph 3-col,
-    // but if it leaked into another tab via stale state, the label
-    // should still resolve sensibly without panicking.
-    #[test]
-    fn stale_commit_panel_falls_back_per_tab() {
-        // Files / Search treat it as preview (the right column).
-        assert_eq!(
-            panel_chip_text(Tab::Files, Panel::Commit),
-            t(Msg::PanelPreview)
-        );
-        assert_eq!(
-            panel_chip_text(Tab::Search, Panel::Commit),
-            t(Msg::PanelPreview)
-        );
-        // Git treats it as diff.
-        assert_eq!(panel_chip_text(Tab::Git, Panel::Commit), t(Msg::PanelDiff));
-    }
-}
-
 fn render_search_prompt(f: &mut Frame, app: &App, area: Rect) {
     let th = app.theme;
     let prefix = if app.search.backwards { '?' } else { '/' };
@@ -952,5 +882,81 @@ fn render_help(f: &mut Frame, app: &App, screen: Rect) {
         ]);
         f.render_widget(line, Rect::new(inner.x, row_y, inner.width, 1));
         row_y += 1;
+    }
+}
+
+#[cfg(test)]
+mod panel_chip_tests {
+    use super::*;
+    use crate::app::{Panel, Tab};
+
+    // Files tab → file tree on the left, preview on the right.
+    #[test]
+    fn files_tab_panels_match_their_role() {
+        assert_eq!(
+            panel_chip_text(Tab::Files, Panel::Files),
+            t(Msg::PanelFiles)
+        );
+        assert_eq!(
+            panel_chip_text(Tab::Files, Panel::Diff),
+            t(Msg::PanelPreview)
+        );
+    }
+
+    // Search tab → query input on the left, preview on the right.
+    // Critical: Panel::Files in Search tab is NOT "Files" — it's the
+    // search query column.
+    #[test]
+    fn search_tab_left_panel_labels_as_search_not_files() {
+        assert_eq!(
+            panel_chip_text(Tab::Search, Panel::Files),
+            t(Msg::PanelSearch)
+        );
+        assert_eq!(
+            panel_chip_text(Tab::Search, Panel::Diff),
+            t(Msg::PanelPreview)
+        );
+    }
+
+    // Git tab → file list on the left, diff (not preview) on the right.
+    #[test]
+    fn git_tab_right_panel_labels_as_diff_not_preview() {
+        assert_eq!(panel_chip_text(Tab::Git, Panel::Files), t(Msg::PanelFiles));
+        assert_eq!(panel_chip_text(Tab::Git, Panel::Diff), t(Msg::PanelDiff));
+    }
+
+    // Graph tab in 3-col mode is the only place all three Panels are
+    // distinct — sidebar/middle/diff each get their own label.
+    #[test]
+    fn graph_tab_distinguishes_all_three_panels() {
+        let g = panel_chip_text(Tab::Graph, Panel::Files);
+        let c = panel_chip_text(Tab::Graph, Panel::Commit);
+        let d = panel_chip_text(Tab::Graph, Panel::Diff);
+        assert_eq!(g, t(Msg::PanelGraph));
+        assert_eq!(c, t(Msg::PanelCommit));
+        assert_eq!(d, t(Msg::PanelDiff));
+        // And those three labels must be pairwise distinct so the chip
+        // is actually informative across the cycle.
+        assert_ne!(g, c);
+        assert_ne!(c, d);
+        assert_ne!(g, d);
+    }
+
+    // Defensive: Panel::Commit only legitimately appears in Graph 3-col,
+    // but if it leaked into another tab via stale state, the label
+    // should still resolve sensibly without panicking.
+    #[test]
+    fn stale_commit_panel_falls_back_per_tab() {
+        // Files / Search treat it as preview (the right column).
+        assert_eq!(
+            panel_chip_text(Tab::Files, Panel::Commit),
+            t(Msg::PanelPreview)
+        );
+        assert_eq!(
+            panel_chip_text(Tab::Search, Panel::Commit),
+            t(Msg::PanelPreview)
+        );
+        // Git treats it as diff.
+        assert_eq!(panel_chip_text(Tab::Git, Panel::Commit), t(Msg::PanelDiff));
     }
 }

--- a/tests/snapshots/ui_snapshots__binary_info_pdf.snap
+++ b/tests/snapshots/ui_snapshots__binary_info_pdf.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 579
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -21,4 +22,4 @@ expression: output
                        │
                        │
                        │
-                     q:quit Tab:switch s:stage u:unstage r:refresh h:help
+                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__empty_repo.snap
+++ b/tests/snapshots/ui_snapshots__empty_repo.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 104
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -21,4 +22,4 @@ expression: output
                        │
                        │
                        │
-                     q:quit Tab:switch s:stage u:unstage r:refresh h:help
+                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__hosts_picker_empty.snap
+++ b/tests/snapshots/ui_snapshots__hosts_picker_empty.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 338
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -21,4 +22,4 @@ expression: output
       │   Enter connect · Ctrl+P path mode · Esc cancel                  │
       └──────────────────────────────────────────────────────────────────┘
                        │
-                     q:quit Tab:switch s:stage u:unstage r:refresh h:help
+                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__hosts_picker_path_mode.snap
+++ b/tests/snapshots/ui_snapshots__hosts_picker_path_mode.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 417
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -21,4 +22,4 @@ expression: output
       │   Enter connect · Esc back to filter                             │
       └──────────────────────────────────────────────────────────────────┘
                        │
-                     q:quit Tab:switch s:stage u:unstage r:refresh h:help
+                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__hosts_picker_populated.snap
+++ b/tests/snapshots/ui_snapshots__hosts_picker_populated.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 385
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -21,4 +22,4 @@ expression: output
       │   Enter connect · Ctrl+P path mode · Esc cancel                  │
       └──────────────────────────────────────────────────────────────────┘
                        │
-                     q:quit Tab:switch s:stage u:unstage r:refresh h:help
+                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__image_preview_halfblocks.snap
+++ b/tests/snapshots/ui_snapshots__image_preview_halfblocks.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 540
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -21,4 +22,4 @@ expression: output
                        │
                        │
                        │
-                     q:quit Tab:switch s:stage u:unstage r:refresh h:help
+                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__tree_context_menu.snap
+++ b/tests/snapshots/ui_snapshots__tree_context_menu.snap
@@ -22,4 +22,4 @@ expression: output
     │  Reveal in Finder    │
     └──────────────────────┘
                        │
-                     q:quit Tab:switch s:stage u:unstage r:refresh h:help
+                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__tree_edit_row_new_file.snap
+++ b/tests/snapshots/ui_snapshots__tree_edit_row_new_file.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 214
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
@@ -21,4 +22,4 @@ expression: output
                        │
                        │
                        │
-                     q:quit Tab:switch s:stage u:unstage r:refresh h:help
+                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__with_staged_and_unstaged.snap
+++ b/tests/snapshots/ui_snapshots__with_staged_and_unstaged.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 126
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
@@ -21,4 +22,4 @@ expression: output
                        │
                        │
                        │
-                     q:quit Tab:switch s:stage u:unstage r:refresh h:help
+                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__with_staged_and_unstaged_light.snap
+++ b/tests/snapshots/ui_snapshots__with_staged_and_unstaged_light.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 444
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
@@ -21,4 +22,4 @@ expression: output
                        │
                        │
                        │
-                     q:quit Tab:switch s:stage u:unstage r:refresh h:help
+                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]


### PR DESCRIPTION
## Summary

The vim-style `/` / `n` / `N` search system already supports a `SearchTarget::FilePreview` arm — but it's invisible: there was no way to *see* which panel had focus, so `/` "did the wrong thing" depending on a state the UI didn't surface. This PR makes panel focus visible everywhere and adds VSCode-style `Ctrl+F` so users don't have to navigate the focus dance to search a file.

- **Focus visuals** — preview title + separator switch between `theme.accent` and `theme.fg_secondary`; file-tree right border highlights in accent when focused; status bar gets a right-aligned `[Files] / [Preview] / [Diff] / [Commit] / [Search] / [Graph]` chip derived from `(active_tab, active_panel)`. `Msg::Panel*` i18n entries cover both languages.
- **`Ctrl+F` (Files / Search tabs)** — forces focus to the preview pane and calls `search::begin`, regardless of which panel was previously active. Suppressed inside text-input modes (commit box, global-search query) so it doesn't yank the user mid-keystroke.
- **`[i/N]` match counter** — `render_card_header` shows current/total when a `/` search has committed matches against `SearchTarget::FilePreview`. Right-aligned in the title row, drops automatically when the panel is too narrow.
- **Tab key re-role** — bare `Tab` cycles panels forward, `Shift+Tab` cycles in reverse, `Ctrl+Tab` is a best-effort "next tab" alias for terminals that distinguish it from bare Tab (kitty/csi-u/ghostty/wezterm/iTerm2). Number keys 1–4 remain the reliable tab-switch path.
- **`Esc` back-out, two-step** — (1) clears dormant `/` highlights *only* when the current panel owns them (so commit-box / multi-select Esc still works on Files panel), (2) otherwise returns focus to `Panel::Files`. Both arms use guards so per-tab Esc handlers (Graph visual mode etc.) still fire when neither applies.
- **Mouse** — clicking the text preview now sets `Panel::Diff` (mirror of `handle_diff_selection`). The previous behavior was: `handle_preview_selection` returned `true` from its rect hit-test, short-circuiting `focus_panel_under_cursor`, so click-on-text-preview didn't change focus.

## Architecture notes

- New `src/ui/focus.rs` (15 lines) — `header_title_style(theme, focused) -> Style`. Convention: focused → `theme.accent`, unfocused → `theme.fg_secondary`; both keep `BOLD` so the typographic weight doesn't jiggle on focus transitions.
- `next_panel(current: Panel, three_col: bool, reverse: bool) -> Panel` and `panel_chip_text(tab: Tab, panel: Panel) -> &'static str` are pure functions (no `&App`) so the state machines are unit-testable. 13 new tests guard them and `header_title_style`.
- `search::resolve_target` promoted to `pub(crate)` so the always-on Esc handler can guard "panel owns the highlights".
- `render_card_header` gained `focused: bool` and `match_count: Option<(usize, usize)>` params; downstream renderers (`render_image`, `render_binary_info`, `render_text`, `render_loading`, `db_preview::render`) plumb them through.

## Trade-offs

- **Behavior change**: bare `Tab` no longer cycles top tabs — that's now `Ctrl+Tab` (best-effort, terminal-dependent) or the number keys 1-4. lazygit precedent (panel-cycle on bare Tab) and the new focus visuals make this the higher-leverage role; tab switching is well covered by absolute-position number keys at 4 tabs. Worth a release-note line.
- **Esc guard via `resolve_target` equality**: instead of always clearing dormant search on Esc (which would intercept commit-box / multi-select Esc), arm 1 only fires when `search::resolve_target(app) == app.search.target`. This means dormant FileTree highlights only get cleared on Esc when the user is on the file tree — same for FilePreview, etc.
- **Snapshot tests update text-only**: the 10 modified `ui_snapshots__*.snap` files all add `[Files]` to the status bar line. The accent-color visual change in the preview header isn't visible in plain-text snapshots; it's covered by `header_title_style` unit tests instead.
- **Best-effort `Ctrl+Tab`**: Terminal.app collapses Ctrl+Tab into bare Tab, in which case the bare-Tab arm fires (panel-cycle) and the user reaches other tabs via number keys.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --lib` — 489 pass (was 476; +13 new tests across `next_panel_tests` × 5, `panel_chip_tests` × 5, `focus::tests` × 3)
- [x] `cargo test --test ui_snapshots` — 12/12, all 10 status-bar diffs match expected `[Files]` chip
- [x] `cargo test --test space_leader_input` — 5/5
- [x] `cargo clippy` — clean, no new warnings
- [ ] Manual UI checks (please run before merging):
  - [ ] Files tab, Shift+Tab between file tree and preview — observe title color change + status bar `[Files]` ↔ `[Preview]`
  - [ ] Focus on preview, press `/`, type a query — `[1/N]` appears in title row; `n`/`N` step matches; `Esc` first clears highlights, second Esc returns focus to file tree
  - [ ] Anywhere in Files tab (or Search tab), press `Ctrl+F` — focus snaps to preview, search prompt opens
  - [ ] Click on text preview — focus moves there (chip + title change)
  - [ ] Bare `Tab` cycles panels (not tabs); number keys 1-4 jump tabs; `Ctrl+Tab` cycles tabs on terminals that support the distinct keypress
  - [ ] In Git tab editing the commit box with dormant search highlights still active in some other panel: pressing `Esc` exits the commit box (doesn't get eaten by the search-clear arm)
  - [ ] Light theme — verify accent contrast on the preview title and tree border

🤖 Generated with [Claude Code](https://claude.com/claude-code)