### PR TITLE
refactor(git): remove double-click stage/unstage toggle

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4214,19 +4214,13 @@ impl App {
             ClickAction::UnstageFile(path) => {
                 self.unstage_file(&path);
             }
-            ClickAction::ToggleStaged => {
-                self.staged_collapsed = !self.staged_collapsed;
-            }
-            ClickAction::ToggleUnstaged => {
-                self.unstaged_collapsed = !self.unstaged_collapsed;
-            }
             ClickAction::StartDragSplit => {
                 self.dragging_split = true;
             }
             ClickAction::StartDragGraphDiffSplit => {
                 self.dragging_graph_diff_split = true;
             }
-            ClickAction::GitCommand { command, args, .. } => {
+            ClickAction::GitCommand { command, args } => {
                 // Try each panel's dispatcher in turn. Unknown commands are
                 // silently dropped — no external handler to fall through to.
                 if crate::ui::git_status_panel::handle_command(self, &command, &args) {

--- a/src/input.rs
+++ b/src/input.rs
@@ -2229,27 +2229,7 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
                     app.last_click = None;
                     return;
                 }
-                // On double-click: if the region carries a dbl action, swap to it
-                // and run through handle_action so host-side side effects fire.
-                let effective = if is_double {
-                    if let ui::mouse::ClickAction::GitCommand {
-                        dbl_command: Some(ref cmd),
-                        ref dbl_args,
-                        ..
-                    } = action
-                    {
-                        ui::mouse::ClickAction::GitCommand {
-                            command: cmd.clone(),
-                            args: dbl_args.clone().unwrap_or(serde_json::Value::Null),
-                            dbl_command: None,
-                            dbl_args: None,
-                        }
-                    } else {
-                        action
-                    }
-                } else {
-                    action
-                };
+                let effective = action;
                 // Shift+Click on a graph row = extend the range, for
                 // terminals that actually forward Shift+Click to the app.
                 // Most macOS terminals intercept this for text selection;
@@ -2257,7 +2237,7 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
                 // click normally instead — the in-visual-mode click path
                 // lives in `git_graph_panel::handle_command`.
                 if mouse.modifiers.contains(KeyModifiers::SHIFT)
-                    && let ui::mouse::ClickAction::GitCommand { command, args, .. } = &effective
+                    && let ui::mouse::ClickAction::GitCommand { command, args } = &effective
                     && command == "git.selectCommit"
                     && let Some(oid) = args.get("oid").and_then(|v| v.as_str())
                     && let Some(target_idx) = app.git_graph.find_row_by_oid(oid)
@@ -2272,9 +2252,8 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
                     return;
                 }
                 // Files-tab tree multi-select / drag-arm overlay.
-                // Modifier handling sits between the generic
-                // double-click swap and the standard `handle_action`
-                // dispatch:
+                // Modifier handling sits before the standard
+                // `handle_action` dispatch:
                 //   Shift+Click → extend the selection range
                 //   Ctrl+Click  → toggle a single row in/out
                 //   plain click → arm a tree-drag press; clear any

--- a/src/ui/commit_detail_panel.rs
+++ b/src/ui/commit_detail_panel.rs
@@ -190,8 +190,6 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
                 ClickAction::GitCommand {
                     command: cmd,
                     args: args.unwrap_or(Value::Null),
-                    dbl_command: None,
-                    dbl_args: None,
                 },
             );
         }

--- a/src/ui/git_graph_panel.rs
+++ b/src/ui/git_graph_panel.rs
@@ -94,8 +94,6 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
             ClickAction::GitCommand {
                 command: "git.selectCommit".into(),
                 args: serde_json::json!({ "oid": row.commit.oid }),
-                dbl_command: None,
-                dbl_args: None,
             },
         );
     }

--- a/src/ui/git_status_panel.rs
+++ b/src/ui/git_status_panel.rs
@@ -89,21 +89,14 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
                 (None, Some(r)) => (Some(r.0.clone()), Some(r.1.clone())),
                 (None, None) => (None, None),
             };
-            let (dbl, dbl_args) = match (&span.dbl, &row.row_dbl) {
-                (Some(c), _) => (Some(c.0.clone()), Some(c.1.clone())),
-                (None, Some(r)) => (Some(r.0.clone()), Some(r.1.clone())),
-                (None, None) => (None, None),
-            };
-            if cmd.is_some() || dbl.is_some() {
+            if let Some(command) = cmd {
                 app.hit_registry.register_row(
                     x,
                     y,
                     w,
                     ClickAction::GitCommand {
-                        command: cmd.unwrap_or_default(),
+                        command,
                         args: args.unwrap_or(Value::Null),
-                        dbl_command: dbl,
-                        dbl_args,
                     },
                 );
             }
@@ -433,14 +426,12 @@ struct RowSpan {
     style: Style,
     /// Single-click command for just this span. Takes precedence over row-level.
     click: Option<(String, Value)>,
-    dbl: Option<(String, Value)>,
 }
 
 #[derive(Debug, Default)]
 struct Row {
     spans: Vec<RowSpan>,
     row_click: Option<(String, Value)>,
-    row_dbl: Option<(String, Value)>,
     /// When this row is a file row, its index into the unified
     /// staged-then-unstaged file list — lines up with `collect_rows` in
     /// `crate::search` for `SearchTarget::GitStatus`. Lets the render loop
@@ -454,7 +445,6 @@ impl RowSpan {
             text: text.into(),
             style: Style::default(),
             click: None,
-            dbl: None,
         }
     }
 
@@ -463,7 +453,6 @@ impl RowSpan {
             text: text.into(),
             style,
             click: None,
-            dbl: None,
         }
     }
 
