### PR TITLE
feat(ui): clickable settings button in status bar

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4149,6 +4149,9 @@ impl App {
             ClickAction::ToggleSidebar => {
                 self.toggle_sidebar();
             }
+            ClickAction::OpenSettings => {
+                self.open_settings();
+            }
             ClickAction::TreeClick(index) => {
                 self.file_tree.selected = index;
                 if let Some(entry) = self.file_tree.entries.get(index) {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -480,7 +480,7 @@ fn render_title_bar(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(title, area);
 }
 
-fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
+fn render_status_bar(f: &mut Frame, app: &mut App, area: Rect) {
     let th = app.theme;
 
     // Search prompt has the highest priority — while active it fully owns the
@@ -685,17 +685,39 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
     let chip_w = UnicodeWidthStr::width(chip.as_str()) as u16;
     let notif_w = UnicodeWidthStr::width(notif.as_str()) as u16;
 
+    // Mouse-only settings entry — Ctrl+, fallback for terminals that
+    // swallow the chord. Glyph mirrors `SettingsTitle` so the icon is
+    // visually self-explanatory.
+    let settings_btn = " ⚙ ";
+    let settings_btn_w = UnicodeWidthStr::width(settings_btn) as u16;
+
     let pad_w = area
         .width
         .saturating_sub(notif_w)
+        .saturating_sub(settings_btn_w)
         .saturating_sub(hint_w)
         .saturating_sub(chip_w);
+
+    let settings_btn_x = area.x + notif_w + pad_w;
+    app.hit_registry.register_row(
+        settings_btn_x,
+        area.y,
+        settings_btn_w,
+        ClickAction::OpenSettings,
+    );
 
     let status = Line::from(vec![
         Span::styled(notif, Style::default().fg(notif_color).bg(th.chrome_bg)),
         Span::styled(
             " ".repeat(pad_w as usize),
             Style::default().bg(th.chrome_bg),
+        ),
+        Span::styled(
+            settings_btn,
+            Style::default()
+                .fg(th.chrome_muted_fg)
+                .bg(th.chrome_bg)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             hint_text,

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -18,6 +18,10 @@ pub enum ClickAction {
     StartDragGraphDiffSplit,
     /// 标签栏右侧的侧边栏可见性切换按钮。等价于 Ctrl+B,但鼠标可点。
     ToggleSidebar,
+    /// 状态栏右侧的设置按钮。等价于 Ctrl+,,给找不到快捷键
+    /// 或终端吞掉 Ctrl+, 的用户兜底。仅在常规状态栏分支注册,
+    /// 各类模态接管(搜索/select/place/paste-conflict 等)期间不出现。
+    OpenSettings,
     SwitchTab(Tab),
     TreeClick(usize),
     /// Click on a row in the quick-open palette. The `usize` indexes

--- a/tests/snapshots/ui_snapshots__binary_info_pdf.snap
+++ b/tests/snapshots/ui_snapshots__binary_info_pdf.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 579
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -22,4 +21,4 @@ expression: output
                        │
                        │
                        │
-                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__empty_repo.snap
+++ b/tests/snapshots/ui_snapshots__empty_repo.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 104
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -22,4 +21,4 @@ expression: output
                        │
                        │
                        │
-                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__hosts_picker_empty.snap
+++ b/tests/snapshots/ui_snapshots__hosts_picker_empty.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 338
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -22,4 +21,4 @@ expression: output
       │   Enter connect · Ctrl+P path mode · Esc cancel                  │
       └──────────────────────────────────────────────────────────────────┘
                        │
-                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__hosts_picker_path_mode.snap
+++ b/tests/snapshots/ui_snapshots__hosts_picker_path_mode.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 417
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -22,4 +21,4 @@ expression: output
       │   Enter connect · Esc back to filter                             │
       └──────────────────────────────────────────────────────────────────┘
                        │
-                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__hosts_picker_populated.snap
+++ b/tests/snapshots/ui_snapshots__hosts_picker_populated.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 385
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -22,4 +21,4 @@ expression: output
       │   Enter connect · Ctrl+P path mode · Esc cancel                  │
       └──────────────────────────────────────────────────────────────────┘
                        │
-                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__image_preview_halfblocks.snap
+++ b/tests/snapshots/ui_snapshots__image_preview_halfblocks.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 540
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -22,4 +21,4 @@ expression: output
                        │
                        │
                        │
-                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__search_tab_replace_open_with_excluded_row.snap
+++ b/tests/snapshots/ui_snapshots__search_tab_replace_open_with_excluded_row.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 631
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
@@ -18,4 +17,4 @@ expression: output
 │                            │
 │1 / 2 · 1 to replace ·  Apply
 └────────────────────────────┘
-                                     q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Search]
+                                  ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Search]

--- a/tests/snapshots/ui_snapshots__tree_context_menu.snap
+++ b/tests/snapshots/ui_snapshots__tree_context_menu.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 251
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
@@ -22,4 +21,4 @@ expression: output
     │  Reveal in Finder    │
     └──────────────────────┘
                        │
-                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__tree_edit_row_new_file.snap
+++ b/tests/snapshots/ui_snapshots__tree_edit_row_new_file.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 214
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
@@ -22,4 +21,4 @@ expression: output
                        │
                        │
                        │
-                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__with_staged_and_unstaged.snap
+++ b/tests/snapshots/ui_snapshots__with_staged_and_unstaged.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 126
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
@@ -22,4 +21,4 @@ expression: output
                        │
                        │
                        │
-                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__with_staged_and_unstaged_light.snap
+++ b/tests/snapshots/ui_snapshots__with_staged_and_unstaged_light.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 444
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
@@ -22,4 +21,4 @@ expression: output
                        │
                        │
                        │
-                  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]


### PR DESCRIPTION
## Summary
- Some terminals swallow `Ctrl+,`, and new users don't always know the chord exists — there was no mouse path into Settings other than the `?` help page.
- Adds a `⚙` glyph to the right side of the status bar (just before the panel chip). Clicking it dispatches `ClickAction::OpenSettings`, which routes through the same `App::open_settings()` that `Ctrl+,` uses (so the idempotent guard and pref-cache refresh both still apply).
- Only registered on the regular status-bar branch. Modal takeovers (search prompt, SELECT/PLACE modes, paste-conflict, tree-delete confirm, graph visual mode) keep their original chrome — those branches all `return` before reaching the new code.
- Keyboard focus is **not** wired up by design — the button is a mouse-only fallback. `Ctrl+,` and `? → Open settings page` remain the keyboard entries.

## Test plan
- [ ] Launch reef in a normal state and click the `⚙` at the bottom-right — settings page opens
- [ ] Re-click does nothing surprising (settings already open; `open_settings()` is idempotent)
- [ ] `Ctrl+,` still works and lands on the same page
- [ ] Trigger a status-bar takeover (e.g. `/search`, SELECT mode `v`, PLACE mode) — `⚙` is hidden and clicking that area does NOT open settings
- [ ] Resize the terminal narrow enough that the right side gets tight — button either renders cleanly or drops out; no garbled chrome
- [ ] Hover/click does not interfere with the `[Panel]` chip immediately to its right

🤖 Generated with [Claude Code](https://claude.com/claude-code)