### PR TITLE
fix(git): keep unstaged selection when file also has staged changes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3702,13 +3702,20 @@ impl App {
                             let in_staged = self.staged_files.iter().any(|f| f.path == sel.path);
                             let in_unstaged =
                                 self.unstaged_files.iter().any(|f| f.path == sel.path);
-                            if in_staged {
-                                sel.is_staged = true;
-                            } else if in_unstaged {
-                                sel.is_staged = false;
-                            } else {
-                                self.selected_file = None;
-                                self.diff_content = None;
+                            // Preserve the user's staged/unstaged choice when the file
+                            // exists in both sections — flipping it would swap the diff
+                            // out from under them right after they clicked.
+                            let still_in_current =
+                                if sel.is_staged { in_staged } else { in_unstaged };
+                            if !still_in_current {
+                                if in_staged {
+                                    sel.is_staged = true;
+                                } else if in_unstaged {
+                                    sel.is_staged = false;
+                                } else {
+                                    self.selected_file = None;
+                                    self.diff_content = None;
+                                }
                             }
                         }
                         if before != self.selected_file {

--- a/src/app.rs
+++ b/src/app.rs
@@ -3705,8 +3705,11 @@ impl App {
                             // Preserve the user's staged/unstaged choice when the file
                             // exists in both sections — flipping it would swap the diff
                             // out from under them right after they clicked.
-                            let still_in_current =
-                                if sel.is_staged { in_staged } else { in_unstaged };
+                            let still_in_current = if sel.is_staged {
+                                in_staged
+                            } else {
+                                in_unstaged
+                            };
                             if !still_in_current {
                                 if in_staged {
                                     sel.is_staged = true;


### PR DESCRIPTION
## Summary
- When a file had both staged and unstaged changes, clicking the unstaged entry briefly showed the unstaged diff and then snapped to the staged one.
- The `GitStatus` refresh handler looked up the current selection by path only and unconditionally set `is_staged = true` if the staged list contained that path, then re-loaded the diff with the wrong side.
- Preserve the user's chosen side on refresh; only fall back to the other section when the current side no longer contains the file.

## Test plan
- [ ] Modify a tracked file, stage it, then modify it again so it appears under both **Staged** and **Unstaged**
- [ ] Click the unstaged entry — the unstaged diff stays put (no flip to staged) across the next status refresh / fs-watcher tick
- [ ] Click the staged entry — staged diff stays put
- [ ] Fully stage/unstage the file and confirm selection follows correctly (falls back to the remaining side, clears when the file leaves both sections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)