@@ -478,7 +467,6 @@ impl Row {
         Self {
             spans,
             row_click: None,
-            row_dbl: None,
             search_row_idx: None,
         }
     }
@@ -489,11 +477,6 @@ impl Row {
 
     fn on_click(mut self, cmd: &str, args: Value) -> Self {
         self.row_click = Some((cmd.to_string(), args));
-        self
-    }
-
-    fn on_dbl_click(mut self, cmd: &str, args: Value) -> Self {
-        self.row_dbl = Some((cmd.to_string(), args));
         self
     }
 
@@ -950,7 +933,6 @@ fn dir_row(
                 .fg(stage_color)
                 .add_modifier(Modifier::BOLD),
             click: Some((stage_cmd.into(), serde_json::json!({ "path": path }))),
-            dbl: None,
         },
         RowSpan::plain(" "),
     ];
@@ -966,7 +948,6 @@ fn dir_row(
                 "git.discardFolderPrompt".into(),
                 serde_json::json!({ "path": path, "staged": is_staged }),
             )),
-            dbl: None,
         });
     }
     Row::new(spans).on_click(
@@ -1088,7 +1069,6 @@ fn file_row(
             "git.revealInTree".to_string(),
             serde_json::json!({ "path": file.path }),
         )),
-        dbl: None,
     });
     spans.push(RowSpan::styled(
         " ".to_string(),
@@ -1106,7 +1086,6 @@ fn file_row(
             button_cmd.to_string(),
             serde_json::json!({ "path": file.path }),
         )),
-        dbl: None,
     });
     spans.push(RowSpan::styled(
         " ".to_string(),
@@ -1128,7 +1107,6 @@ fn file_row(
                     "git.discardPrompt".to_string(),
                     serde_json::json!({ "path": file.path }),
                 )),
-                dbl: None,
             });
             spans.push(RowSpan::styled(
                 " ".to_string(),
@@ -1137,12 +1115,10 @@ fn file_row(
         }
     }
 
-    Row::new(spans)
-        .on_click(
-            "git.selectFile",
-            serde_json::json!({ "path": file.path, "staged": ctx.is_staged }),
-        )
-        .on_dbl_click(button_cmd, serde_json::json!({ "path": file.path }))
+    Row::new(spans).on_click(
+        "git.selectFile",
+        serde_json::json!({ "path": file.path, "staged": ctx.is_staged }),
+    )
 }
 
 fn apply_bg(style: Style, bg: Option<Color>) -> Style {
@@ -1201,7 +1177,6 @@ fn section_header(
                 .fg(action.color)
                 .add_modifier(Modifier::BOLD),
             click: Some((action.cmd.clone(), action.args.clone())),
-            dbl: None,
         });
     }
 
@@ -1351,7 +1326,6 @@ fn push_commit_box(rows: &mut Vec<Row>, app: &App, max_path: usize, theme: &Them
                     .bg(btn_bg)
                     .add_modifier(Modifier::BOLD),
                 click: Some(("git.commitSubmit".into(), Value::Null)),
-                dbl: None,
             },
             RowSpan::plain("  "),
             RowSpan::styled(
@@ -1414,7 +1388,6 @@ fn push_indicator_row(ahead: usize, behind: usize) -> Option<Row> {
                     .bg(Color::Green)
                     .add_modifier(Modifier::BOLD),
                 click: Some(("git.pushPrompt".into(), Value::Null)),
-                dbl: None,
             },
         ])),
         (0, b) => Some(Row::new(vec![RowSpan::styled(
@@ -1430,7 +1403,6 @@ fn push_indicator_row(ahead: usize, behind: usize) -> Option<Row> {
                     .bg(Color::Yellow)
                     .add_modifier(Modifier::BOLD),
                 click: Some(("git.forcePushPrompt".into(), Value::Null)),
-                dbl: None,
             },
         ])),
     }
@@ -1488,7 +1460,6 @@ fn push_inline_confirm_spans(spans: &mut Vec<RowSpan>, theme: &Theme, base_bg: O
             base_bg,
         ),
         click: Some(("git.discardConfirm".to_string(), Value::Null)),
-        dbl: None,
     });
     spans.push(RowSpan::styled(
         " ".to_string(),
@@ -1503,7 +1474,6 @@ fn push_inline_confirm_spans(spans: &mut Vec<RowSpan>, theme: &Theme, base_bg: O
             base_bg,
         ),
         click: Some(("git.discardCancel".to_string(), Value::Null)),
-        dbl: None,
     });
 }
 

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -10,8 +10,6 @@ pub enum ClickAction {
     },
     StageFile(String),
     UnstageFile(String),
