### PR TITLE
fix(files): free Space leader on Files tree; move multi-select to `s`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -707,7 +707,7 @@ pub struct App {
     /// (and cleared, for Cut) by `paste_into`.
     pub file_clipboard: crate::file_clipboard::FileClipboard,
 
-    /// Multi-selection set for the Files-tab tree (Space toggle,
+    /// Multi-selection set for the Files-tab tree (`s` toggle,
     /// Shift+arrow range, Shift/Ctrl-click). All clipboard / drag /
     /// delete operations operate on this set when it's non-empty AND
     /// includes the current cursor row; otherwise they fall back to

--- a/src/file_selection.rs
+++ b/src/file_selection.rs
@@ -1,7 +1,7 @@
 //! Multi-selection state for the Files tab tree. Mirrors VS Code's
 //! Explorer multi-select model:
 //!
-//! - `Space` toggles the current row in/out of the set.
+//! - `s` toggles the current row in/out of the set.
 //! - `Shift+↑/↓` (and `Shift+Click`) extend a contiguous range from
 //!   the *anchor* — the path where the contiguous selection started.
 //! - `Ctrl+Click` toggles a single row without disturbing the rest.

--- a/src/input.rs
+++ b/src/input.rs
@@ -236,17 +236,12 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         && app.active_panel == Panel::Files
         && app.git_status.commit_editing;
     let in_input_mode = search_input_focused || commit_input_focused;
-    // On the Files-tab tree panel bare Space is the multi-select
-    // toggle — leader arming would silently swallow it. Users can
-    // still reach the palettes from the preview panel (Tab-switch),
-    // or via Ctrl+P (defined elsewhere) / Ctrl+O hosts picker.
-    let on_files_tree_panel = app.active_tab == Tab::Files && app.active_panel == Panel::Files;
     let leader_allow_arm = if search_input_focused {
         app.global_search.query.is_empty()
     } else if commit_input_focused {
         app.git_status.commit_message.is_empty()
     } else {
-        !on_files_tree_panel
+        true
     };
     match leader_decision(
         &key,
@@ -1795,7 +1790,7 @@ fn handle_key_files_clipboard(key: KeyEvent, app: &mut App, ctrl: bool, shift: b
             true
         }
         // ── multi-select ──────────────────────────────────────────
-        KeyCode::Char(' ') if key.modifiers.is_empty() => {
+        KeyCode::Char('s') if !ctrl && !alt && !shift => {
             if let Some(p) = app.file_tree.selected_path() {
                 app.file_selection.toggle(p);
             }

--- a/tests/space_leader_input.rs
+++ b/tests/space_leader_input.rs
@@ -21,21 +21,20 @@ fn space_key() -> KeyEvent {
     KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE)
 }
 
+fn s_key() -> KeyEvent {
+    KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE)
+}
+
 #[test]
 fn bare_space_arms_leader_in_normal_context() {
-    // Sanity check: when no text input is focused and the user is NOT
-    // on the Files-tab tree panel (where Space is reserved for the
-    // multi-select toggle), bare Space arms the leader as expected.
-    // Guards against a regression in the input-mode gate accidentally
-    // suppressing the normal path.
+    // Sanity check: when no text input is focused, bare Space arms the
+    // leader. Guards against a regression in the input-mode gate
+    // accidentally suppressing the normal path.
     let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let tmp = TempDir::new().unwrap();
     let _g = CwdGuard::enter(tmp.path());
 
     let mut app = App::new(Theme::dark(), None);
-    // The default tab+panel is Files+Files — bare Space there is the
-    // file-selection toggle. Move focus to the preview pane so we're
-    // exercising the "no input focused, leader unblocked" branch.
     app.active_panel = Panel::Diff;
     assert!(app.space_leader_at.is_none());
     input::handle_key(space_key(), &mut app);
@@ -46,37 +45,53 @@ fn bare_space_arms_leader_in_normal_context() {
 }
 
 #[test]
-fn space_toggles_selection_on_files_tree_panel_instead_of_arming_leader() {
-    // VS Code-style multi-select: bare Space on Tab::Files +
-    // Panel::Files toggles the current row in/out of the selection
-    // set rather than arming the leader chord. Documents the
-    // intentional carve-out from the leader contract above.
+fn bare_space_arms_leader_on_files_tree_panel() {
+    // Files+Files used to be a carve-out where Space toggled multi-
+    // selection. Multi-select moved to `s`, so Space here now arms the
+    // leader uniformly with every other non-input context.
     let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let tmp = TempDir::new().unwrap();
-    // Plant a file so the tree has at least one row to select.
-    std::fs::write(tmp.path().join("a.txt"), "").unwrap();
     let _g = CwdGuard::enter(tmp.path());
 
     let mut app = App::new(Theme::dark(), None);
-    // Default (Tab::Files + Panel::Files) is what we're testing.
     assert_eq!(app.active_tab, Tab::Files);
     assert_eq!(app.active_panel, Panel::Files);
-    assert!(app.file_selection.is_empty());
 
     input::handle_key(space_key(), &mut app);
 
     assert!(
-        app.space_leader_at.is_none(),
-        "Space on Files+Files panel must not arm the leader",
+        app.space_leader_at.is_some(),
+        "Space on Files+Files should arm the leader (multi-select moved to `s`)",
     );
-    // Selection toggled to include the cursor row (or stayed empty if
-    // the tree didn't have any entry — defensive). The contract is:
-    // leader didn't arm. If a row exists, selection contains it.
+    assert!(
+        app.file_selection.is_empty(),
+        "Space must not touch the multi-selection set anymore",
+    );
+}
+
+#[test]
+fn s_toggles_selection_on_files_tree_panel() {
+    // The new multi-select keybinding: bare `s` on Files+Files toggles
+    // the cursor row in/out of the selection set without arming the
+    // leader chord.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "").unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    assert_eq!(app.active_tab, Tab::Files);
+    assert_eq!(app.active_panel, Panel::Files);
+    assert!(app.file_selection.is_empty());
+
+    input::handle_key(s_key(), &mut app);
+
+    assert!(app.space_leader_at.is_none(), "`s` must not arm the leader",);
     if app.file_tree.selected_path().is_some() {
         assert_eq!(
             app.file_selection.len(),
             1,
-            "Space should have toggled the cursor into the selection",
+            "`s` should have toggled the cursor into the selection",
         );
     }
 }


### PR DESCRIPTION
## Summary

- `Space P` / `Space F` were silently swallowed on the Files-tab tree panel because bare `Space` was bound to the multi-select toggle there. Pressing `Space p` would toggle the row, then trigger paste (with the `Clipboard is empty` toast).
- Move the multi-select toggle from `Space` → `s` so `Space` is free to arm the global leader chord uniformly.
- Drop the `on_files_tree_panel` carve-out in `leader_allow_arm` — it's now `true` outside text-input modes.

## Behavior change for users

- **`Space P` / `Space F`** now open quick-open / global-search from anywhere, including the Files tree (previously required `Ctrl+P` / panel switch on that tab).
- **Multi-select toggle** moved from `Space` → `s` on the Files tree. Shift+arrow range, Shift/Ctrl-click selection unchanged.

## Test plan

- [x] `cargo build` clean
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 489 passed
- [ ] Manual: focus Files tree, press `Space P` → quick-open opens
- [ ] Manual: focus Files tree, press `Space F` → global-search opens
- [ ] Manual: focus Files tree, press `s` on a row → row toggles in/out of selection; clipboard ops respect the selection
- [ ] Manual: in commit message editor, typing literal space still works (leader gated by `commit_message.is_empty()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)