### PR TITLE
feat(settings): standalone settings page + configurable editor

### DIFF
--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -48,18 +48,32 @@ pub fn agent_bin() -> PathBuf {
     );
 }
 
+/// Process-wide lock for HOME mutations. Multiple `#[cfg(test)] mod tests`
+/// in different `src/*.rs` files compile into the SAME `cargo test --lib`
+/// binary, so they share the global env-var space. A per-file lock works
+/// only when one file owns every HOME-touching test in its binary; the
+/// moment a second file is added, the two locks no longer serialise
+/// against each other and `HomeGuard` mid-restore can be observed by the
+/// other test as a corrupt $HOME.
+///
+/// All lib-side tests that touch HOME (and any integration test that
+/// doesn't already use its own per-file lock) should grab THIS lock for
+/// the lifetime of the `HomeGuard`. Each integration test (`tests/*.rs`)
+/// is its own binary, so they could in principle keep per-file locks —
+/// but pointing them at the shared lock costs nothing and removes a
+/// footgun for the next contributor.
+pub static HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Redirect `$HOME` to a path for the lifetime of the guard, then restore
 /// whatever value was there before (or remove it if HOME was unset).
 ///
 /// `std::env::set_var` is process-global, so callers MUST serialise HOME
-/// mutations through a `static Mutex<()>` in their test file. This helper
-/// is the "do the unsafe set/restore correctly" part; the lock is yours.
+/// mutations. Use [`HOME_LOCK`] above unless you have a specific reason
+/// to keep a per-file lock.
 ///
 /// Typical use:
 /// ```no_run
-/// use std::sync::Mutex;
-/// use test_support::{tempdir_repo, HomeGuard};
-/// static HOME_LOCK: Mutex<()> = Mutex::new(());
+/// use test_support::{HOME_LOCK, HomeGuard, tempdir_repo};
 ///
 /// # fn body() {
 /// let _lock = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());

--- a/src/app.rs
+++ b/src/app.rs
@@ -140,6 +140,15 @@ fn max_page_for(table: &reef_sqlite_preview::TableSummary, page_size: u32) -> u6
 /// prefetch at all.
 const PREFETCH_DELAY: Duration = Duration::from_millis(300);
 
