### PR TITLE
feat(ui): centered confirm modal with mouse-clickable buttons

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,7 @@ use crate::file_tree::{FileTree, PreviewBody, PreviewContent};
 use crate::git::graph::GraphRow;
 use crate::git::{CommitDetail, CommitInfo, DiffContent, FileEntry, GitRepo, RefLabel};
 use crate::tasks::{AsyncState, TaskCoordinator, WorkerResult};
+use crate::ui::confirm_modal::ConfirmModal;
 use crate::ui::highlight::StyledToken;
 use crate::ui::mouse::{ClickAction, HitTestRegistry};
 use crate::ui::theme::Theme;
@@ -745,10 +746,10 @@ pub struct App {
     /// full input ownership while visible.
     pub tree_context_menu: crate::tree_context_menu::ContextMenuState,
 
-    /// Pending Move-to-Trash / Hard-Delete confirmation. The status
-    /// bar takes over with `⚠ Delete foo? (y / Esc)` while this is
-    /// `Some`. Cleared on confirm or cancel.
-    pub tree_delete_confirm: Option<TreeDeletePending>,
+    /// Generic centered yes/no confirm modal. Owns mouse + keyboard
+    /// input while `Some`. Built by callers via `App::show_confirm` —
+    /// see e.g. `prompt_tree_delete` for the delete-file consumer.
+    pub confirm_modal: Option<ConfirmModal>,
 
     /// VS Code-style internal file clipboard. Holds the paths and the
     /// move-vs-copy intent set by the latest `Cut` / `Copy`. Consumed
@@ -829,15 +830,19 @@ pub struct App {
     next_graph_revalidate_at: Instant,
 }
 
-/// What the user is about to delete once they confirm the status-bar
-/// prompt. `hard` distinguishes Shift+Delete (permanent) from the
-/// default Delete (Trash).
+/// What the user is about to delete once they confirm. Passed by value
+/// through the modal's `on_confirm` closure rather than stored on
+/// `App` directly — keeping it module-private and out of the App struct
+/// avoids a second source of truth for "is a delete pending" alongside
+/// `confirm_modal`. The Clone bound lets `execute_tree_delete` re-open
+/// the modal with the same payload when it has to back off ("operation
+/// still running" toast).
 #[derive(Debug, Clone)]
-pub struct TreeDeletePending {
-    pub path: PathBuf,
-    pub display_name: String,
-    pub is_dir: bool,
-    pub hard: bool,
+struct TreeDeletePending {
+    path: PathBuf,
+    display_name: String,
+    is_dir: bool,
+    hard: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1065,7 +1070,7 @@ impl App {
             place_mode: crate::place_mode::PlaceModeState::default(),
             tree_edit: crate::tree_edit::TreeEditState::default(),
             tree_context_menu: crate::tree_context_menu::ContextMenuState::default(),
-            tree_delete_confirm: None,
+            confirm_modal: None,
             file_clipboard: crate::file_clipboard::FileClipboard::default(),
             file_selection: crate::file_selection::SelectionSet::default(),
             tree_drag: crate::tree_drag::TreeDragState::default(),
@@ -1322,7 +1327,7 @@ impl App {
         // have a pending delete confirm taking over the status bar.
         self.tree_edit.clear();
         self.tree_context_menu.close();
-        self.tree_delete_confirm = None;
+        self.dismiss_confirm();
         self.set_active_tab(Tab::Files);
         self.place_mode.active = true;
         self.place_mode.sources = sources;
@@ -1901,7 +1906,7 @@ impl App {
         }
         // Close competing modals so tree-edit owns the screen.
         self.tree_context_menu.close();
-        self.tree_delete_confirm = None;
+        self.dismiss_confirm();
         self.exit_place_mode();
         self.set_active_tab(Tab::Files);
 
@@ -2273,43 +2278,57 @@ impl App {
         }
     }
 
-    /// Pop the status-bar delete-confirm prompt. `hard` controls
-    /// Trash vs. `fs::remove_*`; the prompt text adjusts accordingly.
+    /// Pop the centered delete-confirm modal. `hard` controls Trash
+    /// vs. `fs::remove_*`; the primary-button label adjusts accordingly,
+    /// while the title is a generic "Confirm" framing (the tone +
+    /// button color carry the severity cue, not the title text).
+    /// The `on_confirm` closure captures the path/is_dir/hard tuple so
+    /// the modal doesn't need a side-channel struct on `App`.
     pub fn prompt_tree_delete(&mut self, path: PathBuf, is_dir: bool, hard: bool) {
+        use crate::ui::confirm_modal::{ConfirmModal, ModalTone};
         let display_name = path
             .file_name()
             .and_then(|n| n.to_str())
             .map(crate::tree_edit::sanitize_filename)
             .unwrap_or_else(|| path.to_string_lossy().to_string());
         self.tree_context_menu.close();
-        self.tree_delete_confirm = Some(TreeDeletePending {
+        let body = crate::i18n::tree_delete_body(&display_name, is_dir, hard);
+        let primary_label = if hard {
+            crate::i18n::confirm_delete_label()
+        } else {
+            crate::i18n::confirm_trash_label()
+        };
+        let pending = TreeDeletePending {
             path,
             display_name,
             is_dir,
             hard,
+        };
+        self.show_confirm(ConfirmModal {
+            title: crate::i18n::confirm_destructive_title(),
+            tone: ModalTone::Danger,
+            body,
+            primary_label,
+            cancel_label: crate::i18n::confirm_cancel_label(),
+            confirm_keys: vec!['y', 'Y'],
+            on_confirm: Box::new(move |app| app.execute_tree_delete(pending)),
+            on_cancel: Box::new(|_| {}),
         });
     }
 
-    /// User pressed Y on the delete confirm. Dispatches the matching
-    /// worker task and clears the prompt.
-    pub fn confirm_tree_delete(&mut self) {
-        // Same generation-bump race as commit_tree_edit: a previous
-        // trash/hard-delete might still be running. Keep the confirm
-        // in place (don't `.take()`) so the user's Y press isn't
-        // lost — they can retry when the prior op completes.
+    /// Run the actual delete after the user confirmed. If a previous
+    /// fs mutation is still in flight, re-open the modal with the same
+    /// pending so the user can retry once the worker drains (matches
+    /// the original `confirm_tree_delete` retry semantics — Y wasn't
+    /// silently lost).
+    fn execute_tree_delete(&mut self, pending: TreeDeletePending) {
         if self.fs_mutation_load.loading {
             self.toasts
                 .push(Toast::warn(crate::i18n::tree_op_blocked_by_in_flight()));
+            self.prompt_tree_delete(pending.path, pending.is_dir, pending.hard);
             return;
         }
-        let Some(pending) = self.tree_delete_confirm.take() else {
-            return;
-        };
         let generation = self.fs_mutation_load.begin();
-        // Convert the (absolute) selection path to a workdir-relative
-        // PathBuf for the Backend call. The UI still stores `abs` because
-        // it came from `file_tree.root.join(entry.path)` — the display
-        // name is derived before we lose the absolute form.
         let first_name = pending.display_name.clone();
         let rel = pending
             .path
@@ -2329,8 +2348,43 @@ impl App {
         }
     }
 
-    pub fn cancel_tree_delete(&mut self) {
-        self.tree_delete_confirm = None;
+    // ── Confirm modal (generic yes/no overlay) ───────────────────────────
+
+    /// Show the centered `ConfirmModal`. If another modal is already
+    /// up, its `on_cancel` fires first so the caller can rely on
+    /// "every modal that opens eventually resolves via one of its
+    /// callbacks". Without this, opening modal B over modal A would
+    /// silently drop A's cancel closure — a leak for any caller that
+    /// uses cancel for cleanup.
+    pub fn show_confirm(&mut self, modal: ConfirmModal) {
+        if self.confirm_modal.is_some() {
+            self.fire_confirm_cancel();
+        }
+        self.confirm_modal = Some(modal);
+    }
+
+    /// Force-close the modal without firing any callback. Used by
+    /// "competing modal opens" paths (place mode, tree edit, tab
+    /// switch) and by successful/failed mutation completion.
+    pub fn dismiss_confirm(&mut self) {
+        self.confirm_modal = None;
+    }
+
+    /// Fire the primary callback. The modal is `take`n first so the
+    /// closure receives a clean `&mut App` (the closure may e.g.
+    /// `show_confirm` again to retry).
+    pub fn fire_confirm_primary(&mut self) {
+        if let Some(modal) = self.confirm_modal.take() {
+            (modal.on_confirm)(self);
+        }
+    }
+
+    /// Fire the cancel callback. Same `take`-first contract as
+    /// `fire_confirm_primary`.
+    pub fn fire_confirm_cancel(&mut self) {
+        if let Some(modal) = self.confirm_modal.take() {
+            (modal.on_cancel)(self);
+        }
     }
 
     // ── Hosts picker (Ctrl+O) ────────────────────────────────────────────
@@ -2688,7 +2742,7 @@ impl App {
         if self.place_mode.active
             || self.tree_edit.active
             || self.tree_context_menu.active
-            || self.tree_delete_confirm.is_some()
+            || self.confirm_modal.is_some()
         {
             return;
         }
@@ -3931,7 +3985,7 @@ impl App {
                         // tree rebuild runs so the renderer doesn't briefly
                         // show a stale cursor on a row that's about to move.
                         self.tree_edit.clear();
-                        self.tree_delete_confirm = None;
+                        self.dismiss_confirm();
                         // Select the newly-created / renamed entry if we
                         // stashed one on dispatch. Delete paths leave
                         // `fs_mutation_select_on_done` as `None` so the
@@ -3955,7 +4009,7 @@ impl App {
                         // fix the buffer and retry. Same as the drag-drop
                         // path: clear stale/error flags so activity_message
                         // doesn't double-surface the toast after it fades.
-                        self.tree_delete_confirm = None;
+                        self.dismiss_confirm();
                         // Drop the pending auto-select — the target path
                         // was never created / renamed, so trying to focus
                         // it would be a stale lookup at best.
@@ -4064,7 +4118,7 @@ impl App {
         if was_files {
             self.tree_edit.clear();
             self.tree_context_menu.close();
-            self.tree_delete_confirm = None;
+            self.dismiss_confirm();
         }
         // Preview selection is scoped to the Files/Search tabs that render
         // the preview panel. Switching away clears it so no stale highlight
@@ -4328,6 +4382,12 @@ impl App {
                 if self.view_mode == ViewMode::Settings {
                     self.settings.select(idx);
                 }
+            }
+            ClickAction::ConfirmModalPrimary => {
+                self.fire_confirm_primary();
+            }
+            ClickAction::ConfirmModalCancel => {
+                self.fire_confirm_cancel();
             }
         }
     }
@@ -4952,5 +5012,182 @@ mod tests {
         assert_eq!(g + c + d, 200);
         assert_eq!(d, 120);
         assert_eq!(c, 80);
+    }
+
+    // ── ConfirmModal lifecycle ───────────────────────────────────────────
+
+    use crate::ui::confirm_modal::{ConfirmModal, ModalTone};
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    /// Build a barebones `ConfirmModal` whose two callbacks each tick a
+    /// shared counter so the test can assert which one fired (and how
+    /// many times). `confirm_keys` is empty — the tests drive the modal
+    /// through the public `App::fire_*` entry points directly, not via
+    /// keyboard.
+    fn modal_with_counters(primary: Rc<Cell<u32>>, cancel: Rc<Cell<u32>>) -> ConfirmModal {
+        ConfirmModal {
+            title: "t".into(),
+            tone: ModalTone::Danger,
+            body: "b".into(),
+            primary_label: "P".into(),
+            cancel_label: "C".into(),
+            confirm_keys: vec![],
+            on_confirm: Box::new(move |_app| primary.set(primary.get() + 1)),
+            on_cancel: Box::new(move |_app| cancel.set(cancel.get() + 1)),
+        }
+    }
+
+    /// Holds the HOME lock + tempdirs alongside the App so each test
+    /// gets a clean isolated environment. Drop order matters: the App
+    /// (and its tasks worker) gets cleaned up before the tempdirs.
+    struct ConfirmFixture {
+        app: App,
+        // Listed after `app` so they outlive it (Rust drops fields top-
+        // down, so these fields drop *after* `app` only because they
+        // appear after it in the struct definition — fine in practice).
+        _home_guard: test_support::HomeGuard,
+        _home: tempfile::TempDir,
+        _repo: tempfile::TempDir,
+        _home_lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    fn make_fixture() -> ConfirmFixture {
+        let lock = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::TempDir::new().expect("home tempdir");
+        let home_guard = HomeGuard::enter(home.path());
+        let (repo, _) = tempdir_repo();
+        let backend = Arc::new(LocalBackend::open_at(repo.path().to_path_buf()));
+        let mut app = App::new_with_backend(Theme::dark(), backend, None);
+        app.fs_watcher_rx = None;
+        ConfirmFixture {
+            app,
+            _home_guard: home_guard,
+            _home: home,
+            _repo: repo,
+            _home_lock: lock,
+        }
+    }
+
+    #[test]
+    fn fire_confirm_primary_runs_closure_and_clears_modal() {
+        let primary = Rc::new(Cell::new(0));
+        let cancel = Rc::new(Cell::new(0));
+        let mut fx = make_fixture();
+
+        fx.app
+            .show_confirm(modal_with_counters(primary.clone(), cancel.clone()));
+        assert!(fx.app.confirm_modal.is_some(), "modal opens");
+
+        fx.app.fire_confirm_primary();
+        assert_eq!(primary.get(), 1, "on_confirm fired exactly once");
+        assert_eq!(cancel.get(), 0, "on_cancel must not fire");
+        assert!(
+            fx.app.confirm_modal.is_none(),
+            "modal cleared after primary"
+        );
+    }
+
+    #[test]
+    fn fire_confirm_cancel_runs_closure_and_clears_modal() {
+        let primary = Rc::new(Cell::new(0));
+        let cancel = Rc::new(Cell::new(0));
+        let mut fx = make_fixture();
+
+        fx.app
+            .show_confirm(modal_with_counters(primary.clone(), cancel.clone()));
+        fx.app.fire_confirm_cancel();
+
+        assert_eq!(primary.get(), 0);
+        assert_eq!(cancel.get(), 1);
+        assert!(fx.app.confirm_modal.is_none());
+    }
+
+    #[test]
+    fn dismiss_confirm_skips_callbacks() {
+        let primary = Rc::new(Cell::new(0));
+        let cancel = Rc::new(Cell::new(0));
+        let mut fx = make_fixture();
+
+        fx.app
+            .show_confirm(modal_with_counters(primary.clone(), cancel.clone()));
+        fx.app.dismiss_confirm();
+
+        // dismiss is the "force-close, drop callbacks" path — used by
+        // competing modal opens, tab switches, mutation completion.
+        assert_eq!(primary.get(), 0);
+        assert_eq!(cancel.get(), 0);
+        assert!(fx.app.confirm_modal.is_none());
+    }
+
+    #[test]
+    fn show_confirm_over_existing_fires_cancel_on_old_modal() {
+        let primary_a = Rc::new(Cell::new(0));
+        let cancel_a = Rc::new(Cell::new(0));
+        let primary_b = Rc::new(Cell::new(0));
+        let cancel_b = Rc::new(Cell::new(0));
+        let mut fx = make_fixture();
+
+        fx.app
+            .show_confirm(modal_with_counters(primary_a.clone(), cancel_a.clone()));
+        // B opens while A is still up — A's on_cancel should fire so its
+        // caller can clean up; A's on_confirm must NOT fire.
+        fx.app
+            .show_confirm(modal_with_counters(primary_b.clone(), cancel_b.clone()));
+
+        assert_eq!(primary_a.get(), 0);
+        assert_eq!(cancel_a.get(), 1, "A's cancel fires on replace");
+        assert_eq!(primary_b.get(), 0);
+        assert_eq!(cancel_b.get(), 0);
+        assert!(fx.app.confirm_modal.is_some(), "B is now the active modal");
+
+        // Drive B to completion to verify it's independent.
+        fx.app.fire_confirm_primary();
+        assert_eq!(primary_b.get(), 1);
+        assert_eq!(cancel_b.get(), 0);
+        assert!(fx.app.confirm_modal.is_none());
+    }
+
+    #[test]
+    fn callback_can_reopen_modal_without_recursion_or_leak() {
+        // A closure that calls `show_confirm` again is the documented
+        // "keep modal open" pattern (mirrors `execute_tree_delete`
+        // backing off on `fs_mutation_load.loading`). Verify it doesn't
+        // stack-overflow and that the second modal is the one left
+        // standing.
+        let counter = Rc::new(Cell::new(0));
+        let mut fx = make_fixture();
+
+        let counter_inner = counter.clone();
+        fx.app.show_confirm(ConfirmModal {
+            title: "t".into(),
+            tone: ModalTone::Danger,
+            body: "b".into(),
+            primary_label: "P".into(),
+            cancel_label: "C".into(),
+            confirm_keys: vec![],
+            on_confirm: Box::new(move |app| {
+                counter_inner.set(counter_inner.get() + 1);
+                // Re-open with a fresh, no-op modal.
+                app.show_confirm(ConfirmModal {
+                    title: "t2".into(),
+                    tone: ModalTone::Danger,
+                    body: "b2".into(),
+                    primary_label: "P".into(),
+                    cancel_label: "C".into(),
+                    confirm_keys: vec![],
+                    on_confirm: Box::new(|_| {}),
+                    on_cancel: Box::new(|_| {}),
+                });
+            }),
+            on_cancel: Box::new(|_| {}),
+        });
+
+        fx.app.fire_confirm_primary();
+        assert_eq!(counter.get(), 1, "first closure ran once");
+        assert!(
+            fx.app.confirm_modal.is_some(),
+            "second modal is still up after the closure re-opened"
+        );
     }
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -898,19 +898,65 @@ pub fn tree_edit_error(err: &crate::tree_edit::TreeEditError) -> String {
     }
 }
 
-/// Status-bar takeover while a delete is pending confirmation. `hard`
-/// switches the wording so the user sees that Shift+Delete is
-/// permanent, not just trash.
-pub fn tree_delete_confirm_prompt(name: &str, is_dir: bool, hard: bool) -> String {
+/// Body text shown inside the file-tree delete-confirm modal. The
+/// keyboard hint (`Y` / `Esc`) lives on the dedicated hint row
+/// rendered by `confirm_modal`, and the title row is generic ("Confirm"
+/// / "确认"), so the body carries the actual question.
+pub fn tree_delete_body(name: &str, is_dir: bool, hard: bool) -> String {
     let kind_zh = if is_dir { "文件夹" } else { "文件" };
     let kind_en = if is_dir { "folder" } else { "file" };
     match (lang(), hard) {
-        (Lang::Zh, true) => format!("  ⚠ 永久删除{kind_zh} `{name}`？(不可恢复) (y / Esc)  "),
+        (Lang::Zh, true) => format!("永久删除{kind_zh} `{name}`？\n此操作不可恢复。"),
         (Lang::En, true) => {
-            format!("  ⚠ Permanently delete {kind_en} `{name}`? (cannot be undone) (y / Esc)  ")
+            format!("Permanently delete {kind_en} `{name}`?\nThis cannot be undone.")
         }
-        (Lang::Zh, false) => format!("  ⚠ 把{kind_zh} `{name}` 移到废纸篓？(y / Esc)  "),
-        (Lang::En, false) => format!("  ⚠ Move {kind_en} `{name}` to Trash? (y / Esc)  "),
+        (Lang::Zh, false) => format!("把{kind_zh} `{name}` 移到废纸篓？"),
+        (Lang::En, false) => format!("Move {kind_en} `{name}` to Trash?"),
+    }
+}
+
+/// Cancel button label for the generic confirm modal.
+pub fn confirm_cancel_label() -> String {
+    match lang() {
+        Lang::Zh => "取消".to_string(),
+        Lang::En => "Cancel".to_string(),
+    }
+}
+
+/// Primary-button label for a hard-delete (Shift+Delete) confirm.
+pub fn confirm_delete_label() -> String {
+    match lang() {
+        Lang::Zh => "永久删除".to_string(),
+        Lang::En => "Delete".to_string(),
+    }
+}
+
+/// Primary-button label for the Move-to-Trash (Delete) confirm.
+pub fn confirm_trash_label() -> String {
+    match lang() {
+        Lang::Zh => "移到废纸篓".to_string(),
+        Lang::En => "Move to Trash".to_string(),
+    }
+}
+
+/// Generic title for destructive confirm modals. Deliberately distinct
+/// from the primary-button verb so the title functions as "this is a
+/// confirmation dialog" framing, not a copy of the action. The tone
+/// (red accent for `Danger`) carries the severity cue.
+pub fn confirm_destructive_title() -> String {
+    match lang() {
+        Lang::Zh => "确认".to_string(),
+        Lang::En => "Confirm".to_string(),
+    }
+}
+
+/// Keyboard hint row shown under the buttons in the confirm modal.
+/// Tells the user what the shortcuts are without bloating the button
+/// labels themselves.
+pub fn confirm_modal_hint() -> String {
+    match lang() {
+        Lang::Zh => "Y 确认 · Esc 取消".to_string(),
+        Lang::En => "Y to confirm · Esc to cancel".to_string(),
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -164,11 +164,12 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         return;
     }
 
-    // Delete confirmation status-bar prompt: Y confirms, N / Esc
-    // cancels. Every other key is ignored so the user can't
-    // accidentally trigger something else while the confirm is up.
-    if app.tree_delete_confirm.is_some() {
-        handle_key_tree_delete_confirm(key, app);
+    // Generic confirm modal owns the keyboard while up. Matches the
+    // paste-conflict / context-menu pattern: explicit early-return
+    // before any global hotkeys so e.g. `q` can't fall through to
+    // "quit" while a "discard changes?" confirm is on screen.
+    if app.confirm_modal.is_some() {
+        handle_key_confirm_modal(key, app);
         return;
     }
 
@@ -1819,13 +1820,49 @@ fn handle_key_hosts_picker(key: KeyEvent, app: &mut App) {
     }
 }
 
-/// Y/Esc handler for the status-bar delete confirm.
-fn handle_key_tree_delete_confirm(key: KeyEvent, app: &mut App) {
-    match key.code {
-        KeyCode::Char('y') | KeyCode::Char('Y') => app.confirm_tree_delete(),
-        KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Char('c') => {
-            app.cancel_tree_delete()
+/// Keyboard handler for the generic `ConfirmModal`.
+///
+/// Routing:
+/// - Any char in `confirm_keys` → primary callback (e.g. `Y` for delete).
+/// - `Esc` / `n` / `N` / `c` / `C` → cancel callback.
+/// - `Ctrl+C` keeps its global "force quit" meaning (mirrors paste-conflict).
+/// - **`Enter` is intentionally ignored** so a stray return can't fire a
+///   destructive primary action. Confirmation must be deliberate (typed
+///   shortcut or a click).
+/// - Modified chars (`Ctrl+*`, `Alt+*`) are *not* treated as the bare
+///   letter — `Ctrl+Y` must not silently fire the destructive primary.
+///   Shift is allowed: capital `Y` is the same intent as lowercase `y`
+///   and matches via the `confirm_keys` list (which contains both).
+/// - Other keys swallowed so they don't fall through to global hotkeys.
+fn handle_key_confirm_modal(key: KeyEvent, app: &mut App) {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
+    if let KeyCode::Char('c') = key.code {
+        if ctrl {
+            app.should_quit = true;
+            return;
         }
+    }
+    // Any ctrl/alt-modified char is not a confirm/cancel shortcut.
+    // We still swallow it (no `_ => {}` fall-through to global keys)
+    // since the modal owns the keyboard while up.
+    if ctrl || alt {
+        return;
+    }
+    match key.code {
+        KeyCode::Char(c) => {
+            let confirms = app
+                .confirm_modal
+                .as_ref()
+                .map(|m| m.confirm_keys.contains(&c))
+                .unwrap_or(false);
+            if confirms {
+                app.fire_confirm_primary();
+            } else if matches!(c, 'n' | 'N' | 'c' | 'C') {
+                app.fire_confirm_cancel();
+            }
+        }
+        KeyCode::Esc => app.fire_confirm_cancel(),
         _ => {}
     }
 }
@@ -2045,6 +2082,32 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
         return;
     }
 
+    // Generic confirm modal fully owns mouse. Left-clicks dispatch via
+    // the hit_registry (Cancel/Primary button zones + a full-screen
+    // fallthrough Cancel zone registered in `confirm_modal::render`);
+    // every other event is swallowed so scrolls / drags / right-clicks
+    // can't leak to the panels underneath while the modal is up.
+    //
+    // Action filter: the registry from the *previous* frame may still
+    // be live if the user clicks before the modal's first render lands
+    // (key-then-immediate-mouse). In that window a click could resolve
+    // to e.g. `TreeClick(n)`, silently mutating the file tree under
+    // the overlay. We restrict dispatch to the two modal-owned
+    // variants; any other hit (or no hit) collapses to "cancel" —
+    // same semantics as clicking outside the rendered modal.
+    if app.confirm_modal.is_some() {
+        if let MouseEventKind::Down(MouseButton::Left) = mouse.kind {
+            match app.hit_registry.hit_test(mouse.column, mouse.row) {
+                Some(action @ ui::mouse::ClickAction::ConfirmModalPrimary)
+                | Some(action @ ui::mouse::ClickAction::ConfirmModalCancel) => {
+                    app.handle_action(action);
+                }
+                _ => app.fire_confirm_cancel(),
+            }
+        }
+        return;
+    }
+
     // Intra-tree drag in progress: route Drag→hover-update,
     // Up→commit, Right-click→cancel. Scroll wheel falls through so
     // the user can scroll the tree to reach a deep destination
@@ -2091,10 +2154,7 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
     // the empty space below rows (root-flavoured menu). Every other
     // hit (toolbar buttons, preview content, no-op areas) bails out.
     if let MouseEventKind::Down(MouseButton::Right) = mouse.kind {
-        if app.active_tab == Tab::Files
-            && !app.tree_edit.active
-            && app.tree_delete_confirm.is_none()
-        {
+        if app.active_tab == Tab::Files && !app.tree_edit.active && app.confirm_modal.is_none() {
             // Second right-click while the menu is already open
             // dismisses it (Finder / VSCode behaviour).
             if app.tree_context_menu.active {

--- a/src/ui/confirm_modal.rs
+++ b/src/ui/confirm_modal.rs
@@ -1,0 +1,261 @@
+//! Generic centered confirm modal — `[Cancel] [Primary]`.
+//!
+//! Callers build a `ConfirmModal` (body text + two `FnOnce` callbacks) and
+//! hand it to `App::show_confirm`. `App::fire_confirm_primary` /
+//! `fire_confirm_cancel` `take()` the modal before calling the closure, so
+//! the closure receives a clean `&mut App` and can even re-`show_confirm`
+//! itself — that's the "keep open while a prior op is still running" retry
+//! path used by `execute_tree_delete`.
+//!
+//! Rendered last in `ui::render` so it floats above other overlays; mouse +
+//! keyboard are gated in `input::*` so events never reach the panels
+//! underneath. A full-screen `ConfirmModalCancel` hit zone is registered
+//! first and button zones last — reverse-order hit-testing makes outside
+//! clicks dismiss while button clicks resolve normally.
+
+use crate::app::App;
+use crate::ui::hover;
+use crate::ui::layout::center_rect;
+use crate::ui::mouse::ClickAction;
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Clear};
+use unicode_width::UnicodeWidthStr;
+
+pub struct ConfirmModal {
+    pub title: String,
+    pub tone: ModalTone,
+    /// Body text. Split on `'\n'` for multi-line rendering.
+    pub body: String,
+    pub primary_label: String,
+    pub cancel_label: String,
+    /// Keys that fire `on_confirm`. Typically `['y', 'Y']`. Empty means
+    /// "only the mouse can confirm" — Esc / N / C still cancel.
+    pub confirm_keys: Vec<char>,
+    pub on_confirm: Box<dyn FnOnce(&mut App)>,
+    pub on_cancel: Box<dyn FnOnce(&mut App)>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModalTone {
+    Default,
+    Danger,
+}
+
+const MIN_W: u16 = 44;
+const MAX_W: u16 = 64;
+const SIDE_PAD: u16 = 4;
+const BUTTON_GAP: u16 = 3;
+const PAD_TOP: u16 = 1;
+const PAD_BOTTOM: u16 = 1;
+const TITLE_TO_BODY: u16 = 1;
+const BODY_TO_BUTTONS: u16 = 1;
+
+pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
+    let Some(modal) = app.confirm_modal.as_ref() else {
+        return;
+    };
+    let th = app.theme;
+
+    let body_lines: Vec<&str> = modal.body.lines().collect();
+    let body_lines = if body_lines.is_empty() {
+        vec![""]
+    } else {
+        body_lines
+    };
+
+    let hint = crate::i18n::confirm_modal_hint();
+    let hint_w = UnicodeWidthStr::width(hint.as_str()) as u16;
+
+    let body_max_w = body_lines
+        .iter()
+        .map(|s| UnicodeWidthStr::width(*s) as u16)
+        .max()
+        .unwrap_or(0);
+    let title_w = UnicodeWidthStr::width(modal.title.as_str()) as u16;
+    let cancel_label_w = UnicodeWidthStr::width(modal.cancel_label.as_str()) as u16;
+    let primary_label_w = UnicodeWidthStr::width(modal.primary_label.as_str()) as u16;
+    // `  label  ` chip = label + 4 cols of left/right padding.
+    let cancel_btn_w = cancel_label_w + 4;
+    let primary_btn_w = primary_label_w + 4;
+    let buttons_w = cancel_btn_w + BUTTON_GAP + primary_btn_w;
+
+    let content_w = body_max_w.max(buttons_w).max(hint_w).max(title_w);
+    // On extremely narrow terminals (< MIN_W) `MAX_W.min(screen.width)` can
+    // dip below `MIN_W`, which would make `clamp(min, max)` panic. Compute
+    // the upper bound first and floor the lower bound to it.
+    let max_w = MAX_W.min(screen.width);
+    let min_w = MIN_W.min(max_w);
+    let popup_w = (content_w + SIDE_PAD * 2).clamp(min_w, max_w);
+
+    // Vertical layout: top_pad | title | gap | body | gap | buttons | hint | bottom_pad
+    let popup_h = (PAD_TOP
+        + 1                       // title
+        + TITLE_TO_BODY
+        + body_lines.len() as u16
+        + BODY_TO_BUTTONS
+        + 1                       // buttons
+        + 1                       // hint
+        + PAD_BOTTOM)
+        .min(screen.height);
+
+    let area = center_rect(screen, popup_w, popup_h);
+
+    // Fallthrough cancel: every screen row gets a cancel hit zone. Button
+    // zones registered later shadow it via reverse-order hit-testing.
+    for sy in screen.y..screen.y + screen.height {
+        app.hit_registry
+            .register_row(screen.x, sy, screen.width, ClickAction::ConfirmModalCancel);
+    }
+
+    // Wipe stale glyphs and paint the card surface in one shot. The
+    // chrome_active_bg is one shade lighter than the underlying panels'
+    // chrome_bg, which provides the "lift" without a line-drawing border.
+    f.render_widget(Clear, area);
+    f.render_widget(
+        Block::default().style(Style::default().bg(th.chrome_active_bg)),
+        area,
+    );
+
+    let card_bg = th.chrome_active_bg;
+    let title_accent = match modal.tone {
+        ModalTone::Danger => th.removed_accent,
+        ModalTone::Default => th.accent,
+    };
+
+    let inner_x = area.x + SIDE_PAD;
+    let inner_w = area.width.saturating_sub(SIDE_PAD * 2);
+
+    // Title row, left-aligned within the inner content column. Pure
+    // foreground accent — no bg banner, no border integration.
+    let title_y = area.y + PAD_TOP;
+    if title_y < area.y + area.height {
+        f.render_widget(
+            Line::from(Span::styled(
+                modal.title.clone(),
+                Style::default()
+                    .fg(title_accent)
+                    .bg(card_bg)
+                    .add_modifier(Modifier::BOLD),
+            )),
+            Rect::new(inner_x, title_y, inner_w, 1),
+        );
+    }
+
+    // Body lines.
+    let body_start_y = title_y + 1 + TITLE_TO_BODY;
+    for (i, line) in body_lines.iter().enumerate() {
+        let row_y = body_start_y + i as u16;
+        if row_y >= area.y + area.height {
+            break;
+        }
+        f.render_widget(
+            Line::from(Span::styled(
+                line.to_string(),
+                Style::default().fg(th.fg_primary).bg(card_bg),
+            )),
+            Rect::new(inner_x, row_y, inner_w, 1),
+        );
+    }
+
+    let buttons_y = body_start_y + body_lines.len() as u16 + BODY_TO_BUTTONS;
+    let hint_y = buttons_y + 1;
+
+    // Buttons centered within `inner`.
+    let buttons_start_x = inner_x + inner_w.saturating_sub(buttons_w) / 2;
+    let cancel_x = buttons_start_x;
+    let primary_x = buttons_start_x + cancel_btn_w + BUTTON_GAP;
+
+    // Buttons + hint are skipped when `popup_h` got clamped against an
+    // extremely short terminal. The modal isn't usable at that point
+    // anyway — the user just sees the title + body — but bailing out
+    // here avoids an off-bounds `Rect::new` panic.
+    if buttons_y < area.y + area.height {
+        let cancel_hovered = hover::is_hover(
+            app,
+            Rect::new(cancel_x, buttons_y, cancel_btn_w, 1),
+            buttons_y,
+        );
+        let primary_hovered = hover::is_hover(
+            app,
+            Rect::new(primary_x, buttons_y, primary_btn_w, 1),
+            buttons_y,
+        );
+
+        // Cancel: recessed chip — chrome_bg is *darker* than the card,
+        // so the button reads as "pressed into" the surface. Lifts to
+        // hover_bg on mouse-over.
+        let cancel_bg = if cancel_hovered {
+            th.selection_bg
+        } else {
+            th.chrome_bg
+        };
+        f.render_widget(
+            Line::from(Span::styled(
+                format!("  {}  ", modal.cancel_label),
+                Style::default()
+                    .fg(th.fg_primary)
+                    .bg(cancel_bg)
+                    .add_modifier(if cancel_hovered {
+                        Modifier::BOLD
+                    } else {
+                        Modifier::empty()
+                    }),
+            )),
+            Rect::new(cancel_x, buttons_y, cancel_btn_w, 1),
+        );
+
+        // Primary: tone-coloured chip — danger uses error_bg, default uses
+        // accent. Hover adds UNDERLINED rather than REVERSED so the chip
+        // stays legible on light themes (REVERSED would swap fg/bg and
+        // give us dark-text-on-cyan, which fights the high-contrast
+        // light preset).
+        let (primary_bg, primary_fg) = match modal.tone {
+            ModalTone::Danger => (th.error_bg, th.fg_primary),
+            ModalTone::Default => (th.accent, th.chrome_bg),
+        };
+        let mut primary_style = Style::default()
+            .fg(primary_fg)
+            .bg(primary_bg)
+            .add_modifier(Modifier::BOLD);
+        if primary_hovered {
+            primary_style = primary_style.add_modifier(Modifier::UNDERLINED);
+        }
+        f.render_widget(
+            Line::from(Span::styled(
+                format!("  {}  ", modal.primary_label),
+                primary_style,
+            )),
+            Rect::new(primary_x, buttons_y, primary_btn_w, 1),
+        );
+
+        // Hit zones registered LAST so they shadow the fallthrough cancel.
+        app.hit_registry.register_row(
+            cancel_x,
+            buttons_y,
+            cancel_btn_w,
+            ClickAction::ConfirmModalCancel,
+        );
+        app.hit_registry.register_row(
+            primary_x,
+            buttons_y,
+            primary_btn_w,
+            ClickAction::ConfirmModalPrimary,
+        );
+    }
+
+    // Keyboard hint centered under the buttons. Secondary fg so it reads
+    // as chrome, not as part of the prompt itself.
+    if hint_y < area.y + area.height {
+        let hint_x = inner_x + inner_w.saturating_sub(hint_w) / 2;
+        f.render_widget(
+            Line::from(Span::styled(
+                hint,
+                Style::default().fg(th.fg_secondary).bg(card_bg),
+            )),
+            Rect::new(hint_x, hint_y, hint_w, 1),
+        );
+    }
+}

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,0 +1,18 @@
+//! Tiny geometry helpers shared by overlay panels.
+//!
+//! Multiple overlays (`confirm_modal`, `quick_open_panel`,
+//! `global_search_panel`, `hosts_picker_panel`) center a popup over the
+//! current screen using the same `(screen - popup) / 2` math. Keeping
+//! the calculation in one place avoids drift if we later swap in
+//! `Rect::y` clamping, off-center placement for dialogs near the cursor,
+//! or anything more elaborate.
+
+use ratatui::layout::Rect;
+
+/// Center a `w × h` rectangle inside `screen`, saturating to the
+/// top-left if `screen` is smaller than the popup in either dimension.
+pub fn center_rect(screen: Rect, w: u16, h: u16) -> Rect {
+    let x = screen.x + screen.width.saturating_sub(w) / 2;
+    let y = screen.y + screen.height.saturating_sub(h) / 2;
+    Rect::new(x, y, w, h)
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,4 +1,5 @@
 pub mod commit_detail_panel;
+pub mod confirm_modal;
 pub mod context_menu_panel;
 pub mod db_preview;
 pub mod diff_panel;
@@ -11,6 +12,7 @@ pub mod global_search_panel;
 pub mod highlight;
 pub mod hosts_picker_panel;
 pub mod hover;
+pub mod layout;
 pub mod mouse;
 pub mod quick_open_panel;
 pub mod search_tab;
@@ -219,6 +221,12 @@ pub fn render(f: &mut Frame, app: &mut App) {
     // check only looks at `tree_context_menu.active`.
     if app.tree_context_menu.active {
         context_menu_panel::render(f, app, size);
+    }
+    // ConfirmModal sits on top of everything — including context menu —
+    // because once the user has committed to a destructive choice, the
+    // confirm must be the only thing eligible to receive input.
+    if app.confirm_modal.is_some() {
+        confirm_modal::render(f, app, size);
     }
 }
 
@@ -554,45 +562,6 @@ fn render_status_bar(f: &mut Frame, app: &mut App, area: Rect) {
             ),
             Span::styled(
                 text,
-                Style::default()
-                    .fg(th.fg_primary)
-                    .bg(th.chrome_bg)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " ".repeat(area.width.saturating_sub(80) as usize),
-                Style::default().bg(th.chrome_bg),
-            ),
-        ]);
-        f.render_widget(hint, area);
-        return;
-    }
-
-    // Tree delete-confirm: status bar becomes a red ⚠ prompt. Mirrors
-    // the select/place mode takeover pattern. Confirm key routing
-    // lives in `input::handle_key_tree_delete_confirm` — here we
-    // just draw.
-    if let Some(pending) = app.tree_delete_confirm.as_ref() {
-        let prompt = crate::i18n::tree_delete_confirm_prompt(
-            &pending.display_name,
-            pending.is_dir,
-            pending.hard,
-        );
-        let badge = if pending.hard {
-            " ⚠ DELETE "
-        } else {
-            " 🗑 TRASH "
-        };
-        let hint = Line::from(vec![
-            Span::styled(
-                badge,
-                Style::default()
-                    .fg(Color::White)
-                    .bg(th.error_bg)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                prompt,
                 Style::default()
                     .fg(th.fg_primary)
                     .bg(th.chrome_bg)

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -104,6 +104,14 @@ pub enum ClickAction {
     /// keyboard-only, mirroring the file tree where double-click /
     /// Enter is the deliberate-action gate.
     SettingsRow(usize),
+    /// Click on the primary (e.g. "Delete") button of the generic
+    /// `ConfirmModal`. Dispatched to `App::fire_confirm_primary`,
+    /// which `take()`s the modal and fires its `on_confirm` closure.
+    ConfirmModalPrimary,
+    /// Click on the Cancel button, or anywhere outside the
+    /// `ConfirmModal`. Fires `on_cancel` (usually a no-op) and clears
+    /// the modal.
+    ConfirmModalCancel,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

- **Centered borderless confirm modal** replacing the status-bar `⚠ DELETE foo? (y / Esc)` takeover for `Delete` / `Shift+Delete`. Buttons are mouse-clickable; click outside dismisses; `Y` / `Esc` still work for keyboard users.
- **Generic `ConfirmModal` API** on `App` (`show_confirm` + `FnOnce` callbacks). Reusable for future yes/no dialogs (discard unsaved changes, overwrite file, quit with running task, …) without per-feature state on `App`.
- **Hardened input gating** while the modal is up: a stale-registry filter prevents previous-frame clicks from mutating the file tree under the overlay, `Ctrl/Alt+Y` doesn't fire the destructive primary, and `Enter` is intentionally ignored.

## Test plan

- [x] `cargo build` clean, `cargo clippy --all-targets -- -D warnings` clean, `cargo test --lib` (539 passed including 5 new ConfirmModal lifecycle tests)
- [ ] `cargo run` → Files tab → select a file → `Delete` shows the modal centered, status bar untouched
- [ ] `Y` confirms; `Esc` / `n` / `C` cancels; `Enter` is a no-op
- [ ] Click the `Cancel` / `Move to Trash` button; click anywhere outside dismisses
- [ ] `Shift+Delete` shows the `Delete` primary instead of `Move to Trash`
- [ ] hover on either button highlights it
- [ ] modal is dismissed cleanly on tab switch / place-mode entry / tree-edit entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)