### PR TITLE
feat(search): seed Space+F from selection + paste in palette & Search tab

### DIFF
--- a/src/global_search.rs
+++ b/src/global_search.rs
@@ -302,14 +302,94 @@ pub const PREVIEW_SYNC_DEBOUNCE: std::time::Duration = std::time::Duration::from
 
 // ─── Entry points ────────────────────────────────────────────────────────────
 
-/// Open the palette. Keeps existing `query`/`results` so Esc-peek-and-return
-/// doesn't lose state.
+/// Open the palette. If the active tab has a non-empty text selection
+/// (file-preview drag-select on Tab::Files, diff drag-select on Tab::Git
+/// /Tab::Graph), seed the query with it — VSCode's "Find with Selection"
+/// shortcut. Otherwise keeps the existing `query`/`results` so Esc-peek-
+/// and-return doesn't lose state.
 pub fn begin(app: &mut App) {
-    app.global_search.active = true;
+    if let Some(seed) = current_text_selection(app)
+        && seed != app.global_search.query
+    {
+        // Skip the rerun + excluded-clear when the seed equals the
+        // existing query: the user might have ticked off hits in
+        // replace mode and we don't want a no-op chord to wipe that.
+        app.global_search.query = seed;
+        mark_query_edited(&mut app.global_search);
+    }
     app.global_search.cursor = app.global_search.query.len();
+    app.global_search.active = true;
     // Fresh leader slot — a stale timestamp from a prior session would make
     // the first Space-after-open surprisingly close the palette.
     app.global_search.space_leader_at = None;
+}
+
+/// Snapshot the user's current text selection as a one-line search seed.
+///
+/// Sources, in priority order:
+/// 1. File preview selection (`preview_selection` × `preview_content`'s
+///    text body) — covers Tab::Files and the Tab::Search preview pane.
+/// 2. Diff selection (`diff_selection` × `last_diff_hit`) — covers
+///    Tab::Git and the Tab::Graph 3-col diff column.
+///
+/// Multi-line selections collapse to the first non-empty line, then
+/// trim leading/trailing whitespace: the global-search prompt is
+/// single-line and feeding it raw indentation produces zero matches
+/// for anything but the first line of a function.
+fn current_text_selection(app: &App) -> Option<String> {
+    if let (Some(sel), Some(preview)) =
+        (app.preview_selection.as_ref(), app.preview_content.as_ref())
+        && !sel.is_empty()
+        && let crate::file_tree::PreviewBody::Text { lines, .. } = &preview.body
+    {
+        let text = crate::ui::selection::collect_selected_text(lines, sel);
+        if let Some(line) = first_nonempty_trimmed_line(&text) {
+            return Some(line);
+        }
+    }
+    if let (Some(sel), Some(hit)) = (app.diff_selection.as_ref(), app.last_diff_hit.as_ref())
+        && !sel.sel.is_empty()
+    {
+        let text = crate::ui::selection::collect_diff_selected_text(hit, sel);
+        if let Some(line) = first_nonempty_trimmed_line(&text) {
+            return Some(line);
+        }
+    }
+    None
+}
+
+fn first_nonempty_trimmed_line(s: &str) -> Option<String> {
+    s.lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .map(str::to_string)
+}
+
+/// Bracketed-paste arrival while the Space+F overlay is active. Strips
+/// newlines and re-runs the search. Called from `input::handle_paste`
+/// after the drop-path parser has declined the payload.
+pub fn handle_paste_overlay(s: &str, state: &mut GlobalSearchState) {
+    if input_edit::paste_single_line(s, &mut state.query, &mut state.cursor) {
+        mark_query_edited(state);
+    }
+}
+
+/// Bracketed-paste arrival while a Tab::Search input row is focused.
+/// Routes to `query` (FindInput) or `replace_text` (ReplaceInput) based
+/// on `focus`; List focus is a no-op (no text input to receive the
+/// payload).
+pub fn handle_paste_search_tab(s: &str, state: &mut GlobalSearchState) {
+    match state.focus {
+        SearchPanelFocus::FindInput => {
+            if input_edit::paste_single_line(s, &mut state.query, &mut state.cursor) {
+                mark_query_edited(state);
+            }
+        }
+        SearchPanelFocus::ReplaceInput => {
+            input_edit::paste_single_line(s, &mut state.replace_text, &mut state.replace_cursor);
+        }
+        SearchPanelFocus::List => {}
+    }
 }
 
 /// Commit the selected hit: close the palette, switch to the Files tab,