+/// `Settings` is a full-screen takeover that hides the tab bar; the
+/// background work coordinator keeps running so the four-tab snapshots
+/// are fresh on return.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ViewMode {
+    Main,
+    Settings,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Tab {
     Git,
@@ -188,10 +197,47 @@ pub enum DiffLayout {
     SideBySide, // 左右对比视图
 }
 
+impl DiffLayout {
+    /// Stable string used in `~/.config/reef/prefs`. Must round-trip via
+    /// `from_pref_str` — every reader (`load_prefs`, `App::new`,
+    /// `settings::current_value`) and every writer (`save_prefs`,
+    /// `settings::cycle`) must go through these two methods so the spelling
+    /// stays consistent.
+    pub fn pref_str(self) -> &'static str {
+        match self {
+            DiffLayout::Unified => "unified",
+            DiffLayout::SideBySide => "side_by_side",
+        }
+    }
+
+    pub fn from_pref_str(s: &str) -> Self {
+        match s {
+            "side_by_side" => DiffLayout::SideBySide,
+            _ => DiffLayout::Unified,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiffMode {
     Compact,  // 只显示变更区域 ± context
     FullFile, // 显示整个文件
+}
+
+impl DiffMode {
+    pub fn pref_str(self) -> &'static str {
+        match self {
+            DiffMode::Compact => "compact",
+            DiffMode::FullFile => "full_file",
+        }
+    }
+
+    pub fn from_pref_str(s: &str) -> Self {
+        match s {
+            "full_file" => DiffMode::FullFile,
+            _ => DiffMode::Compact,
+        }
+    }
 }
 
 /// What the user is about to discard when the confirmation banner is up.
@@ -432,6 +478,9 @@ pub struct App {
     // Tab
     pub active_tab: Tab,
     pub active_panel: Panel,
+
+    pub view_mode: ViewMode,
+    pub settings: crate::settings::SettingsState,
 
     // ── Git tab state ──
     pub staged_files: Vec<FileEntry>,
@@ -926,6 +975,8 @@ impl App {
             branch_name,
             active_tab: Tab::Files,
             active_panel: Panel::Files,
+            view_mode: ViewMode::Main,
+            settings: crate::settings::SettingsState::default(),
             staged_files: Vec::new(),
             unstaged_files: Vec::new(),
             selected_file: None,
@@ -984,14 +1035,14 @@ impl App {
             },
             git_graph: GitGraphState::default(),
             commit_detail: CommitDetailState {
-                diff_layout: match crate::prefs::get("commit.diff_layout").as_deref() {
-                    Some("side_by_side") => DiffLayout::SideBySide,
-                    _ => DiffLayout::Unified,
-                },
-                diff_mode: match crate::prefs::get("commit.diff_mode").as_deref() {
-                    Some("full_file") => DiffMode::FullFile,
-                    _ => DiffMode::Compact,
-                },
+                diff_layout: crate::prefs::get("commit.diff_layout")
+                    .as_deref()
+                    .map(DiffLayout::from_pref_str)
+                    .unwrap_or(DiffLayout::Unified),
+                diff_mode: crate::prefs::get("commit.diff_mode")
+                    .as_deref()
+                    .map(DiffMode::from_pref_str)
+                    .unwrap_or(DiffMode::Compact),
                 files_tree_mode: crate::prefs::get_bool("commit.files_tree_mode"),
                 ..CommitDetailState::default()
             },
@@ -2744,6 +2795,38 @@ impl App {
         save_prefs(self.diff_layout, self.diff_mode);
     }
 
+    pub fn toggle_status_tree_mode(&mut self) {
+        self.git_status.tree_mode = !self.git_status.tree_mode;
+        crate::prefs::set_bool("status.tree_mode", self.git_status.tree_mode);
+    }
+
+    pub fn toggle_commit_diff_layout(&mut self) {
+        self.commit_detail.diff_layout = match self.commit_detail.diff_layout {
+            DiffLayout::Unified => DiffLayout::SideBySide,
+            DiffLayout::SideBySide => DiffLayout::Unified,
+        };
+        crate::prefs::set(
+            "commit.diff_layout",
+            self.commit_detail.diff_layout.pref_str(),
+        );
+    }
+
+    pub fn toggle_commit_diff_mode(&mut self) {
+        self.commit_detail.diff_mode = match self.commit_detail.diff_mode {
+            DiffMode::Compact => DiffMode::FullFile,
+            DiffMode::FullFile => DiffMode::Compact,
+        };
+        crate::prefs::set("commit.diff_mode", self.commit_detail.diff_mode.pref_str());
+        // The compact↔full-file flip changes the context-lines argument the
+        // worker uses, so the cached diff is now wrong shape — refetch.
+        self.reload_commit_file_diff();
+    }
+
+    pub fn toggle_commit_files_tree_mode(&mut self) {
+        self.commit_detail.files_tree_mode = !self.commit_detail.files_tree_mode;
+        crate::prefs::set_bool("commit.files_tree_mode", self.commit_detail.files_tree_mode);
+    }
+
     pub fn stage_file(&mut self, path: &str) {
         let ok = self.backend.stage(path).is_ok();
         if ok {
@@ -3940,6 +4023,26 @@ impl App {
         }
     }
 
+    /// Open Settings. No-op when already open so a stray re-entry
+    /// can't silently discard an in-progress inline text edit. The
+    /// pref-cache refresh keeps the page reading from memory rather
+    /// than disk on every render.
+    pub fn open_settings(&mut self) {
+        if self.view_mode == ViewMode::Settings {
+            return;
+        }
+        self.view_mode = ViewMode::Settings;
+        self.settings.editor_edit = None;
+        crate::settings::refresh_pref_cache(&mut self.settings);
+    }
+
+    /// Esc semantics — uncommitted buffer discarded, Enter is the
+    /// explicit commit.
+    pub fn close_settings(&mut self) {
+        self.view_mode = ViewMode::Main;
+        self.settings.editor_edit = None;
+    }
+
     pub fn set_active_tab(&mut self, tab: Tab) {
         if self.active_tab == tab {
             return;
@@ -4210,6 +4313,11 @@ impl App {
             }
             ClickAction::SearchApplyReplace => {
                 self.commit_replace_in_files();
+            }
+            ClickAction::SettingsRow(idx) => {
+                if self.view_mode == ViewMode::Settings {
+                    self.settings.select(idx);
+                }
             }
         }
     }
@@ -4566,32 +4674,20 @@ fn folder_contains(folder_path: &str, file_path: &str) -> bool {
 /// unprefixed `layout=` / `mode=` entries have been renamed by the time
 /// we get here.
 fn load_prefs() -> (DiffLayout, DiffMode) {
-    let layout = match crate::prefs::get("diff.layout").as_deref() {
-        Some("side_by_side") => DiffLayout::SideBySide,
-        _ => DiffLayout::Unified,
-    };
-    let mode = match crate::prefs::get("diff.mode").as_deref() {
-        Some("full_file") => DiffMode::FullFile,
-        _ => DiffMode::Compact,
-    };
+    let layout = crate::prefs::get("diff.layout")
+        .as_deref()
+        .map(DiffLayout::from_pref_str)
+        .unwrap_or(DiffLayout::Unified);
+    let mode = crate::prefs::get("diff.mode")
+        .as_deref()
+        .map(DiffMode::from_pref_str)
+        .unwrap_or(DiffMode::Compact);
     (layout, mode)
 }
 
 fn save_prefs(layout: DiffLayout, mode: DiffMode) {
-    crate::prefs::set(
-        "diff.layout",
-        match layout {
-            DiffLayout::Unified => "unified",
-            DiffLayout::SideBySide => "side_by_side",
-        },
-    );
-    crate::prefs::set(
-        "diff.mode",
-        match mode {
-            DiffMode::Compact => "compact",
-            DiffMode::FullFile => "full_file",
-        },
-    );
+    crate::prefs::set("diff.layout", layout.pref_str());
+    crate::prefs::set("diff.mode", mode.pref_str());
 }
 
 #[cfg(test)]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -36,8 +36,15 @@ pub fn parse_editor_command(s: &str) -> Option<(String, Vec<String>)> {
     Some((prog, args))
 }
 
-/// Resolve `$VISUAL`, then `$EDITOR`, then a platform fallback.
+/// Priority: `editor.command` pref → `$VISUAL` → `$EDITOR` → `vi`. The
+/// pref is consulted first so a value chosen in the Settings page wins
+/// over an inherited shell environment.
 pub(crate) fn resolve_editor() -> Option<(String, Vec<String>)> {
+    if let Some(s) = crate::prefs::get("editor.command") {
+        if let Some(cmd) = parse_editor_command(&s) {
+            return Some(cmd);
+        }
+    }
     for var in ["VISUAL", "EDITOR"] {
         if let Ok(s) = std::env::var(var) {
             if let Some(cmd) = parse_editor_command(&s) {
@@ -144,6 +151,50 @@ pub fn launch_spec<B: Backend>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
+    use test_support::{HOME_LOCK, HomeGuard};
+
+    /// `resolve_editor` reads from prefs (which lives under $HOME) and
+    /// from $VISUAL / $EDITOR. Tests that exercise the precedence
+    /// ladder must clear both env vars and set $HOME to an empty
+    /// tempdir so the user's real prefs / shell config don't leak in.
+    /// Shares `HOME_LOCK` with `prefs::tests` and `settings::tests` —
+    /// all three modules compile into the same `cargo test --lib`
+    /// binary and would race on $HOME otherwise.
+    fn isolated_env() -> (
+        std::sync::MutexGuard<'static, ()>,
+        HomeGuard,
+        TempDir,
+        Option<String>,
+        Option<String>,
+    ) {
+        let lock = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev_visual = std::env::var("VISUAL").ok();
+        let prev_editor = std::env::var("EDITOR").ok();
+        // SAFETY: serialised by HOME_LOCK; no other test thread reads
+        // these for the duration of the test.
+        unsafe {
+            std::env::remove_var("VISUAL");
+            std::env::remove_var("EDITOR");
+        }
+        let tmp = TempDir::new().unwrap();
+        let home = HomeGuard::enter(tmp.path());
+        (lock, home, tmp, prev_visual, prev_editor)
+    }
+
+    fn restore_env(prev_visual: Option<String>, prev_editor: Option<String>) {
+        // SAFETY: caller holds HOME_LOCK.
+        unsafe {
+            match prev_visual {
+                Some(v) => std::env::set_var("VISUAL", v),
+                None => std::env::remove_var("VISUAL"),
+            }
+            match prev_editor {
+                Some(v) => std::env::set_var("EDITOR", v),
+                None => std::env::remove_var("EDITOR"),
+            }
+        }
+    }
 
     #[test]
     fn parse_empty_returns_none() {
@@ -170,5 +221,60 @@ mod tests {
         let (prog, args) = parse_editor_command("  nvim\t --clean ").unwrap();
         assert_eq!(prog, "nvim");
         assert_eq!(args, vec!["--clean"]);
+    }
+
+    #[test]
+    fn pref_wins_over_env_vars() {
+        let (_lock, _home, _tmp, prev_visual, prev_editor) = isolated_env();
+        // SAFETY: under EDITOR_LOCK.
+        unsafe {
+            std::env::set_var("VISUAL", "vim");
+            std::env::set_var("EDITOR", "vi");
+        }
+        crate::prefs::set("editor.command", "nvim --clean");
+        let (prog, args) = resolve_editor().unwrap();
+        assert_eq!(prog, "nvim");
+        assert_eq!(args, vec!["--clean"]);
+        restore_env(prev_visual, prev_editor);
+    }
+
+    #[test]
+    fn falls_back_to_visual_then_editor_then_vi() {
+        let (_lock, _home, _tmp, prev_visual, prev_editor) = isolated_env();
+        // No pref, no env: unix gets `vi`.
+        let (prog, _) = resolve_editor().unwrap();
+        assert_eq!(prog, "vi");
+        // EDITOR alone wins over the platform fallback.
+        // SAFETY: under EDITOR_LOCK.
+        unsafe {
+            std::env::set_var("EDITOR", "helix");
+        }
+        let (prog, _) = resolve_editor().unwrap();
+        assert_eq!(prog, "helix");
+        // VISUAL trumps EDITOR.
+        // SAFETY: under EDITOR_LOCK.
+        unsafe {
+            std::env::set_var("VISUAL", "code -w");
+        }
+        let (prog, args) = resolve_editor().unwrap();
+        assert_eq!(prog, "code");
+        assert_eq!(args, vec!["-w"]);
+        restore_env(prev_visual, prev_editor);
+    }
+
+    #[test]
+    fn whitespace_pref_is_ignored() {
+        // A pref of "   " parses to None; we should fall through to env
+        // vars rather than blow up later trying to spawn an empty
+        // program.
+        let (_lock, _home, _tmp, prev_visual, prev_editor) = isolated_env();
+        crate::prefs::set("editor.command", "   ");
+        // SAFETY: under EDITOR_LOCK.
+        unsafe {
+            std::env::set_var("EDITOR", "ed");
+        }
+        let (prog, _) = resolve_editor().unwrap();
+        assert_eq!(prog, "ed");
+        restore_env(prev_visual, prev_editor);
     }
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -212,6 +212,7 @@ pub enum Msg {
     HelpHardDeleteEntry,
     HelpRightClickMenu,
     HelpToggleSidebar,
+    HelpOpenSettings,
     /// `Esc` row in the help popup — describes the general two-step
     /// back-out behaviour (clear dormant search, then return panel
     /// focus to the list/tree column). The Graph-visual-mode row
@@ -228,6 +229,41 @@ pub enum Msg {
     PanelDiff,
     PanelSearch,
     PanelGraph,
+
+    // Settings page
+    SettingsTitle,
+    SettingsFooterHint,
+    SettingsEditorEditHint,
+    SettingsSectionGeneral,
+    SettingsSectionEditor,
+    SettingsSectionGit,
+    SettingsSectionGraph,
+    SettingsItemTheme,
+    SettingsItemEditor,
+    SettingsItemDiffLayout,
+    SettingsItemDiffMode,
+    SettingsItemStatusTreeMode,
+    SettingsItemCommitDiffLayout,
+    SettingsItemCommitDiffMode,
+    SettingsItemCommitFilesTreeMode,
+    SettingsDescTheme,
+    SettingsDescEditor,
+    SettingsDescDiffLayout,
+    SettingsDescDiffMode,
+    SettingsDescStatusTreeMode,
+    SettingsDescCommitDiffLayout,
+    SettingsDescCommitDiffMode,
+    SettingsDescCommitFilesTreeMode,
+    SettingsValueThemeAuto,
+    SettingsValueThemeDark,
+    SettingsValueThemeLight,
+    SettingsValueOn,
+    SettingsValueOff,
+    SettingsEditorPlaceholder,
+    /// Toast for cycling `ui.theme` to `auto` — the OSC 11 probe only
+    /// runs at startup before raw mode, so the live theme keeps its
+    /// current preset until next launch.
+    SettingsAutoThemeOnNextLaunch,
 }
 
 pub fn t(m: Msg) -> &'static str {
@@ -362,6 +398,9 @@ fn t_zh(m: Msg) -> &'static str {
         HelpHardDeleteEntry => "永久删除（不可撤销）",
         HelpRightClickMenu => "打开文件树右键菜单",
         HelpToggleSidebar => "切换侧边栏显示",
+        HelpOpenSettings => {
+            "打开设置页（部分终端不转发 Ctrl+, ，可在 Settings 内手动通过 Esc 退出）"
+        }
         HelpEscBackOut => "退出焦点 / 清除搜索",
         SidebarHiddenHint => "侧边栏已隐藏 — Ctrl+B 可恢复",
         HelpAnyKey => "关闭帮助",
@@ -371,6 +410,38 @@ fn t_zh(m: Msg) -> &'static str {
         PanelDiff => "Diff",
         PanelSearch => "搜索",
         PanelGraph => "图表",
+        SettingsTitle => " ⚙ 设置 ",
+        SettingsFooterHint => "  ↑↓ 选择 · Enter 切换/编辑 · Esc 返回",
+        SettingsEditorEditHint => "  Enter 保存 · Esc 取消",
+        SettingsSectionGeneral => "通用",
+        SettingsSectionEditor => "外部编辑器",
+        SettingsSectionGit => "Git Diff",
+        SettingsSectionGraph => "提交详情",
+        SettingsItemTheme => "主题",
+        SettingsItemEditor => "编辑器命令",
+        SettingsItemDiffLayout => "Diff 布局",
+        SettingsItemDiffMode => "Diff 模式",
+        SettingsItemStatusTreeMode => "状态侧栏树形视图",
+        SettingsItemCommitDiffLayout => "提交 Diff 布局",
+        SettingsItemCommitDiffMode => "提交 Diff 模式",
+        SettingsItemCommitFilesTreeMode => "提交文件列表树形视图",
+        SettingsDescTheme => "auto 自动检测终端背景；显式指定可避免误判（重启后生效一次）",
+        SettingsDescEditor => {
+            "Enter 打开文件时调用的命令；留空则按 $VISUAL → $EDITOR → vi 顺序回退"
+        }
+        SettingsDescDiffLayout => "Git tab 右侧 diff 显示方式：上下统一 / 左右对比",
+        SettingsDescDiffMode => "Git tab diff 显示范围：仅变更块 / 整个文件",
+        SettingsDescStatusTreeMode => "Git tab 文件列表用树形或列表呈现",
+        SettingsDescCommitDiffLayout => "图表 tab commit 详情中的 diff 显示方式",
+        SettingsDescCommitDiffMode => "图表 tab commit 详情中的 diff 显示范围",
+        SettingsDescCommitFilesTreeMode => "图表 tab commit 变更文件用树形或列表呈现",
+        SettingsValueThemeAuto => "自动",
+        SettingsValueThemeDark => "深色",
+        SettingsValueThemeLight => "浅色",
+        SettingsValueOn => "开",
+        SettingsValueOff => "关",
+        SettingsEditorPlaceholder => "(未设置 — 使用 $VISUAL / $EDITOR / vi)",
+        SettingsAutoThemeOnNextLaunch => "已切换到 auto 主题，下次启动生效",
     }
 }
 
@@ -501,6 +572,7 @@ fn t_en(m: Msg) -> &'static str {
         HelpHardDeleteEntry => "Delete permanently (cannot be undone)",
         HelpRightClickMenu => "Open file-tree context menu",
         HelpToggleSidebar => "Toggle sidebar",
+        HelpOpenSettings => "Open settings page (some terminals don't forward Ctrl+,)",
         HelpEscBackOut => "Exit focus / clear search",
         SidebarHiddenHint => "Sidebar hidden — Ctrl+B to restore",
         HelpAnyKey => "Close help",
@@ -510,6 +582,40 @@ fn t_en(m: Msg) -> &'static str {
         PanelDiff => "Diff",
         PanelSearch => "Search",
         PanelGraph => "Graph",
+        SettingsTitle => " ⚙ Settings ",
+        SettingsFooterHint => "  ↑↓ select · Enter toggle/edit · Esc back",
+        SettingsEditorEditHint => "  Enter save · Esc cancel",
+        SettingsSectionGeneral => "General",
+        SettingsSectionEditor => "External editor",
+        SettingsSectionGit => "Git diff",
+        SettingsSectionGraph => "Commit detail",
+        SettingsItemTheme => "Theme",
+        SettingsItemEditor => "Editor command",
+        SettingsItemDiffLayout => "Diff layout",
+        SettingsItemDiffMode => "Diff mode",
+        SettingsItemStatusTreeMode => "Status sidebar — tree view",
+        SettingsItemCommitDiffLayout => "Commit diff layout",
+        SettingsItemCommitDiffMode => "Commit diff mode",
+        SettingsItemCommitFilesTreeMode => "Commit files — tree view",
+        SettingsDescTheme => {
+            "auto detects terminal background; pick dark / light to override (takes effect on next launch)"
+        }
+        SettingsDescEditor => {
+            "Command launched when you press Enter on a file; empty falls back to $VISUAL → $EDITOR → vi"
+        }
+        SettingsDescDiffLayout => "Git tab right-side diff layout — unified / side-by-side",
+        SettingsDescDiffMode => "Git tab diff body — compact (changed hunks) / full file",
+        SettingsDescStatusTreeMode => "Git tab file list — tree or flat list",
+        SettingsDescCommitDiffLayout => "Graph tab commit-detail diff layout",
+        SettingsDescCommitDiffMode => "Graph tab commit-detail diff body",
+        SettingsDescCommitFilesTreeMode => "Graph tab commit changed files — tree or flat list",
+        SettingsValueThemeAuto => "auto",
+        SettingsValueThemeDark => "dark",
+        SettingsValueThemeLight => "light",
+        SettingsValueOn => "on",
+        SettingsValueOff => "off",
+        SettingsEditorPlaceholder => "(unset — uses $VISUAL / $EDITOR / vi)",
+        SettingsAutoThemeOnNextLaunch => "Theme set to auto — takes effect on next launch",
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -8,12 +8,13 @@
 //! capture mode, and both are simple enough that splitting them out would
 //! just add indirection.
 
-use crate::app::{App, DbNav, Panel, Tab};
+use crate::app::{App, DbNav, Panel, Tab, ViewMode};
 use crate::clipboard;
 use crate::global_search;
 use crate::i18n::{Msg, t};
 use crate::quick_open;
 use crate::search;
+use crate::settings;
 use crate::ui;
 use crate::ui::selection::{
     DiffSelection, DiffSide, PreviewSelection, col_to_byte_offset, collect_diff_selected_text,
@@ -223,6 +224,15 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         return;
     }
 
+    // Settings owns every key while open. Sits below the modal gates
+    // above so a half-typed filename / commit message isn't yanked
+    // away, and above the global keymap below so Ctrl+, can flip to
+    // Esc-returns semantics inside.
+    if app.view_mode == ViewMode::Settings {
+        handle_key_settings(key, app);
+        return;
+    }
+
     // Space-leader chord: bare Space primes, bare `p` opens the quick-open
     // palette, bare `f` opens the global-search palette. Bare Space has no
     // other global meaning, so the chord doesn't collide with any existing
@@ -325,6 +335,12 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         // return earlier so they're unaffected.
         KeyCode::Char('b') if key.modifiers.contains(KeyModifiers::CONTROL) => {
             app.toggle_sidebar();
+            return;
+        }
+        // Suppressed in input mode so a literal comma in a commit
+        // message / search query isn't stolen by the chord.
+        KeyCode::Char(',') if key.modifiers.contains(KeyModifiers::CONTROL) && !in_input_mode => {
+            app.open_settings();
             return;
         }
         // Ctrl+F: VSCode-style find-in-file. Forces focus onto the
@@ -560,6 +576,67 @@ fn handle_key_db_goto(key: KeyEvent, app: &mut App) {
             app.db_goto_input = None;
         }
         _ => {}
+    }
+}
+
+/// Settings page key dispatcher. Two modes:
+///
+/// - **List mode** (default): ↑↓/k/j/Home/End/PageUp/PageDown move the
+///   selection cursor; Enter cycles the selected enum / toggles the
+///   selected bool, or opens the inline text editor for the
+///   `editor.command` row; Esc closes the page.
+/// - **Editor-command edit mode** (`app.settings.editor_edit.is_some()`):
+///   typing fills the buffer, Enter commits, Esc cancels and reverts.
+///
+/// Sits below the high-priority modal gates in `handle_key`, so a
+/// half-typed commit message / search query won't be yanked away by a
+/// stray Settings dispatch — but above the global keymap, so we own
+/// every key while the page is open.
+fn handle_key_settings(key: KeyEvent, app: &mut App) {
+    if app.settings.editor_edit.is_some() {
+        handle_key_settings_editor(key, app);
+        return;
+    }
+
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    match key.code {
+        KeyCode::Esc => app.close_settings(),
+        // Match the other modal-takeover panels (place mode, paste
+        // conflict): bare q / Ctrl+C always exit reef so a confused
+        // user can bail without first popping the modal.
+        KeyCode::Char('q') if !ctrl => app.should_quit = true,
+        KeyCode::Char('c') if ctrl => app.should_quit = true,
+        KeyCode::Up | KeyCode::Char('k') if !ctrl => app.settings.move_selection(-1),
+        KeyCode::Down | KeyCode::Char('j') if !ctrl => app.settings.move_selection(1),
+        KeyCode::Char('p') if ctrl => app.settings.move_selection(-1),
+        KeyCode::Char('n') if ctrl => app.settings.move_selection(1),
+        // The list is too short for a real "page" concept; PageUp /
+        // PageDown collapse to first / last to match user expectation.
+        KeyCode::PageUp | KeyCode::Home => app.settings.select(0),
+        KeyCode::PageDown | KeyCode::End => app
+            .settings
+            .select(crate::settings::SettingItem::ALL.len().saturating_sub(1)),
+        KeyCode::Enter | KeyCode::Char(' ') => {
+            let item = app.settings.selected();
+            if matches!(item, crate::settings::SettingItem::EditorCommand) {
+                settings::begin_edit_editor_command(&mut app.settings);
+            } else {
+                settings::cycle(app, item);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn handle_key_settings_editor(key: KeyEvent, app: &mut App) {
+    match key.code {
+        KeyCode::Esc => settings::cancel_editor_command(&mut app.settings),
+        KeyCode::Enter => settings::commit_editor_command(&mut app.settings),
+        _ => {
+            if let Some(edit) = app.settings.editor_edit.as_mut() {
+                let _ = crate::input_edit::dispatch_key(&key, &mut edit.buffer, &mut edit.cursor);
+            }
+        }
     }
 }
 
@@ -1939,6 +2016,22 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
 
     if app.place_mode.active {
         handle_mouse_place_mode(mouse, app);
+        return;
+    }
+
+    // Mid-edit click cancels the inline editor before moving the row
+    // cursor (mirrors `cancel_tree_edit` on the file tree); otherwise
+    // the prompt + footer hint would point at a row the buffer no
+    // longer belongs to.
+    if app.view_mode == ViewMode::Settings {
+        if matches!(mouse.kind, MouseEventKind::Down(_)) && app.settings.editor_edit.is_some() {
+            crate::settings::cancel_editor_command(&mut app.settings);
+        }
+        if let MouseEventKind::Down(MouseButton::Left) = mouse.kind {
+            if let Some(action) = app.hit_registry.hit_test(mouse.column, mouse.row) {
+                app.handle_action(action);
+            }
+        }
         return;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod prefs;
 pub mod quick_open;
 pub mod reveal;
 pub mod search;
+pub mod settings;
 pub mod shell_integration;
 pub mod tasks;
 pub mod tree_context_menu;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use crossterm::{
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use reef::agent_deploy::{self, InstallPath, SshSession};
-use reef::app::App;
+use reef::app::{App, ViewMode};
 use reef::backend::{Backend, LocalBackend, RemoteBackend};
 use reef::i18n;
 use reef::images;
@@ -310,14 +310,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         // because it's the only input that needs to poke the terminal
                         // backend mid-loop.
                         //
-                        // When any palette (quick-open or global-search) is active
-                        // it owns every key unconditionally — 'v' must land as a
-                        // literal in the query, and 'any key' must not dismiss
-                        // help — so route to handle_key first and let it delegate
-                        // to the palette.
+                        // When any palette (quick-open or global-search) is active,
+                        // or while the full-screen Settings page is up, it owns every
+                        // key unconditionally — 'v' must land as a literal in the
+                        // query / editor.command buffer, and 'any key' must not
+                        // dismiss help — so route to handle_key first and let it
+                        // delegate to the page.
                         if app.quick_open.active
                             || app.global_search.active
                             || app.hosts_picker.active
+                            || app.view_mode == ViewMode::Settings
                         {
                             input::handle_key(key, &mut app);
                         } else if key.code == KeyCode::Char('v') && key.modifiers.is_empty() {

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -87,6 +87,13 @@ pub fn set(key: &str, value: &str) {
     write_all(&map);
 }
 
+/// Pair of [`get_bool`]: writes `"true"` / `"false"` so the value
+/// round-trips. Callers should prefer this over building the literal
+/// string at every flip site.
+pub fn set_bool(key: &str, value: bool) {
+    set(key, if value { "true" } else { "false" });
+}
+
 /// Fold unprefixed legacy keys into the new prefixed namespace and delete the
 /// old `git.prefs` file. Safe to call repeatedly — already-migrated keys are
 /// left alone and never overwrite explicit values. Writes only when state
@@ -134,17 +141,12 @@ pub fn migrate_legacy_prefs() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
     use tempfile::TempDir;
-    use test_support::HomeGuard;
+    use test_support::{HOME_LOCK, HomeGuard};
 
-    // `set_var("HOME", ...)` is process-global; serialise to avoid races
-    // with any other test that touches HOME in this crate.
-    static HOME_LOCK: Mutex<()> = Mutex::new(());
-
-    /// Grab HOME_LOCK, make a fresh tempdir, point `$HOME` at it, and return
-    /// the three guards to hold for the whole test. Drop order restores HOME
-    /// before the tempdir is removed.
+    /// Workspace-shared HOME_LOCK so this serialises against any other
+    /// test in the same `cargo test --lib` binary that touches HOME.
     fn isolated_home() -> (MutexGuard<'static, ()>, HomeGuard, TempDir) {
         let lock = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = TempDir::new().unwrap();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,460 @@
+//! Settings page state + pure helpers. The renderer lives in
+//! `ui::settings_panel`; the keyboard router in `input::handle_key_settings`.
+//! Adding a new row is one [`SettingItem`] variant + an entry in
+//! [`SettingItem::ALL`] + match arms in `section`/`label`/`description`/
+//! [`current_value`]/[`cycle`].
+
+use crate::app::{App, DiffLayout, DiffMode};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingSection {
+    General,
+    Editor,
+    Git,
+    Graph,
+}
+
+impl SettingSection {
+    pub(crate) fn label(self) -> crate::i18n::Msg {
+        use crate::i18n::Msg;
+        match self {
+            SettingSection::General => Msg::SettingsSectionGeneral,
+            SettingSection::Editor => Msg::SettingsSectionEditor,
+            SettingSection::Git => Msg::SettingsSectionGit,
+            SettingSection::Graph => Msg::SettingsSectionGraph,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingItem {
+    Theme,
+    EditorCommand,
+    DiffLayout,
+    DiffMode,
+    StatusTreeMode,
+    CommitDiffLayout,
+    CommitDiffMode,
+    CommitFilesTreeMode,
+}
+
+impl SettingItem {
+    pub const ALL: &'static [SettingItem] = &[
+        SettingItem::Theme,
+        SettingItem::EditorCommand,
+        SettingItem::DiffLayout,
+        SettingItem::DiffMode,
+        SettingItem::StatusTreeMode,
+        SettingItem::CommitDiffLayout,
+        SettingItem::CommitDiffMode,
+        SettingItem::CommitFilesTreeMode,
+    ];
+
+    pub(crate) fn section(self) -> SettingSection {
+        match self {
+            SettingItem::Theme => SettingSection::General,
+            SettingItem::EditorCommand => SettingSection::Editor,
+            SettingItem::DiffLayout | SettingItem::DiffMode | SettingItem::StatusTreeMode => {
+                SettingSection::Git
+            }
+            SettingItem::CommitDiffLayout
+            | SettingItem::CommitDiffMode
+            | SettingItem::CommitFilesTreeMode => SettingSection::Graph,
+        }
+    }
+
+    pub(crate) fn label(self) -> crate::i18n::Msg {
+        use crate::i18n::Msg;
+        match self {
+            SettingItem::Theme => Msg::SettingsItemTheme,
+            SettingItem::EditorCommand => Msg::SettingsItemEditor,
+            SettingItem::DiffLayout => Msg::SettingsItemDiffLayout,
+            SettingItem::DiffMode => Msg::SettingsItemDiffMode,
+            SettingItem::StatusTreeMode => Msg::SettingsItemStatusTreeMode,
+            SettingItem::CommitDiffLayout => Msg::SettingsItemCommitDiffLayout,
+            SettingItem::CommitDiffMode => Msg::SettingsItemCommitDiffMode,
+            SettingItem::CommitFilesTreeMode => Msg::SettingsItemCommitFilesTreeMode,
+        }
+    }
+
+    pub(crate) fn description(self) -> crate::i18n::Msg {
+        use crate::i18n::Msg;
+        match self {
+            SettingItem::Theme => Msg::SettingsDescTheme,
+            SettingItem::EditorCommand => Msg::SettingsDescEditor,
+            SettingItem::DiffLayout => Msg::SettingsDescDiffLayout,
+            SettingItem::DiffMode => Msg::SettingsDescDiffMode,
+            SettingItem::StatusTreeMode => Msg::SettingsDescStatusTreeMode,
+            SettingItem::CommitDiffLayout => Msg::SettingsDescCommitDiffLayout,
+            SettingItem::CommitDiffMode => Msg::SettingsDescCommitDiffMode,
+            SettingItem::CommitFilesTreeMode => Msg::SettingsDescCommitFilesTreeMode,
+        }
+    }
+}
+
+/// Theme preference — distinct from `ui::theme::Theme` (the resolved
+/// palette) because `Auto` isn't a palette, it's a "probe at startup"
+/// instruction. The render path needs the pref string for display; the
+/// cycle path needs the next state. Keeping it as one enum centralises
+/// both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ThemePref {
+    #[default]
+    Auto,
+    Dark,
+    Light,
+}
+
+impl ThemePref {
+    fn pref_str(self) -> &'static str {
+        match self {
+            ThemePref::Auto => "auto",
+            ThemePref::Dark => "dark",
+            ThemePref::Light => "light",
+        }
+    }
+
+    fn from_pref_str(s: &str) -> Self {
+        match s {
+            "dark" => ThemePref::Dark,
+            "light" => ThemePref::Light,
+            _ => ThemePref::Auto,
+        }
+    }
+
+    fn next(self) -> Self {
+        match self {
+            ThemePref::Auto => ThemePref::Dark,
+            ThemePref::Dark => ThemePref::Light,
+            ThemePref::Light => ThemePref::Auto,
+        }
+    }
+
+    fn label_msg(self) -> crate::i18n::Msg {
+        use crate::i18n::Msg;
+        match self {
+            ThemePref::Auto => Msg::SettingsValueThemeAuto,
+            ThemePref::Dark => Msg::SettingsValueThemeDark,
+            ThemePref::Light => Msg::SettingsValueThemeLight,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct EditorEdit {
+    pub buffer: String,
+    pub cursor: usize,
+}
+
+#[derive(Debug, Default)]
+pub struct SettingsState {
+    pub selected_idx: usize,
+    pub editor_edit: Option<EditorEdit>,
+    /// Pref-backed values cached so [`current_value`] reads memory, not
+    /// disk. Refreshed by [`refresh_pref_cache`] on every entry to the
+    /// page and after every mutation.
+    theme_pref: ThemePref,
+    editor_command: String,
+}
+
+impl SettingsState {
+    pub fn selected(&self) -> SettingItem {
+        let i = self.selected_idx.min(SettingItem::ALL.len() - 1);
+        SettingItem::ALL[i]
+    }
+
+    pub fn move_selection(&mut self, delta: i32) {
+        let n = SettingItem::ALL.len() as i32;
+        let cur = (self.selected_idx as i32).clamp(0, n - 1);
+        let next = (cur + delta).rem_euclid(n);
+        self.selected_idx = next as usize;
+    }
+
+    pub fn select(&mut self, idx: usize) {
+        if idx < SettingItem::ALL.len() {
+            self.selected_idx = idx;
+        }
+    }
+}
+
+/// Reload the pref-backed cache from disk. Cheap (one prefs read) but
+/// not free, so we only call this on transitions: opening the page, and
+/// after each mutation that could have changed a cached value.
+pub fn refresh_pref_cache(state: &mut SettingsState) {
+    state.theme_pref = crate::prefs::get("ui.theme")
+        .as_deref()
+        .map(ThemePref::from_pref_str)
+        .unwrap_or_default();
+    state.editor_command = crate::prefs::get("editor.command").unwrap_or_default();
+}
+
+#[derive(Debug, Clone)]
+pub enum ItemValue {
+    Bool(bool),
+    Choice(&'static str),
+    Text(String),
+}
+
+pub(crate) fn current_value(item: SettingItem, app: &App) -> ItemValue {
+    use crate::i18n::t;
+    match item {
+        SettingItem::Theme => ItemValue::Choice(t(app.settings.theme_pref.label_msg())),
+        SettingItem::EditorCommand => ItemValue::Text(app.settings.editor_command.clone()),
+        SettingItem::DiffLayout => ItemValue::Choice(diff_layout_label(app.diff_layout)),
+        SettingItem::DiffMode => ItemValue::Choice(diff_mode_label(app.diff_mode)),
+        SettingItem::StatusTreeMode => ItemValue::Bool(app.git_status.tree_mode),
+        SettingItem::CommitDiffLayout => {
+            ItemValue::Choice(diff_layout_label(app.commit_detail.diff_layout))
+        }
+        SettingItem::CommitDiffMode => {
+            ItemValue::Choice(diff_mode_label(app.commit_detail.diff_mode))
+        }
+        SettingItem::CommitFilesTreeMode => ItemValue::Bool(app.commit_detail.files_tree_mode),
+    }
+}
+
+fn diff_layout_label(layout: DiffLayout) -> &'static str {
+    use crate::i18n::{Msg, t};
+    match layout {
+        DiffLayout::Unified => t(Msg::LayoutUnified),
+        DiffLayout::SideBySide => t(Msg::LayoutSideBySide),
+    }
+}
+
+fn diff_mode_label(mode: DiffMode) -> &'static str {
+    use crate::i18n::{Msg, t};
+    match mode {
+        DiffMode::Compact => t(Msg::ModeCompact),
+        DiffMode::FullFile => t(Msg::ModeFullFile),
+    }
+}
+
+/// Cycle the selected item. `EditorCommand` is a no-op here — the input
+/// layer routes Enter on that row to [`begin_edit_editor_command`] instead.
+pub fn cycle(app: &mut App, item: SettingItem) {
+    match item {
+        SettingItem::Theme => cycle_theme(app),
+        SettingItem::EditorCommand => {}
+        SettingItem::DiffLayout => app.toggle_diff_layout(),
+        SettingItem::DiffMode => app.toggle_diff_mode(),
+        SettingItem::StatusTreeMode => app.toggle_status_tree_mode(),
+        SettingItem::CommitDiffLayout => app.toggle_commit_diff_layout(),
+        SettingItem::CommitDiffMode => app.toggle_commit_diff_mode(),
+        SettingItem::CommitFilesTreeMode => app.toggle_commit_files_tree_mode(),
+    }
+    refresh_pref_cache(&mut app.settings);
+}
+
+fn cycle_theme(app: &mut App) {
+    let next = app.settings.theme_pref.next();
+    crate::prefs::set("ui.theme", next.pref_str());
+    match next {
+        ThemePref::Dark => app.theme = crate::ui::theme::Theme::dark(),
+        ThemePref::Light => app.theme = crate::ui::theme::Theme::light(),
+        // The OSC 11 probe must run before raw mode, so we can't redo
+        // it from here. Keep the current live theme and tell the user
+        // their pick takes effect on next launch.
+        ThemePref::Auto => {
+            app.toasts
+                .push(crate::ui::toast::Toast::info(crate::i18n::t(
+                    crate::i18n::Msg::SettingsAutoThemeOnNextLaunch,
+                )));
+        }
+    }
+}
+
+pub fn begin_edit_editor_command(state: &mut SettingsState) {
+    let current = state.editor_command.clone();
+    let cursor = current.len();
+    state.editor_edit = Some(EditorEdit {
+        buffer: current,
+        cursor,
+    });
+}
+
+/// Sanitises control characters before writing: the prefs file is a
+/// flat `key=value` per line, so a stray `\n` would corrupt every key
+/// after `editor.command`.
+pub(crate) fn commit_editor_command(state: &mut SettingsState) {
+    if let Some(edit) = state.editor_edit.take() {
+        let trimmed = edit.buffer.replace(['\n', '\r', '\t'], " ");
+        let trimmed = trimmed.trim();
+        crate::prefs::set("editor.command", trimmed);
+        state.editor_command = trimmed.to_string();
+    }
+}
+
+pub(crate) fn cancel_editor_command(state: &mut SettingsState) {
+    state.editor_edit = None;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::App;
+    use crate::ui::theme::Theme;
+    use std::sync::MutexGuard;
+    use tempfile::TempDir;
+    use test_support::{CwdGuard, HOME_LOCK, HomeGuard};
+
+    fn isolated_app() -> (
+        MutexGuard<'static, ()>,
+        HomeGuard,
+        CwdGuard,
+        TempDir,
+        TempDir,
+        App,
+    ) {
+        let lock = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = TempDir::new().unwrap();
+        let cwd = TempDir::new().unwrap();
+        let h = HomeGuard::enter(home.path());
+        let g = CwdGuard::enter(cwd.path());
+        let app = App::new(Theme::dark(), None);
+        (lock, h, g, home, cwd, app)
+    }
+
+    #[test]
+    fn move_selection_wraps() {
+        let mut s = SettingsState::default();
+        s.move_selection(-1);
+        assert_eq!(s.selected_idx, SettingItem::ALL.len() - 1);
+        s.move_selection(1);
+        assert_eq!(s.selected_idx, 0);
+    }
+
+    #[test]
+    fn move_selection_clamps_starting_idx() {
+        // ALL shrinking between sessions could leave a stale idx in
+        // saved state — next nav must recover, not panic.
+        let mut s = SettingsState {
+            selected_idx: 999,
+            ..Default::default()
+        };
+        s.move_selection(1);
+        assert_eq!(s.selected_idx, 0);
+    }
+
+    #[test]
+    fn settings_section_assignment_is_complete() {
+        for item in SettingItem::ALL {
+            let _ = item.section();
+            let _ = item.label();
+            let _ = item.description();
+        }
+    }
+
+    #[test]
+    fn cycle_status_tree_mode_updates_app_and_prefs() {
+        let (_lock, _h, _g, _home, _cwd, mut app) = isolated_app();
+        assert!(!app.git_status.tree_mode);
+
+        cycle(&mut app, SettingItem::StatusTreeMode);
+        assert!(app.git_status.tree_mode);
+        assert_eq!(
+            crate::prefs::get("status.tree_mode").as_deref(),
+            Some("true")
+        );
+
+        cycle(&mut app, SettingItem::StatusTreeMode);
+        assert!(!app.git_status.tree_mode);
+        assert_eq!(
+            crate::prefs::get("status.tree_mode").as_deref(),
+            Some("false")
+        );
+    }
+
+    #[test]
+    fn cycle_theme_walks_auto_dark_light() {
+        let (_lock, _h, _g, _home, _cwd, mut app) = isolated_app();
+        refresh_pref_cache(&mut app.settings);
+        assert_eq!(app.settings.theme_pref, ThemePref::Auto);
+
+        cycle(&mut app, SettingItem::Theme);
+        assert_eq!(app.settings.theme_pref, ThemePref::Dark);
+        assert!(app.theme.is_dark);
+
+        cycle(&mut app, SettingItem::Theme);
+        assert_eq!(app.settings.theme_pref, ThemePref::Light);
+        assert!(!app.theme.is_dark);
+
+        // Auto must NOT change the live theme — the probe ran before
+        // raw mode and we can't redo it. Toast covers the visible-no-op.
+        let toasts_before = app.toasts.len();
+        cycle(&mut app, SettingItem::Theme);
+        assert_eq!(app.settings.theme_pref, ThemePref::Auto);
+        assert!(!app.theme.is_dark, "auto must not change live theme");
+        assert!(app.toasts.len() > toasts_before);
+    }
+
+    #[test]
+    fn cycle_commit_diff_layout_persists_independently() {
+        // The Git tab and Graph tab keep separate prefs; crossing the
+        // wires would silently break one tab.
+        let (_lock, _h, _g, _home, _cwd, mut app) = isolated_app();
+        cycle(&mut app, SettingItem::CommitDiffLayout);
+        assert!(matches!(
+            app.commit_detail.diff_layout,
+            DiffLayout::SideBySide
+        ));
+        assert_eq!(
+            crate::prefs::get("commit.diff_layout").as_deref(),
+            Some("side_by_side")
+        );
+        assert_eq!(crate::prefs::get("diff.layout"), None);
+    }
+
+    #[test]
+    fn commit_editor_command_empty_clears_pref() {
+        let (_lock, _h, _g, _home, _cwd, mut app) = isolated_app();
+        crate::prefs::set("editor.command", "old");
+        app.settings.editor_edit = Some(EditorEdit {
+            buffer: "   \t  ".to_string(),
+            cursor: 0,
+        });
+        commit_editor_command(&mut app.settings);
+        assert!(app.settings.editor_edit.is_none());
+        assert_eq!(crate::prefs::get("editor.command").as_deref(), Some(""));
+    }
+
+    #[test]
+    fn commit_editor_command_sanitises_control_chars() {
+        let (_lock, _h, _g, _home, _cwd, mut app) = isolated_app();
+        app.settings.editor_edit = Some(EditorEdit {
+            buffer: "code\n--wait\tfoo".to_string(),
+            cursor: 0,
+        });
+        commit_editor_command(&mut app.settings);
+        let saved = crate::prefs::get("editor.command").unwrap();
+        assert!(!saved.contains('\n'));
+        assert!(!saved.contains('\t'));
+        assert!(!saved.contains('\r'));
+        let (prog, _) = crate::editor::parse_editor_command(&saved).unwrap();
+        assert_eq!(prog, "code");
+    }
+
+    #[test]
+    fn cancel_editor_command_does_not_write_prefs() {
+        let (_lock, _h, _g, _home, _cwd, mut app) = isolated_app();
+        crate::prefs::set("editor.command", "vim");
+        app.settings.editor_edit = Some(EditorEdit {
+            buffer: "garbage".to_string(),
+            cursor: 0,
+        });
+        cancel_editor_command(&mut app.settings);
+        assert!(app.settings.editor_edit.is_none());
+        assert_eq!(crate::prefs::get("editor.command").as_deref(), Some("vim"));
+    }
+
+    #[test]
+    fn open_settings_idempotent_preserves_edit() {
+        let (_lock, _h, _g, _home, _cwd, mut app) = isolated_app();
+        app.open_settings();
+        app.settings.editor_edit = Some(EditorEdit {
+            buffer: "in progress".to_string(),
+            cursor: 0,
+        });
+        app.open_settings();
+        assert!(app.settings.editor_edit.is_some());
+    }
+}

--- a/src/ui/commit_detail_panel.rs
+++ b/src/ui/commit_detail_panel.rs
@@ -408,44 +408,15 @@ fn split_sbs_ranges(
 pub fn handle_key(app: &mut App, key: &str) -> bool {
     match key {
         "m" => {
-            app.commit_detail.diff_layout = match app.commit_detail.diff_layout {
-                DiffLayout::Unified => DiffLayout::SideBySide,
-                DiffLayout::SideBySide => DiffLayout::Unified,
-            };
-            crate::prefs::set(
-                "commit.diff_layout",
-                match app.commit_detail.diff_layout {
-                    DiffLayout::Unified => "unified",
-                    DiffLayout::SideBySide => "side_by_side",
-                },
-            );
+            app.toggle_commit_diff_layout();
             true
         }
         "f" => {
-            app.commit_detail.diff_mode = match app.commit_detail.diff_mode {
-                DiffMode::Compact => DiffMode::FullFile,
-                DiffMode::FullFile => DiffMode::Compact,
-            };
-            crate::prefs::set(
-                "commit.diff_mode",
-                match app.commit_detail.diff_mode {
-                    DiffMode::Compact => "compact",
-                    DiffMode::FullFile => "full_file",
-                },
-            );
-            app.reload_commit_file_diff();
+            app.toggle_commit_diff_mode();
             true
         }
         "t" => {
-            app.commit_detail.files_tree_mode = !app.commit_detail.files_tree_mode;
-            crate::prefs::set(
-                "commit.files_tree_mode",
-                if app.commit_detail.files_tree_mode {
-                    "true"
-                } else {
-                    "false"
-                },
-            );
+            app.toggle_commit_files_tree_mode();
             true
         }
         _ => false,

--- a/src/ui/git_status_panel.rs
+++ b/src/ui/git_status_panel.rs
@@ -186,15 +186,7 @@ pub fn handle_key(app: &mut App, key: &str) -> bool {
             true
         }
         "t" => {
-            app.git_status.tree_mode = !app.git_status.tree_mode;
-            crate::prefs::set(
-                "status.tree_mode",
-                if app.git_status.tree_mode {
-                    "true"
-                } else {
-                    "false"
-                },
-            );
+            app.toggle_status_tree_mode();
             true
         }
         _ => false,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -15,11 +15,12 @@ pub mod mouse;
 pub mod quick_open_panel;
 pub mod search_tab;
 pub mod selection;
+pub mod settings_panel;
 pub mod text;
 pub mod theme;
 pub mod toast;
 
-use crate::app::{App, Tab};
+use crate::app::{App, Tab, ViewMode};
 use crate::i18n::{Msg, t};
 use crate::ui::mouse::ClickAction;
 use crate::ui::toast::ToastLevel;
@@ -54,6 +55,15 @@ pub fn render(f: &mut Frame, app: &mut App) {
     // from steering mouse selection toward a hidden region.
     app.last_diff_rect = None;
     app.last_diff_hit = None;
+
+    // Settings page is a full-screen takeover — render it instead of
+    // the normal title/tab/body/status frame. The four-tab body still
+    // gets its async work scheduled in the background; we just don't
+    // draw it.
+    if app.view_mode == ViewMode::Settings {
+        settings_panel::render(f, app, size);
+        return;
+    }
 
     let main_layout = Layout::default()
         .direction(Direction::Vertical)
@@ -832,6 +842,7 @@ fn render_help(f: &mut Frame, app: &App, screen: Rect) {
         ("v", t(Msg::HelpSelectMode)),
         ("h", t(Msg::HelpShowHelp)),
         ("Ctrl+B", t(Msg::HelpToggleSidebar)),
+        ("Ctrl+,", t(Msg::HelpOpenSettings)),
         ("Space p", t(Msg::HelpQuickOpen)),
         ("Space f", t(Msg::HelpGlobalSearch)),
         (t(Msg::HelpKeyDragDrop), t(Msg::HelpDragDrop)),

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -94,6 +94,12 @@ pub enum ClickAction {
     /// Jump directly to a 1-based page index. Clicking the `[5]` chip
     /// dispatches `DbGotoPage(5)`.
     DbGotoPage(u64),
+    /// Click on a row in the Settings page. The `usize` indexes into
+    /// `crate::settings::SettingItem::ALL`. Clicking just moves the
+    /// selection cursor — activation (toggle / open inline editor) is
+    /// keyboard-only, mirroring the file tree where double-click /
+    /// Enter is the deliberate-action gate.
+    SettingsRow(usize),
 }
 
 #[derive(Debug, Clone)]

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -1,0 +1,222 @@
+//! Full-screen renderer for the Settings page. Activation goes through
+//! Enter (not click) so a stray click can't silently flip a pref the
+//! user wasn't aiming at.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Padding};
+use unicode_width::UnicodeWidthStr;
+
+use crate::app::App;
+use crate::i18n::{Msg, t};
+use crate::settings::{ItemValue, SettingItem, SettingSection, current_value};
+use crate::ui::mouse::ClickAction;
+
+const LABEL_COL_WIDTH: u16 = 28;
+
+pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
+    let th = app.theme;
+    f.render_widget(Clear, area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(th.accent))
+        .title(Span::styled(
+            t(Msg::SettingsTitle),
+            Style::default()
+                .fg(th.fg_primary)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .padding(Padding::new(2, 2, 1, 0));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    if inner.height < 3 || inner.width < 30 {
+        return;
+    }
+
+    let footer_y = inner.y + inner.height.saturating_sub(1);
+    let desc_y = inner.y + inner.height.saturating_sub(2);
+    let body_h = inner.height.saturating_sub(2);
+    let body_rect = Rect::new(inner.x, inner.y, inner.width, body_h);
+
+    let selected = app.settings.selected();
+    render_body(f, app, body_rect, selected);
+
+    let editing_editor = app.settings.editor_edit.is_some();
+    if editing_editor {
+        render_inline_editor_prompt(f, app, Rect::new(inner.x, desc_y, inner.width, 1));
+    } else {
+        let desc = t(selected.description());
+        let line = Line::from(Span::styled(
+            format!("  {desc}"),
+            Style::default().fg(th.fg_secondary),
+        ));
+        f.render_widget(line, Rect::new(inner.x, desc_y, inner.width, 1));
+    }
+
+    let footer_msg = if editing_editor {
+        Msg::SettingsEditorEditHint
+    } else {
+        Msg::SettingsFooterHint
+    };
+    let footer = Line::from(Span::styled(
+        t(footer_msg),
+        Style::default().fg(th.chrome_muted_fg),
+    ));
+    f.render_widget(footer, Rect::new(inner.x, footer_y, inner.width, 1));
+}
+
+fn render_body(f: &mut Frame, app: &mut App, area: Rect, selected: SettingItem) {
+    let th = app.theme;
+    let mut y = area.y;
+    let max_y = area.y + area.height;
+    let mut last_section: Option<SettingSection> = None;
+    let value_col = (area.width.saturating_sub(2))
+        .saturating_sub(LABEL_COL_WIDTH)
+        .max(20);
+
+    for (idx, item) in SettingItem::ALL.iter().enumerate() {
+        if y >= max_y {
+            break;
+        }
+        let section = item.section();
+        if Some(section) != last_section {
+            if last_section.is_some() {
+                y += 1;
+                if y >= max_y {
+                    break;
+                }
+            }
+            let header = Line::from(Span::styled(
+                t(section.label()).to_uppercase(),
+                Style::default().fg(th.accent).add_modifier(Modifier::BOLD),
+            ));
+            f.render_widget(header, Rect::new(area.x, y, area.width, 1));
+            y += 1;
+            last_section = Some(section);
+            if y >= max_y {
+                break;
+            }
+        }
+
+        let row_rect = Rect::new(area.x, y, area.width, 1);
+        render_row(f, app, row_rect, value_col, *item, *item == selected);
+        app.hit_registry
+            .register(row_rect, ClickAction::SettingsRow(idx));
+        y += 1;
+    }
+}
+
+fn render_row(
+    f: &mut Frame,
+    app: &App,
+    rect: Rect,
+    value_col: u16,
+    item: SettingItem,
+    selected: bool,
+) {
+    let th = app.theme;
+    let row_bg = if selected {
+        th.selection_bg
+    } else {
+        th.chrome_bg
+    };
+    let chevron = if selected { " › " } else { "   " };
+
+    let label_text = t(item.label());
+    let (value_text, value_style) = format_value(&current_value(item, app), th, selected);
+
+    let consumed = UnicodeWidthStr::width(chevron) + UnicodeWidthStr::width(label_text);
+    let pad_str = " ".repeat((value_col as usize).saturating_sub(consumed));
+
+    // ratatui has no "row background" primitive; a full-width styled
+    // space is the standard workaround so the selected row's bg sweeps
+    // past the value pill to the right edge.
+    let bg_line = Line::from(Span::styled(
+        " ".repeat(rect.width as usize),
+        Style::default().bg(row_bg),
+    ));
+    f.render_widget(bg_line, rect);
+
+    let label_style = Style::default()
+        .fg(th.fg_primary)
+        .bg(row_bg)
+        .add_modifier(if selected {
+            Modifier::BOLD
+        } else {
+            Modifier::empty()
+        });
+    let chevron_style = Style::default()
+        .fg(th.accent)
+        .bg(row_bg)
+        .add_modifier(Modifier::BOLD);
+
+    let line = Line::from(vec![
+        Span::styled(chevron, chevron_style),
+        Span::styled(label_text, label_style),
+        Span::styled(pad_str, Style::default().bg(row_bg)),
+        Span::styled(value_text, value_style.bg(row_bg)),
+    ]);
+    f.render_widget(line, rect);
+}
+
+fn format_value(value: &ItemValue, th: crate::ui::theme::Theme, selected: bool) -> (String, Style) {
+    let strong = if selected {
+        Style::default().fg(th.accent).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(th.fg_primary)
+    };
+    match value {
+        // Bools carry no good/bad semantics — colouring `on` green
+        // would imply "on is desirable", which isn't true for tree-mode
+        // toggles. Off-state dim + on-state accent reads as "current
+        // selection" instead.
+        ItemValue::Bool(b) => {
+            let label = if *b {
+                t(Msg::SettingsValueOn)
+            } else {
+                t(Msg::SettingsValueOff)
+            };
+            let style = if *b {
+                strong
+            } else {
+                Style::default().fg(th.fg_secondary)
+            };
+            (format!("[{label}]"), style)
+        }
+        ItemValue::Choice(label) => (format!("[{label}]"), strong),
+        ItemValue::Text(s) if s.is_empty() => (
+            t(Msg::SettingsEditorPlaceholder).to_string(),
+            Style::default()
+                .fg(th.fg_secondary)
+                .add_modifier(Modifier::ITALIC),
+        ),
+        ItemValue::Text(s) => (s.clone(), strong),
+    }
+}
+
+fn render_inline_editor_prompt(f: &mut Frame, app: &App, area: Rect) {
+    let th = app.theme;
+    let Some(edit) = app.settings.editor_edit.as_ref() else {
+        return;
+    };
+    let prompt = "  › ";
+    let line = Line::from(vec![
+        Span::styled(
+            prompt,
+            Style::default().fg(th.accent).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(edit.buffer.clone(), Style::default().fg(th.fg_primary)),
+    ]);
+    f.render_widget(line, area);
+
+    let prompt_w = UnicodeWidthStr::width(prompt) as u16;
+    let buffer_w =
+        UnicodeWidthStr::width(&edit.buffer[..edit.cursor.min(edit.buffer.len())]) as u16;
+    let cursor_x = area.x + (prompt_w + buffer_w).min(area.width.saturating_sub(1));
+    f.set_cursor_position((cursor_x, area.y));
+}

--- a/tests/backend_editor_spec.rs
+++ b/tests/backend_editor_spec.rs
@@ -10,7 +10,7 @@ use std::sync::Mutex;
 
 use reef::backend::{Backend, BackendError, LocalBackend, RemoteBackend};
 use tempfile::TempDir;
-use test_support::agent_bin;
+use test_support::{HOME_LOCK, HomeGuard, agent_bin};
 
 static BACKEND_LOCK: Mutex<()> = Mutex::new(());
 
@@ -24,18 +24,19 @@ fn spawn_remote(workdir: &Path) -> RemoteBackend {
     RemoteBackend::spawn(&argv).expect("spawn remote")
 }
 
-/// Env-var reads are process-wide, so this test serialises against
-/// anything else that mutates $VISUAL/$EDITOR. The existing loopback
-/// tests in the suite don't touch those, so a dedicated lock here is
-/// sufficient.
-static EDITOR_ENV_LOCK: Mutex<()> = Mutex::new(());
-
 #[test]
 fn local_editor_spec_uses_editor_env() {
-    let _lock = EDITOR_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-    // SAFETY: single-threaded env mutation protected by EDITOR_ENV_LOCK.
-    // Other tests in this binary can't race because cargo runs test cases
-    // within one binary sequentially by default (plus the mutex).
+    // `resolve_editor` now reads the `editor.command` pref before
+    // $VISUAL / $EDITOR (so the in-app Settings page can override the
+    // shell environment). Redirect $HOME to an empty tempdir so the
+    // developer's real `~/.config/reef/prefs` doesn't override the
+    // env-var contract this test is asserting. Shares the
+    // workspace-wide HOME_LOCK so we serialise against any future
+    // test in this binary that touches HOME.
+    let _lock = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let home_tmp = TempDir::new().unwrap();
+    let _home = HomeGuard::enter(home_tmp.path());
+    // SAFETY: single-threaded env mutation protected by HOME_LOCK.
     unsafe {
         std::env::set_var("VISUAL", "");
         std::env::set_var("EDITOR", "true");
@@ -75,7 +76,13 @@ fn remote_spawn_variant_refuses_editor_spec() {
 
 #[test]
 fn local_editor_spec_rejects_path_escape() {
-    let _lock = EDITOR_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // Same HOME isolation rationale as `local_editor_spec_uses_editor_env`
+    // — without it the dev's real `editor.command` pref leaks in. The
+    // PathEscape check happens before editor resolution though, so this
+    // is mostly defensive.
+    let _lock = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let home_tmp = TempDir::new().unwrap();
+    let _home = HomeGuard::enter(home_tmp.path());
     unsafe {
         std::env::set_var("EDITOR", "true");
     }

--- a/tests/settings_input.rs
+++ b/tests/settings_input.rs
@@ -1,0 +1,130 @@
+//! Settings page entry / exit + inline-editor key dispatch.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use reef::app::{App, Panel, Tab, ViewMode};
+use reef::input;
+use reef::settings::SettingItem;
+use reef::ui::theme::Theme;
+use std::sync::MutexGuard;
+use tempfile::TempDir;
+use test_support::{CwdGuard, HOME_LOCK, HomeGuard};
+
+fn ctrl_comma() -> KeyEvent {
+    KeyEvent::new(KeyCode::Char(','), KeyModifiers::CONTROL)
+}
+
+fn esc() -> KeyEvent {
+    KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)
+}
+
+fn enter() -> KeyEvent {
+    KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)
+}
+
+fn char_key(c: char) -> KeyEvent {
+    KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+}
+
+fn isolated_app() -> (
+    MutexGuard<'static, ()>,
+    HomeGuard,
+    CwdGuard,
+    TempDir,
+    TempDir,
+    App,
+) {
+    let lock = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let home = TempDir::new().unwrap();
+    let cwd = TempDir::new().unwrap();
+    let h = HomeGuard::enter(home.path());
+    let g = CwdGuard::enter(cwd.path());
+    let app = App::new(Theme::dark(), None);
+    (lock, h, g, home, cwd, app)
+}
+
+fn editor_command_idx() -> usize {
+    SettingItem::ALL
+        .iter()
+        .position(|i| matches!(i, SettingItem::EditorCommand))
+        .expect("EditorCommand must be in SettingItem::ALL")
+}
+
+#[test]
+fn ctrl_comma_opens_settings_and_esc_closes() {
+    let (_lock, _h, _g, _home, _cwd, mut app) = isolated_app();
+    assert_eq!(app.view_mode, ViewMode::Main);
+
+    input::handle_key(ctrl_comma(), &mut app);
+    assert_eq!(app.view_mode, ViewMode::Settings);
+
+    input::handle_key(esc(), &mut app);
+    assert_eq!(app.view_mode, ViewMode::Main);
+}
+
+#[test]
+fn ctrl_comma_suppressed_in_commit_message_input_mode() {
+    let (_lock, _h, _g, _home, _cwd, mut app) = isolated_app();
+    app.set_active_tab(Tab::Git);
+    app.active_panel = Panel::Files;
+    app.git_status.commit_editing = true;
+    app.git_status.commit_message = "fix:".into();
+    app.git_status.commit_cursor = app.git_status.commit_message.len();
+
+    input::handle_key(ctrl_comma(), &mut app);
+    assert_eq!(app.view_mode, ViewMode::Main);
+}
+
+#[test]
+fn enter_on_editor_command_row_opens_inline_editor() {
+    let (_lock, _h, _g, _home, _cwd, mut app) = isolated_app();
+    input::handle_key(ctrl_comma(), &mut app);
+    app.settings.select(editor_command_idx());
+
+    input::handle_key(enter(), &mut app);
+    assert!(app.settings.editor_edit.is_some());
+
+    for c in "nvim".chars() {
+        input::handle_key(char_key(c), &mut app);
+    }
+    input::handle_key(enter(), &mut app);
+    assert!(app.settings.editor_edit.is_none());
+    assert_eq!(reef::prefs::get("editor.command").as_deref(), Some("nvim"));
+}
+
+#[test]
+fn esc_in_inline_editor_cancels_without_writing_prefs() {
+    let (_lock, _h, _g, _home, _cwd, mut app) = isolated_app();
+    reef::prefs::set("editor.command", "vim");
+    input::handle_key(ctrl_comma(), &mut app);
+    app.settings.select(editor_command_idx());
+    input::handle_key(enter(), &mut app);
+
+    for c in "garbage".chars() {
+        input::handle_key(char_key(c), &mut app);
+    }
+    // First Esc closes the inline editor; second Esc closes the page.
+    input::handle_key(esc(), &mut app);
+    assert!(app.settings.editor_edit.is_none());
+    assert_eq!(app.view_mode, ViewMode::Settings);
+    assert_eq!(reef::prefs::get("editor.command").as_deref(), Some("vim"));
+
+    input::handle_key(esc(), &mut app);
+    assert_eq!(app.view_mode, ViewMode::Main);
+}
+
+/// Regression: bare `v` is intercepted in `main.rs` as the select-mode
+/// toggle. The Settings page must override that interception so `v`
+/// reaches the inline editor as a literal char.
+#[test]
+fn typing_v_in_inline_editor_inserts_literal() {
+    let (_lock, _h, _g, _home, _cwd, mut app) = isolated_app();
+    input::handle_key(ctrl_comma(), &mut app);
+    app.settings.select(editor_command_idx());
+    input::handle_key(enter(), &mut app);
+
+    for c in "nvim".chars() {
+        input::handle_key(char_key(c), &mut app);
+    }
+    let edit = app.settings.editor_edit.as_ref().unwrap();
+    assert_eq!(edit.buffer, "nvim");
+}

--- a/tests/snapshots/ui_snapshots__settings_page_default.snap
+++ b/tests/snapshots/ui_snapshots__settings_page_default.snap
@@ -1,0 +1,29 @@
+---
+source: tests/ui_snapshots.rs
+assertion_line: 652
+expression: output
+---
+┌ ⚙ Settings ──────────────────────────────────────────────────────────────────┐
+│                                                                              │
+│  GENERAL                                                                     │
+│   › Theme                                    [auto]                          │
+│                                                                              │
+│  EXTERNAL EDITOR                                                             │
+│     Editor command                           (unset — uses $VISUAL / $EDITO  │
+│                                                                              │
+│  GIT DIFF                                                                    │
+│     Diff layout                              [unified]                       │
+│     Diff mode                                [compact]                       │
+│     Status sidebar — tree view               [off]                           │
+│                                                                              │
+│  COMMIT DETAIL                                                               │
+│     Commit diff layout                       [unified]                       │
+│     Commit diff mode                         [compact]                       │
+│     Commit files — tree view                 [off]                           │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│    auto detects terminal background; pick dark / light to override (takes e  │
+│    ↑↓ select · Enter toggle/edit · Esc back                                  │
+└──────────────────────────────────────────────────────────────────────────────┘

--- a/tests/snapshots/ui_snapshots__settings_page_editing_editor_command.snap
+++ b/tests/snapshots/ui_snapshots__settings_page_editing_editor_command.snap
@@ -1,0 +1,29 @@
+---
+source: tests/ui_snapshots.rs
+assertion_line: 680
+expression: output
+---
+┌ ⚙ Settings ──────────────────────────────────────────────────────────────────┐
+│                                                                              │
+│  GENERAL                                                                     │
+│     Theme                                    [auto]                          │
+│                                                                              │
+│  EXTERNAL EDITOR                                                             │
+│   › Editor command                           (unset — uses $VISUAL / $EDITO  │
+│                                                                              │
+│  GIT DIFF                                                                    │
+│     Diff layout                              [unified]                       │
+│     Diff mode                                [compact]                       │
+│     Status sidebar — tree view               [off]                           │
+│                                                                              │
+│  COMMIT DETAIL                                                               │
+│     Commit diff layout                       [unified]                       │
+│     Commit diff mode                         [compact]                       │
+│     Commit files — tree view                 [off]                           │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│    › nvim --clean                                                            │
+│    Enter save · Esc cancel                                                   │
+└──────────────────────────────────────────────────────────────────────────────┘

--- a/tests/ui_snapshots.rs
+++ b/tests/ui_snapshots.rs
@@ -631,3 +631,49 @@ fn snapshot_search_tab_replace_open_with_excluded_row() {
         insta::assert_snapshot!("search_tab_replace_open_with_excluded_row", output)
     });
 }
+
+#[test]
+fn snapshot_settings_page_default() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    force_en_lang();
+    let (tmp, _raw) = tempdir_repo();
+    let home = tempfile::TempDir::new().expect("home tempdir");
+    let _h = HomeGuard::enter(home.path());
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    wait_for_file_tree(&mut app);
+    app.open_settings();
+    let output = render_app(&mut app, 80, 24);
+    with_filters(&[], || {
+        insta::assert_snapshot!("settings_page_default", output)
+    });
+}
+
+#[test]
+fn snapshot_settings_page_editing_editor_command() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    force_en_lang();
+    let (tmp, _raw) = tempdir_repo();
+    let home = tempfile::TempDir::new().expect("home tempdir");
+    let _h = HomeGuard::enter(home.path());
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    wait_for_file_tree(&mut app);
+    app.open_settings();
+    let editor_idx = reef::settings::SettingItem::ALL
+        .iter()
+        .position(|i| matches!(i, reef::settings::SettingItem::EditorCommand))
+        .unwrap();
+    app.settings.select(editor_idx);
+    reef::settings::begin_edit_editor_command(&mut app.settings);
+    if let Some(edit) = app.settings.editor_edit.as_mut() {
+        edit.buffer = "nvim --clean".to_string();
+        edit.cursor = edit.buffer.len();
+    }
+    let output = render_app(&mut app, 80, 24);
+    with_filters(&[], || {
+        insta::assert_snapshot!("settings_page_editing_editor_command", output)
+    });
+}


### PR DESCRIPTION
## Summary

- New full-screen Settings page (`Ctrl+,` to open, `Esc` to close). Hides the tab bar; replaces the body with a categorised list of preference rows. Background workers keep refreshing the four-tab snapshots while the page is open, so they're current on return.
- New `editor.command` pref consulted before `$VISUAL` / `$EDITOR` in `editor::resolve_editor`. The per-launch env override still works when the pref is unset.
- Inline `editor.command` text editor reuses `input_edit::dispatch_key`, picking up the same readline / VSCode editing aliases (Ctrl+A/E/B/F, Alt+Backspace, Delete, word-jump, …) as the search and quick-open palettes.
- All previously-scattered prefs surface from one page: theme (auto / dark / light), editor command, diff layout & mode (Git tab), status sidebar tree mode, commit diff layout & mode (Graph tab), commit files tree mode.

## Notable refactors

- `DiffLayout` / `DiffMode` get `pref_str` / `from_pref_str`; readers and writers across `app::load_prefs`, `App::new`, and `settings::cycle` share one mapping.
- New `App::toggle_status_tree_mode` / `toggle_commit_diff_layout` / `toggle_commit_diff_mode` / `toggle_commit_files_tree_mode`. Both the in-place `t / m / f` keybindings (in `commit_detail_panel` / `git_status_panel`) and the Settings page cycle path delegate here, deduplicating three previous call sites and fixing a latent bug where Settings could flip `commit.diff_mode` without refetching the diff.
- `prefs::set_bool` paired with the existing `get_bool`.
- `SettingsState` caches `theme_pref` + `editor_command` so `current_value()` reads memory, not disk on every render.
- `test-support` exports a workspace-shared `HOME_LOCK` so unit tests in different `src/*.rs` modules of the same `cargo test --lib` binary stop racing on `$HOME` mutations. `prefs::tests`, `editor::tests`, and the new `settings::tests` all migrate to it.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features --lib` (517 tests, 5 stress runs all green)
- [x] `cargo test --workspace --doc`
- [x] `cargo test --test ui_snapshots --test settings_input --test backend_editor_spec`
- [x] Two new snapshot tests pin the page layout (default + inline-editor mode)
- [x] Five new integration tests in `tests/settings_input.rs` cover Ctrl+, opener, Esc closer, input-mode suppression of Ctrl+,, inline-editor commit / cancel, and bare-`v` literal insertion (regression for the `v`-as-select-mode toggle in main.rs)
- [x] Existing snapshots and integration tests still pass; only the pre-existing `fs_watcher_integration` macOS flake is red on this branch and on `main`

## Notes

- `Ctrl+,` is not a portable terminal control sequence; iTerm2 / Alacritty / kitty / WezTerm / Windows Terminal forward it, but Terminal.app and basic xterm don't. The help popup row has a note about this. A `Space + ,` leader chord could be added later if the limitation bites.
- Theme `auto` cycles still write the pref, but the live theme is left untouched (the OSC 11 probe must run before raw mode and we can't redo it from inside the page). A toast surfaces the "takes effect on next launch" hint so the user isn't confused by the unchanged screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)