-    ToggleStaged,
-    ToggleUnstaged,
     StartDragSplit,
     /// Graph tab 3-col 布局下,中间 commit 列与右侧 diff 列之间的拖拽
     /// 分界。跟 `StartDragSplit` 互不干扰。
@@ -60,12 +58,9 @@ pub enum ClickAction {
     /// replace mode is open. Commits the replace batch.
     SearchApplyReplace,
     /// Invoke an inline Git panel command (`git.stage`, `git.selectCommit`, …).
-    /// `dbl_command`/`dbl_args`, if present, are fired on double-click instead.
     GitCommand {
         command: String,
         args: serde_json::Value,
-        dbl_command: Option<String>,
-        dbl_args: Option<serde_json::Value>,
     },
     /// Place-mode destination: dropping onto a specific folder row.
     /// Index into `file_tree.entries`; must point at a directory entry.
@@ -177,14 +172,14 @@ mod tests {
     #[test]
     fn hit_test_returns_registered_action() {
         let mut r = HitTestRegistry::new();
-        r.register_row(10, 5, 20, ClickAction::ToggleStaged);
-        assert!(matches!(r.hit_test(15, 5), Some(ClickAction::ToggleStaged)));
+        r.register_row(10, 5, 20, ClickAction::OpenSettings);
+        assert!(matches!(r.hit_test(15, 5), Some(ClickAction::OpenSettings)));
     }
 
     #[test]
     fn hit_test_misses_outside_rect() {
         let mut r = HitTestRegistry::new();
-        r.register_row(10, 5, 20, ClickAction::ToggleStaged);
+        r.register_row(10, 5, 20, ClickAction::OpenSettings);
         assert!(r.hit_test(9, 5).is_none(), "col just to the left");
         assert!(r.hit_test(30, 5).is_none(), "col at right edge (exclusive)");
         assert!(r.hit_test(15, 4).is_none(), "row above");
@@ -194,19 +189,16 @@ mod tests {
     #[test]
     fn hit_test_later_region_takes_priority() {
         let mut r = HitTestRegistry::new();
-        r.register_row(0, 0, 10, ClickAction::ToggleStaged);
-        r.register_row(0, 0, 10, ClickAction::ToggleUnstaged);
+        r.register_row(0, 0, 10, ClickAction::OpenSettings);
+        r.register_row(0, 0, 10, ClickAction::ToggleSidebar);
         // Later registration should win on overlap
-        assert!(matches!(
-            r.hit_test(5, 0),
-            Some(ClickAction::ToggleUnstaged)
-        ));
+        assert!(matches!(r.hit_test(5, 0), Some(ClickAction::ToggleSidebar)));
     }
 
     #[test]
     fn clear_removes_all_regions() {
         let mut r = HitTestRegistry::new();
-        r.register_row(0, 0, 10, ClickAction::ToggleStaged);
+        r.register_row(0, 0, 10, ClickAction::OpenSettings);
         r.clear();
         assert!(r.hit_test(5, 0).is_none());
     }
@@ -214,7 +206,7 @@ mod tests {
     #[test]
     fn hit_test_inclusive_left_exclusive_right() {
         let mut r = HitTestRegistry::new();
-        r.register_row(10, 0, 5, ClickAction::ToggleStaged); // cols 10..15
+        r.register_row(10, 0, 5, ClickAction::OpenSettings); // cols 10..15
         assert!(r.hit_test(10, 0).is_some(), "left edge is inclusive");
         assert!(r.hit_test(14, 0).is_some(), "last valid col");
         assert!(r.hit_test(15, 0).is_none(), "right edge is exclusive");


### PR DESCRIPTION
## Summary
- Remove the "double-click a file row to toggle staged/unstaged" gesture in the git tab — inline `+`/`-` buttons and the `s`/`u` keyboard shortcuts already cover the same action, so the gesture was an unmotivated third path.
- Cleanup that falls out of removing it:
  - drop `dbl_command`/`dbl_args` on `ClickAction::GitCommand`
  - drop `dbl`/`row_dbl` fields and `on_dbl_click` on the git-status panel's local `RowSpan`/`Row`
  - drop the double-click action-swap branch in `input::handle_mouse`
- Drive-by: delete the dead `ToggleStaged`/`ToggleUnstaged` `ClickAction` variants (section-header collapse has been going through `GitCommand { command: "git.toggleStaged" }` for a while; nothing registers the bare variants) and the now-redundant `, ..` rest patterns left over from the wider `GitCommand` shape.
- Net: −88 / +19 lines, no behavior change beyond removing the gesture itself.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo check`
- [x] `cargo clippy --all-targets --no-deps`
- [x] `cargo test --lib mouse` (6/6, hit-test registry tests switched to `OpenSettings`/`ToggleSidebar` placeholders)
- [ ] Manual: in the git tab, double-click a file row → nothing happens (selection stays); click `+`/`-` → stages/unstages as before; press `s`/`u` on a selected row → stages/unstages as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)