@@ -891,5 +971,126 @@ mod tests {
             line_text: String::new(),
             byte_range: 0..0,
         }
+    }
+
+    // ── selection-seed plumbing ──────────────────────────────────────────
+
+    #[test]
+    fn first_nonempty_trimmed_line_returns_none_for_blank_input() {
+        assert_eq!(first_nonempty_trimmed_line(""), None);
+        assert_eq!(first_nonempty_trimmed_line("   \n  \t\n"), None);
+    }
+
+    #[test]
+    fn first_nonempty_trimmed_line_skips_leading_blanks() {
+        assert_eq!(
+            first_nonempty_trimmed_line("\n\n   first\nsecond"),
+            Some("first".to_string()),
+        );
+    }
+
+    #[test]
+    fn first_nonempty_trimmed_line_strips_indentation_and_trailing_ws() {
+        // The selection on a function body grabs the leading indent —
+        // feeding "    fn foo()" verbatim into ripgrep would miss every
+        // call site that isn't indented identically.
+        assert_eq!(
+            first_nonempty_trimmed_line("    fn foo()   "),
+            Some("fn foo()".to_string()),
+        );
+    }
+
+    // ── handle_paste_overlay ────────────────────────────────────────────
+
+    #[test]
+    fn handle_paste_overlay_inserts_and_marks_edited() {
+        let mut state = GlobalSearchState::default();
+        assert!(state.last_keystroke_at.is_none());
+        handle_paste_overlay("hello", &mut state);
+        assert_eq!(state.query, "hello");
+        assert_eq!(state.cursor, 5);
+        assert!(
+            state.last_keystroke_at.is_some(),
+            "non-empty paste must arm the search-rerun debounce",
+        );
+    }
+
+    #[test]
+    fn handle_paste_overlay_pure_newlines_do_not_trigger_rerun() {
+        let mut state = GlobalSearchState::default();
+        handle_paste_overlay("\n\r\n", &mut state);
+        assert_eq!(state.query, "");
+        assert!(
+            state.last_keystroke_at.is_none(),
+            "all-newline paste inserts nothing → search rerun must NOT fire",
+        );
+    }
+
+    #[test]
+    fn handle_paste_overlay_does_not_clear_unrelated_state() {
+        // Regression guard: the rerun debounce is the only side-effect
+        // the overlay paste should have. `selected` and `replace_text`
+        // must survive untouched.
+        let mut state = GlobalSearchState {
+            results: vec![dummy_hit("a"), dummy_hit("b"), dummy_hit("c")],
+            selected: 2,
+            replace_text: "kept".to_string(),
+            replace_cursor: 4,
+            ..GlobalSearchState::default()
+        };
+        handle_paste_overlay("foo", &mut state);
+        assert_eq!(state.selected, 2);
+        assert_eq!(state.replace_text, "kept");
+        assert_eq!(state.replace_cursor, 4);
+    }
+
+    // ── handle_paste_search_tab ─────────────────────────────────────────
+
+    #[test]
+    fn handle_paste_search_tab_routes_find_input_to_query() {
+        let mut state = GlobalSearchState {
+            focus: SearchPanelFocus::FindInput,
+            ..GlobalSearchState::default()
+        };
+        handle_paste_search_tab("abc", &mut state);
+        assert_eq!(state.query, "abc");
+        assert_eq!(state.cursor, 3);
+        assert!(state.last_keystroke_at.is_some());
+        assert_eq!(state.replace_text, "");
+    }
+
+    #[test]
+    fn handle_paste_search_tab_routes_replace_input_to_replace_text() {
+        let mut state = GlobalSearchState {
+            focus: SearchPanelFocus::ReplaceInput,
+            replace_open: true,
+            ..GlobalSearchState::default()
+        };
+        handle_paste_search_tab("xyz", &mut state);
+        assert_eq!(state.replace_text, "xyz");
+        assert_eq!(state.replace_cursor, 3);
+        assert_eq!(state.query, "");
+        assert!(
+            state.last_keystroke_at.is_none(),
+            "replace-input edits never re-run the search",
+        );
+    }
+
+    #[test]
+    fn handle_paste_search_tab_list_focus_is_noop() {
+        // List focus = no text input is selected → bracketed paste has
+        // nowhere to land. Must not silently leak into either field.
+        let mut state = GlobalSearchState {
+            focus: SearchPanelFocus::List,
+            query: "kept-query".to_string(),
+            cursor: 10,
+            replace_text: "kept-replace".to_string(),
+            replace_cursor: 12,
+            ..GlobalSearchState::default()
+        };
+        handle_paste_search_tab("LEAK", &mut state);
+        assert_eq!(state.query, "kept-query");
+        assert_eq!(state.replace_text, "kept-replace");
+        assert!(state.last_keystroke_at.is_none());
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -3055,6 +3055,13 @@ pub fn handle_paste(s: String, app: &mut App) {
         quick_open::handle_paste(&s, app);
     } else if app.search.active {
         search::handle_paste(&s, app);
+    } else if app.global_search.active {
+        global_search::handle_paste_overlay(&s, &mut app.global_search);
+    } else if app.active_tab == Tab::Search
+        && app.active_panel == Panel::Files
+        && app.global_search.input_focused()
+    {
+        global_search::handle_paste_search_tab(&s, &mut app.global_search);
     }
     // No focused input; intentionally dropped. A stray paste into the
     // global keymap has no defined meaning, and we don't want to

--- a/src/input_edit.rs
+++ b/src/input_edit.rs
@@ -126,6 +126,26 @@ pub fn insert_char(text: &mut String, cursor: &mut usize, c: char) {
     *cursor += c.len_utf8();
 }
 
+/// Insert a bracketed-paste payload into a single-line `(text, cursor)`
+/// buffer, dropping CR/LF so a multi-line clipboard can't leave
+/// invisible characters in the prompt. Returns `true` when at least one
+/// char actually landed.
+///
+/// Filters into a temporary `String` then does a single `insert_str`
+/// instead of per-char `String::insert` — an N-char paste at position P
+/// becomes O(N+L) bytes moved rather than O(N·(L−P)) per-char memmoves.
+/// Bracketed-paste payloads can be MB-scale (large clipboards), so this
+/// matters even though the typical case is small.
+pub fn paste_single_line(s: &str, text: &mut String, cursor: &mut usize) -> bool {
+    let filtered: String = s.chars().filter(|c| *c != '\n' && *c != '\r').collect();
+    if filtered.is_empty() {
+        return false;
+    }
+    text.insert_str(*cursor, &filtered);
+    *cursor += filtered.len();
+    true
+}
+
 pub fn backspace(text: &mut String, cursor: &mut usize) {
     if *cursor == 0 {
         return;
@@ -456,5 +476,45 @@ mod tests {
         delete_word_forward(&mut q, &mut c);
         assert_eq!(q, "foo");
         assert_eq!(c, 3);
+    }
+
+    #[test]
+    fn paste_single_line_inserts_at_cursor_and_advances() {
+        let (mut t, mut c) = state("ab", 1);
+        assert!(paste_single_line("XY", &mut t, &mut c));
+        assert_eq!(t, "aXYb");
+        assert_eq!(c, 3);
+    }
+
+    #[test]
+    fn paste_single_line_drops_crlf() {
+        // Multi-line payload (Windows clipboard) flattens into a single
+        // run with no embedded line terminators.
+        let (mut t, mut c) = state("", 0);
+        assert!(paste_single_line("foo\r\nbar\nbaz", &mut t, &mut c));
+        assert_eq!(t, "foobarbaz");
+        assert_eq!(c, 9);
+    }
+
+    #[test]
+    fn paste_single_line_returns_false_for_empty_or_pure_newlines() {
+        let (mut t, mut c) = state("keep", 4);
+        assert!(!paste_single_line("", &mut t, &mut c));
+        assert!(!paste_single_line("\n\r\n", &mut t, &mut c));
+        assert_eq!(t, "keep");
+        assert_eq!(c, 4);
+    }
+
+    #[test]
+    fn paste_single_line_preserves_utf8_at_cursor() {
+        // Insert into a string with multi-byte chars on either side of
+        // the cursor — verifies the byte-offset cursor lands on a
+        // codepoint boundary after the insert.
+        let s = "你好";
+        let mid = s.char_indices().nth(1).map(|(i, _)| i).unwrap(); // between '你' and '好'
+        let (mut t, mut c) = state(s, mid);
+        assert!(paste_single_line("X", &mut t, &mut c));
+        assert_eq!(t, "你X好");
+        assert_eq!(c, mid + 1);
     }
 }

--- a/src/quick_open.rs
+++ b/src/quick_open.rs
@@ -302,12 +302,7 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
 /// Called from `input::handle_paste` after the drop-path parser has already
 /// ruled out the payload as a file drop.
 pub fn handle_paste(s: &str, app: &mut App) {
-    for c in s.chars() {
-        if c == '\n' || c == '\r' {
-            continue;
-        }
-        input_edit::insert_char(&mut app.quick_open.query, &mut app.quick_open.cursor, c);
-    }
+    input_edit::paste_single_line(s, &mut app.quick_open.query, &mut app.quick_open.cursor);
     filter(&mut app.quick_open);
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -261,15 +261,7 @@ pub fn handle_key_in_search_mode(key: KeyEvent, app: &mut App) {
 /// prompt model. Called from `input::handle_paste` after the drop-path
 /// parser has declined the payload.
 pub fn handle_paste(s: &str, app: &mut App) {
-    let mut added = false;
-    for c in s.chars() {
-        if c == '\n' || c == '\r' {
-            continue;
-        }
-        input_edit::insert_char(&mut app.search.query, &mut app.search.cursor, c);
-        added = true;
-    }
-    if added {
+    if input_edit::paste_single_line(s, &mut app.search.query, &mut app.search.cursor) {
         app.search.wrap_msg = None;
         recompute_and_jump(app, /*from_step=*/ false);
     }

--- a/tests/global_search_seed.rs
+++ b/tests/global_search_seed.rs
@@ -1,0 +1,129 @@
+//! `global_search::begin` selection-seed contract: opening the Space+F
+//! palette while text is selected pre-fills the query with the first
+//! non-empty trimmed line of the selection (VSCode "Find with
+//! Selection"). Without a selection, the existing `query` survives so
+//! Esc-peek-and-return is non-destructive.
+
+use reef::app::App;
+use reef::file_tree::{PreviewBody, PreviewContent};
+use reef::global_search;
+use reef::ui::selection::PreviewSelection;
+use reef::ui::theme::Theme;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use tempfile::TempDir;
+use test_support::CwdGuard;
+
+// `App::new` cd's into the workdir + reads $HOME prefs; the rest of the
+// suite uses the same lock to keep parallel tests from racing on those
+// process-globals.
+static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+fn fresh_app() -> (App, TempDir, CwdGuard) {
+    let tmp = TempDir::new().unwrap();
+    let g = CwdGuard::enter(tmp.path());
+    let app = App::new(Theme::dark(), None);
+    (app, tmp, g)
+}
+
+fn install_text_preview(app: &mut App, lines: &[&str]) {
+    app.preview_content = Some(PreviewContent {
+        file_path: "scratch.txt".to_string(),
+        body: PreviewBody::Text {
+            lines: lines.iter().map(|s| s.to_string()).collect(),
+            highlighted: None,
+        },
+    });
+}
+
+fn select_byte_range(app: &mut App, start: (usize, usize), end: (usize, usize)) {
+    let mut sel = PreviewSelection::new(start);
+    sel.active = end;
+    sel.dragging = false;
+    app.preview_selection = Some(sel);
+}
+
+#[test]
+fn begin_without_selection_preserves_existing_query() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    app.global_search.query = "previous".to_string();
+    app.global_search.cursor = "previous".len();
+
+    global_search::begin(&mut app);
+
+    assert!(app.global_search.active);
+    assert_eq!(app.global_search.query, "previous");
+    assert_eq!(app.global_search.cursor, "previous".len());
+}
+
+#[test]
+fn begin_seeds_query_from_preview_selection() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    install_text_preview(&mut app, &["fn foo() {", "    bar();", "}"]);
+    // Select "    bar();" — the helper must trim the leading indent.
+    select_byte_range(&mut app, (1, 0), (1, "    bar();".len()));
+
+    global_search::begin(&mut app);
+
+    assert_eq!(app.global_search.query, "bar();");
+    assert_eq!(app.global_search.cursor, "bar();".len());
+    assert!(app.global_search.active);
+}
+
+#[test]
+fn begin_seeds_first_nonempty_line_when_selection_spans_multiple_rows() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    install_text_preview(&mut app, &["", "  hello", "world"]);
+    // Selection: blank row 0 fully, all of row 1, all of row 2.
+    select_byte_range(&mut app, (0, 0), (2, "world".len()));
+
+    global_search::begin(&mut app);
+
+    assert_eq!(
+        app.global_search.query, "hello",
+        "leading blank row must be skipped, indent must be trimmed",
+    );
+}
+
+#[test]
+fn begin_with_seed_equal_to_existing_query_keeps_excluded_set() {
+    // The user has a search active with a per-match opt-out; they then
+    // re-trigger Space+F with the same text selected. Re-arming the
+    // search would clear `excluded` and re-show the deselected hit.
+    // Guard: `begin()` skips `mark_query_edited` when the seed matches.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    app.global_search.query = "bar".to_string();
+    app.global_search
+        .excluded
+        .insert((PathBuf::from("a.rs"), 1));
+    install_text_preview(&mut app, &["bar"]);
+    select_byte_range(&mut app, (0, 0), (0, 3));
+
+    global_search::begin(&mut app);
+
+    assert_eq!(app.global_search.query, "bar");
+    assert!(
+        !app.global_search.excluded.is_empty(),
+        "no-op seed must not wipe per-match opt-outs",
+    );
+}
+
+#[test]
+fn begin_with_empty_selection_keeps_existing_query() {
+    // A `PreviewSelection` exists but is collapsed (anchor == active).
+    // That's the "click but don't drag" state — there's no text to
+    // seed with, so the existing query stays.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    app.global_search.query = "kept".to_string();
+    install_text_preview(&mut app, &["foo bar"]);
+    select_byte_range(&mut app, (0, 2), (0, 2));
+
+    global_search::begin(&mut app);
+
+    assert_eq!(app.global_search.query, "kept");
+}


### PR DESCRIPTION
## Summary

Two paper-cuts on the Space+F flow:

- **Selection-seeded query.** Opening the palette no longer keeps whatever you last typed — it reads any active text selection (file preview on Files/Search tabs, diff selection on Git/Graph), takes the first non-empty trimmed line, and pre-fills the query. Equivalent of VSCode's "Find with Selection."
- **Bracketed paste in the overlay and Search tab.** The previous paste dispatch only knew about quick-open and the in-file find prompt. Pasting now lands in `query` (overlay or FindInput) or `replace_text` (ReplaceInput), newline-stripped same as the other paste sites.

Plus a small efficiency clean-up that fell out of unifying the three paste handlers.

## Changes

- `src/global_search.rs` — `begin()` seeds query from `current_text_selection(app)`; multi-line selections collapse to the first non-empty trimmed line. Skips `mark_query_edited` when the seed equals the existing query so Space+F on already-pinned text doesn't wipe the replace-mode `excluded` set.
- `src/global_search.rs` — new `handle_paste_overlay` / `handle_paste_search_tab` taking `&mut GlobalSearchState`. The Search-tab variant routes by `focus`: FindInput → query (with rerun), ReplaceInput → replace_text (no rerun), List → no-op.
- `src/input.rs` — `handle_paste` adds two arms after the existing quick-open / search-prompt arms.
- `src/input_edit.rs` — new `paste_single_line(s, &mut text, &mut cursor) -> bool` shared by all three paste sites. Implementation switched from per-char `String::insert` (O(N·L) memmoves) to a single `insert_str` of a pre-filtered string (O(N+L)). Matters because bracketed-paste payloads can be MB-scale.
- `src/quick_open.rs`, `src/search.rs` — consume the shared helper, deleting their hand-rolled per-char loops.

## Tests

- `src/input_edit.rs::mod tests` — 4 new tests pinning `paste_single_line`'s contract (insert + advance, CRLF stripping, no-op on empty / pure-newline input, UTF-8 boundary).
- `src/global_search.rs::mod tests` — 8 new tests on `first_nonempty_trimmed_line`, `handle_paste_overlay`, and `handle_paste_search_tab` (focus routing, side-effect gating, no leakage to unrelated state).
- `tests/global_search_seed.rs` — 5 integration tests on the `begin()` seeding contract: no-selection preserves query, preview selection seeds the query, multi-row selection collapses to first non-empty trimmed line, equal seed preserves `excluded`, empty (collapsed) selection is a no-op.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` (533 passed, +13 over baseline)
- [x] `cargo test --test global_search_seed --test global_search_integration --test space_leader_input --test ui_snapshots` (36 passed)
- [ ] Manual smoke: select text in file preview → Space+F → query pre-filled, results show
- [ ] Manual smoke: open Space+F overlay → ⌘V → pasted text appears in query, search runs
- [ ] Manual smoke: Tab::Search FindInput focused → ⌘V → paste lands in find query; ReplaceInput → paste lands in replace text
- [ ] Manual smoke: drag across multiple lines → Space+F → first non-empty trimmed line appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)