### PR TITLE
refactor: remove `v` select-mode toggle

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -684,7 +684,6 @@ pub struct App {
 
     // Control
     pub should_quit: bool,
-    pub select_mode: bool,
     pub show_help: bool,
 
     /// Set by the input layer when the user asks to edit a file. Consumed
@@ -1053,7 +1052,6 @@ impl App {
             commit_rx: None,
             fs_watcher_rx,
             should_quit: false,
-            select_mode: false,
             show_help: false,
             pending_edit: None,
             theme,
@@ -1292,23 +1290,12 @@ impl App {
     /// `input::handle_paste` when a paste payload resolves to existing
     /// on-disk paths.
     ///
-    /// Refuses the transition in two situations that would otherwise
-    /// leave the user stranded:
-    ///
-    /// - `select_mode` is active — mouse capture is off in that mode,
-    ///   so the user would have no way to click a drop target. The
-    ///   toast points them at the `v` escape hatch.
-    /// - a place-mode copy is already in flight — overwriting
-    ///   `sources` would invalidate the worker's generation and the
-    ///   previous copy's completion result (including the success
-    ///   toast and tree refresh) would be silently dropped.
+    /// Refuses the transition when a place-mode copy is already in
+    /// flight — overwriting `sources` would invalidate the worker's
+    /// generation and the previous copy's completion result (including
+    /// the success toast and tree refresh) would be silently dropped.
     pub fn enter_place_mode(&mut self, sources: Vec<PathBuf>) {
         if sources.is_empty() {
-            return;
-        }
-        if self.select_mode {
-            self.toasts
-                .push(Toast::warn(crate::i18n::place_mode_blocked_by_select_mode()));
             return;
         }
         if self.file_copy_load.loading {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -61,16 +61,8 @@ pub(crate) fn resolve_editor() -> Option<(String, Vec<String>)> {
 }
 
 /// Suspend the TUI, run the user's editor on `path`, then restore the TUI.
-///
-/// `mouse_capture_was_on` tells us whether to re-enable mouse capture on
-/// resume — the caller tracks this because `v` (select mode) may have
-/// disabled it before the user triggered the edit.
 #[allow(dead_code)]
-pub fn launch<B: Backend>(
-    terminal: &mut Terminal<B>,
-    path: &Path,
-    mouse_capture_was_on: bool,
-) -> io::Result<()> {
+pub fn launch<B: Backend>(terminal: &mut Terminal<B>, path: &Path) -> io::Result<()> {
     let (prog, extra_args) = resolve_editor().ok_or_else(|| {
         io::Error::new(io::ErrorKind::NotFound, "no editor set (VISUAL / EDITOR)")
     })?;
@@ -90,10 +82,7 @@ pub fn launch<B: Backend>(
     // mode on the regular buffer — unusable.
     let restore = (|| -> io::Result<()> {
         enable_raw_mode()?;
-        execute!(stdout, EnterAlternateScreen)?;
-        if mouse_capture_was_on {
-            execute!(stdout, EnableMouseCapture)?;
-        }
+        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
         // `B::Error` isn't guaranteed to convert to io::Error without a
         // bound; stringify it so this stays generic over backends.
         terminal
@@ -121,7 +110,6 @@ pub fn launch<B: Backend>(
 pub fn launch_spec<B: Backend>(
     terminal: &mut Terminal<B>,
     spec: &EditorLaunchSpec,
-    mouse_capture_was_on: bool,
 ) -> io::Result<()> {
     disable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -131,10 +119,7 @@ pub fn launch_spec<B: Backend>(
 
     let restore = (|| -> io::Result<()> {
         enable_raw_mode()?;
-        execute!(stdout, EnterAlternateScreen)?;
-        if mouse_capture_was_on {
-            execute!(stdout, EnableMouseCapture)?;
-        }
+        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
         terminal
             .clear()
             .map_err(|e| io::Error::other(format!("{e:?}")))?;

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -53,7 +53,6 @@ pub enum Msg {
 
     // Chrome
     StatusBarHint,
-    SelectModeHint,
     HelpTitle,
 
     // No-repo panel
@@ -202,7 +201,6 @@ pub enum Msg {
     HelpDiffMode,
     HelpToggleView,
     HelpRefresh,
-    HelpSelectMode,
     HelpShowHelp,
     HelpQuickOpen,
     HelpGlobalSearch,
@@ -282,7 +280,6 @@ fn t_zh(m: Msg) -> &'static str {
         TabGraph => " ⑂ 图表 ",
         TabBarHint => " 1:文件 2:搜索 3:Git 4:图表",
         StatusBarHint => " q:退出 Tab:切换 s:暂存 u:取消 r:刷新 h:帮助 ",
-        SelectModeHint => "  拖拽鼠标选择文字，按 v 退出选择模式",
         HelpTitle => " 快捷键帮助 ",
         NoRepoTitle => "不在 git 仓库中",
         NoRepoHint => "运行 `git init` 初始化，或在 git 仓库里打开 reef。",
@@ -388,7 +385,6 @@ fn t_zh(m: Msg) -> &'static str {
         HelpDiffMode => "切换 Diff 模式（局部 ↔ 全量）",
         HelpToggleView => "切换列表 / 树形视图",
         HelpRefresh => "刷新",
-        HelpSelectMode => "文字选择模式",
         HelpShowHelp => "显示 / 关闭此帮助",
         HelpQuickOpen => "打开 / 关闭快速打开浮层（全局模糊搜索）",
         HelpGlobalSearch => "打开全局内容搜索浮层",
@@ -454,7 +450,6 @@ fn t_en(m: Msg) -> &'static str {
         TabGraph => " ⑂ Graph ",
         TabBarHint => " 1:Files 2:Search 3:Git 4:Graph",
         StatusBarHint => " q:quit Tab:switch s:stage u:unstage r:refresh h:help ",
-        SelectModeHint => "  Drag to select text, press v to exit select mode",
         HelpTitle => " Keybindings ",
         NoRepoTitle => "Not a git repository",
         NoRepoHint => "Run `git init` to initialise one, or open reef inside a git repo.",
@@ -560,7 +555,6 @@ fn t_en(m: Msg) -> &'static str {
         HelpDiffMode => "Toggle diff mode (compact ↔ full)",
         HelpToggleView => "Toggle list / tree view",
         HelpRefresh => "Refresh",
-        HelpSelectMode => "Text selection mode",
         HelpShowHelp => "Show / close this help",
         HelpQuickOpen => "Toggle quick-open palette (global fuzzy search)",
         HelpGlobalSearch => "Open global content-search palette",
@@ -787,16 +781,6 @@ pub fn place_mode_copy_failed(e: &str) -> String {
     match lang() {
         Lang::Zh => format!("复制失败: {e}"),
         Lang::En => format!("Copy failed: {e}"),
-    }
-}
-
-/// Warning when a drop arrives while the user is in select-mode. Mouse
-/// capture is off in that state, so entering place mode would leave
-/// the user with no way to click a target.
-pub fn place_mode_blocked_by_select_mode() -> String {
-    match lang() {
-        Lang::Zh => "拖拽被选择模式拦住了：按 v 退出选择模式后再试".to_string(),
-        Lang::En => "Drop blocked by select mode — press v to exit, then retry".to_string(),
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -2,11 +2,9 @@
 //! event-drain loop to `handle_key` and `handle_mouse` here, so the binary
 //! entry point stays focused on terminal bootstrap.
 //!
-//! The one exception is the `v` (select mode toggle) and `show_help`
-//! dismiss — those stay inline in `main.rs` because the first needs
-//! `execute!(terminal.backend_mut(), ...)` to flip crossterm's mouse
-//! capture mode, and both are simple enough that splitting them out would
-//! just add indirection.
+//! The one exception is the `show_help` dismiss, which stays inline in
+//! `main.rs` because it's simple enough that splitting it out would just
+//! add indirection.
 
 use crate::app::{App, DbNav, Panel, Tab, ViewMode};
 use crate::clipboard;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use crossterm::{
     event::{
         self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-        Event, KeyCode, KeyEventKind, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
+        Event, KeyEventKind, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
         PushKeyboardEnhancementFlags,
     },
     execute,
@@ -305,30 +305,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             continue;
                         }
 
-                        // `v` toggles select mode, which flips crossterm's mouse capture
-                        // so the terminal's native text-selection works. Kept inline
-                        // because it's the only input that needs to poke the terminal
-                        // backend mid-loop.
-                        //
-                        // When any palette (quick-open or global-search) is active,
-                        // or while the full-screen Settings page is up, it owns every
-                        // key unconditionally — 'v' must land as a literal in the
-                        // query / editor.command buffer, and 'any key' must not
-                        // dismiss help — so route to handle_key first and let it
-                        // delegate to the page.
+                        // Palettes (quick-open / global-search / hosts-picker) and
+                        // the full-screen Settings page own every key unconditionally —
+                        // 'any key' must not dismiss help while one of them is up — so
+                        // route to handle_key first and let it delegate to the page.
                         if app.quick_open.active
                             || app.global_search.active
                             || app.hosts_picker.active
                             || app.view_mode == ViewMode::Settings
                         {
                             input::handle_key(key, &mut app);
-                        } else if key.code == KeyCode::Char('v') && key.modifiers.is_empty() {
-                            app.select_mode = !app.select_mode;
-                            if app.select_mode {
-                                execute!(terminal.backend_mut(), DisableMouseCapture)?;
-                            } else {
-                                execute!(terminal.backend_mut(), EnableMouseCapture)?;
-                            }
                         } else if app.show_help {
                             app.show_help = false;
                         } else {
@@ -336,9 +322,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         }
                     }
                     Event::Mouse(mouse) => {
-                        if !app.select_mode {
-                            input::handle_mouse(mouse, &mut app, &terminal);
-                        }
+                        input::handle_mouse(mouse, &mut app, &terminal);
                     }
                     Event::Paste(s) => {
                         input::handle_paste(s, &mut app);
@@ -363,10 +347,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             // Handle an edit request *after* event drain so the terminal is
             // idle. Suspends the TUI, runs `$EDITOR` (or `ssh -t host
-            // $EDITOR rel` for remote), resumes. Mouse capture tracks
-            // `select_mode` — off in select mode, on otherwise.
+            // $EDITOR rel` for remote), resumes.
             if let Some(path) = app.pending_edit.take() {
-                let mouse_was_on = !app.select_mode;
                 // Convert an absolute path (input.rs synthesises
                 // `file_tree.root.join(entry.path)`) back to a workdir-
                 // relative form so the backend's remote variant can ship the
@@ -379,7 +361,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .unwrap_or_else(|_| path.clone());
                 match app.backend.editor_launch_spec(&rel_for_spec) {
                     Ok(spec) => {
-                        if let Err(e) = editor::launch_spec(&mut terminal, &spec, mouse_was_on) {
+                        if let Err(e) = editor::launch_spec(&mut terminal, &spec) {
                             app.toasts
                                 .push(Toast::error(i18n::edit_open_failed(&e.to_string())));
                         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -498,29 +498,11 @@ fn render_status_bar(f: &mut Frame, app: &mut App, area: Rect) {
         return;
     }
 
-    if app.select_mode {
-        let hint = Line::from(vec![
-            Span::styled(
-                " SELECT ",
-                Style::default()
-                    .fg(Color::Black)
-                    .bg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                t(Msg::SelectModeHint),
-                Style::default().fg(Color::Yellow).bg(th.chrome_bg),
-            ),
-        ]);
-        f.render_widget(hint, area);
-        return;
-    }
-
-    // Place-mode modal indicator. Mirrors the select-mode pattern: a loud
-    // badge in the accent color so the user can't miss that a mode is
-    // active, plus a hint describing how to commit or cancel. When a
-    // copy is actively running the hint swaps to a copying indicator so
-    // the status bar proves the worker is still alive on big transfers.
+    // Place-mode modal indicator: a loud badge in the accent color so the
+    // user can't miss that a mode is active, plus a hint describing how
+    // to commit or cancel. When a copy is actively running the hint
+    // swaps to a copying indicator so the status bar proves the worker
+    // is still alive on big transfers.
     if app.place_mode.active {
         let copying = app.file_copy_load.loading;
         let (badge_text, hint_text) = if copying {
@@ -861,7 +843,6 @@ fn render_help(f: &mut Frame, app: &App, screen: Rect) {
         ("f", t(Msg::HelpDiffMode)),
         ("t", t(Msg::HelpToggleView)),
         ("r", t(Msg::HelpRefresh)),
-        ("v", t(Msg::HelpSelectMode)),
         ("h", t(Msg::HelpShowHelp)),
         ("Ctrl+B", t(Msg::HelpToggleSidebar)),
         ("Ctrl+,", t(Msg::HelpOpenSettings)),

--- a/tests/settings_input.rs
+++ b/tests/settings_input.rs
@@ -111,20 +111,3 @@ fn esc_in_inline_editor_cancels_without_writing_prefs() {
     input::handle_key(esc(), &mut app);
     assert_eq!(app.view_mode, ViewMode::Main);
 }
-
-/// Regression: bare `v` is intercepted in `main.rs` as the select-mode
-/// toggle. The Settings page must override that interception so `v`
-/// reaches the inline editor as a literal char.
-#[test]
-fn typing_v_in_inline_editor_inserts_literal() {
-    let (_lock, _h, _g, _home, _cwd, mut app) = isolated_app();
-    input::handle_key(ctrl_comma(), &mut app);
-    app.settings.select(editor_command_idx());
-    input::handle_key(enter(), &mut app);
-
-    for c in "nvim".chars() {
-        input::handle_key(char_key(c), &mut app);
-    }
-    let edit = app.settings.editor_edit.as_ref().unwrap();
-    assert_eq!(edit.buffer, "nvim");
-}


### PR DESCRIPTION
## Summary
- Deletes the `v` keybinding that toggled crossterm mouse capture for native text selection, plus the `App::select_mode` state, SELECT status-bar badge, help-dialog entry, and i18n strings (`SelectModeHint` / `HelpSelectMode`).
- Drops the `enter_place_mode` guard / toast that pointed users at the `v` escape hatch (`place_mode_blocked_by_select_mode`).
- Simplifies `editor::launch` / `editor::launch_spec`: with no select-mode, mouse capture is always re-enabled on resume, so the `mouse_capture_was_on` parameter is gone.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --test settings_input`
- [ ] Manual: open reef, confirm `v` no longer enters a special mode and just routes through normal input

🤖 Generated with [Claude Code](https://claude.com/claude-code)