### PR TITLE
feat(input): VSCode-style drag-select auto-scroll

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -629,6 +629,18 @@ pub struct App {
     /// 连击计数器:diff 面板的 Down(Left) 序列,和 `preview_click_state`
     /// 语义一致,但分开存以防两个 tab 之间的点击串扰。
     pub diff_click_state: Option<(Instant, u16, u16, u8)>,
+    /// 拖拽选中过程中,上一次观察到的鼠标 `(column, row)`。终端在鼠标
+    /// 不动时不会再发 Drag 事件,所以 VSCode 风格的"鼠标移出视口后
+    /// 自动滚动"必须每帧重放最后已知位置——`tick_drag_autoscroll`
+    /// 读这个字段。Down/Drag 时由 selection handler 写入,Up 时清空;
+    /// 没有进行中的拖拽时为 None。
+    pub last_drag_mouse: Option<(u16, u16)>,
+    /// 上一次 preview / diff 自动滚动触发的时刻,用作速率限制。距离视口边缘
+    /// 越远 `tick_drag_autoscroll` 取的间隔越短,但单帧最快也不超过这个节流
+    /// 闸,避免 60Hz tick 把视口直接甩飞。None 表示当前帧首次触发。两个
+    /// 面板各持一份,避免 Up 丢事件时两边互相干扰彼此的节流。
+    pub preview_autoscroll_at: Option<Instant>,
+    pub diff_autoscroll_at: Option<Instant>,
 
     // Layout
     pub split_percent: u16,
@@ -1032,6 +1044,9 @@ impl App {
             last_diff_rect: None,
             last_diff_hit: None,
             diff_click_state: None,
+            last_drag_mouse: None,
+            preview_autoscroll_at: None,
+            diff_autoscroll_at: None,
             split_percent: 30,
             sidebar_visible: true,
             sidebar_hide_hint_shown: false,
@@ -4513,6 +4528,7 @@ impl App {
         self.kick_active_tab_work();
         self.tick_place_mode_auto_expand();
         self.tick_tree_drag_auto_expand();
+        crate::input::tick_drag_autoscroll(self);
         self.drain_task_results();
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -2461,6 +2461,10 @@ fn handle_preview_selection(mouse: &MouseEvent, app: &mut App) -> bool {
                 _ => PreviewSelection::new((file_line, byte_offset)),
             };
             app.preview_selection = Some(sel);
+            // Seed the drag-autoscroll tracker so the first tick after
+            // Down can fire if the user clicks at the very edge.
+            app.last_drag_mouse = Some((mouse.column, mouse.row));
+            app.preview_autoscroll_at = None;
             true
         }
         MouseEventKind::Drag(MouseButton::Left) => {
@@ -2468,6 +2472,10 @@ fn handle_preview_selection(mouse: &MouseEvent, app: &mut App) -> bool {
             if !dragging {
                 return false;
             }
+            // Refresh the autoscroll tracker even if origin is missing —
+            // the tick will guard on origin separately and we still want
+            // the latest mouse position for the next valid frame.
+            app.last_drag_mouse = Some((mouse.column, mouse.row));
             let Some(origin) = content_origin else {
                 return true; // swallow even without update — the drag is ours
             };
@@ -2486,6 +2494,9 @@ fn handle_preview_selection(mouse: &MouseEvent, app: &mut App) -> bool {
                 return false;
             }
             sel.dragging = false;
+            // Drag ended — stop the autoscroll loop.
+            app.last_drag_mouse = None;
+            app.preview_autoscroll_at = None;
             let sel_snapshot = *sel;
             if !sel_snapshot.is_empty() {
                 if let Some(preview) = app.preview_content.as_ref() {
@@ -2585,6 +2596,8 @@ fn handle_diff_selection(mouse: &MouseEvent, app: &mut App) -> bool {
                 _ => PreviewSelection::new((row_idx, byte_offset)),
             };
             app.diff_selection = Some(DiffSelection { sel, side });
+            app.last_drag_mouse = Some((mouse.column, mouse.row));
+            app.diff_autoscroll_at = None;
             true
         }
         MouseEventKind::Drag(MouseButton::Left) => {
@@ -2592,6 +2605,7 @@ fn handle_diff_selection(mouse: &MouseEvent, app: &mut App) -> bool {
             if !dragging {
                 return false;
             }
+            app.last_drag_mouse = Some((mouse.column, mouse.row));
             let Some(hit) = app.last_diff_hit.as_ref() else {
                 return true;
             };
@@ -2615,6 +2629,8 @@ fn handle_diff_selection(mouse: &MouseEvent, app: &mut App) -> bool {
                 return false;
             }
             sel.sel.dragging = false;
+            app.last_drag_mouse = None;
+            app.diff_autoscroll_at = None;
             let snap = *sel;
             if !snap.sel.is_empty() {
                 if let Some(hit) = app.last_diff_hit.as_ref() {
@@ -2688,6 +2704,206 @@ fn mouse_to_file_coord(
     let byte_offset = col_to_byte_offset(line, visible_col);
 
     Some((file_line, byte_offset))
+}
+
+// ─── Drag-select auto-scroll ────────────────────────────────────────────────
+//
+// VSCode-style: while the left button is held and the cursor leaves the
+// preview / diff viewport vertically, scroll the view toward the cursor and
+// extend the selection along with it. Terminals don't deliver Drag events
+// when the mouse is idle, so we replay the last known mouse position from
+// `App::tick` and let the scroll edge "pull" the selection.
+//
+// Step size scales gently with distance — at the boundary one line per
+// step, farther out up to four — so a hovering "just outside" reads as
+// smooth and a deliberate "drag way past the panel" feels deliberate.
+// A short throttle keeps a 60Hz tick loop from running away.
+
+/// Number of lines to scroll per step, signed (negative = up). Zero when
+/// the cursor is inside `[content_top, content_bottom)`.
+fn autoscroll_step(mouse_y: u16, content_top: u16, content_bottom: u16) -> i32 {
+    if mouse_y < content_top {
+        let dist = (content_top - mouse_y) as i32;
+        -((1 + dist / 3).min(4))
+    } else if mouse_y >= content_bottom {
+        let dist = (mouse_y - content_bottom + 1) as i32;
+        (1 + dist / 3).min(4)
+    } else {
+        0
+    }
+}
+
+/// Min wall-clock spacing between autoscroll steps. Distance is how far
+/// the cursor sits past the nearest viewport edge — close = slow, far =
+/// fast. The 15ms floor keeps a sustained "drag way off" capped near
+/// 60-some lines/sec even when the tick loop runs at full 60Hz, so the
+/// viewport doesn't slingshot.
+fn autoscroll_interval(distance: u16) -> Duration {
+    let denom = 1 + (distance as u64) / 2;
+    let ms = (90 / denom).max(15);
+    Duration::from_millis(ms)
+}
+
+/// `true` when a tick at `distance` from the viewport edge should be
+/// throttled out — the previous step is still inside its cool-off
+/// window. `None` last_at always passes (first step after Down).
+fn autoscroll_throttled(last_at: Option<Instant>, distance: u16, now: Instant) -> bool {
+    last_at.is_some_and(|at| now.duration_since(at) < autoscroll_interval(distance))
+}
+
+/// Distance (in terminal rows) between `mouse_y` and the viewport edge it
+/// has crossed. 0 when inside the viewport. Used to scale step size and
+/// throttle.
+fn autoscroll_distance(mouse_y: u16, content_top: u16, content_bottom: u16) -> u16 {
+    if mouse_y < content_top {
+        content_top - mouse_y
+    } else if mouse_y >= content_bottom {
+        mouse_y - content_bottom + 1
+    } else {
+        0
+    }
+}
+
+/// Run autoscroll for whichever panel currently owns a dragging selection.
+/// Invoked from `App::tick`. No-op when no drag is active or when the
+/// frozen mouse position sits inside the viewport.
+pub fn tick_drag_autoscroll(app: &mut App) {
+    tick_preview_drag_autoscroll(app);
+    tick_diff_drag_autoscroll(app);
+}
+
+fn tick_preview_drag_autoscroll(app: &mut App) {
+    let dragging = app.preview_selection.is_some_and(|s| s.dragging);
+    if !dragging {
+        return;
+    }
+    let Some(origin) = app.last_preview_content_origin else {
+        return;
+    };
+    let Some((mx, my)) = app.last_drag_mouse else {
+        return;
+    };
+    let view_h = app.last_preview_view_h;
+    if view_h == 0 {
+        return;
+    }
+    let content_top = origin.1;
+    let content_bottom = content_top.saturating_add(view_h);
+    let step = autoscroll_step(my, content_top, content_bottom);
+    if step == 0 {
+        return;
+    }
+
+    // Throttle: skip if the previous step is too recent for the current
+    // distance. First step after Down/edge entry passes immediately
+    // (preview_autoscroll_at cleared on Down / on Up).
+    let now = Instant::now();
+    let dist = autoscroll_distance(my, content_top, content_bottom);
+    if autoscroll_throttled(app.preview_autoscroll_at, dist, now) {
+        return;
+    }
+
+    // Clamp the scroll target to the line count, accounting for the
+    // viewport height (you can't scroll the last line off the top).
+    let Some(preview) = app.preview_content.as_ref() else {
+        return;
+    };
+    let line_count = match &preview.body {
+        crate::file_tree::PreviewBody::Text { lines, .. } => lines.len(),
+        _ => return,
+    };
+    let max_scroll = line_count.saturating_sub(view_h as usize);
+    let new_scroll = if step < 0 {
+        app.preview_scroll
+            .saturating_sub(step.unsigned_abs() as usize)
+    } else {
+        (app.preview_scroll + step as usize).min(max_scroll)
+    };
+    if new_scroll == app.preview_scroll {
+        return;
+    }
+    app.preview_scroll = new_scroll;
+    app.preview_autoscroll_at = Some(now);
+
+    // Re-translate the frozen mouse against the new scroll — this is what
+    // makes the selection extend with the viewport as it scrolls.
+    if let Some(coord) = mouse_to_file_coord(app, mx, my, origin) {
+        if let Some(s) = app.preview_selection.as_mut() {
+            s.active = coord;
+        }
+    }
+}
+
+fn tick_diff_drag_autoscroll(app: &mut App) {
+    let dsel = match app.diff_selection {
+        Some(d) if d.sel.dragging => d,
+        _ => return,
+    };
+    let Some((mx, my)) = app.last_drag_mouse else {
+        return;
+    };
+    let view_h = app.last_diff_view_h;
+    if view_h == 0 {
+        return;
+    }
+    // Snapshot what we need from the cached DiffHit before we take a
+    // mut borrow on the scroll field below.
+    let Some((content_top, rows_len)) = app
+        .last_diff_hit
+        .as_ref()
+        .map(|h| (h.content_y, h.rows.len()))
+    else {
+        return;
+    };
+    if rows_len == 0 {
+        return;
+    }
+    let content_bottom = content_top.saturating_add(view_h);
+    let step = autoscroll_step(my, content_top, content_bottom);
+    if step == 0 {
+        return;
+    }
+
+    let now = Instant::now();
+    let dist = autoscroll_distance(my, content_top, content_bottom);
+    if autoscroll_throttled(app.diff_autoscroll_at, dist, now) {
+        return;
+    }
+
+    // Which scroll field backs the active diff panel — Git tab and Graph
+    // tab keep their own offsets, mirroring `dispatch_vertical_scroll`.
+    let scroll_field: &mut usize = match app.active_tab {
+        Tab::Git => &mut app.diff_scroll,
+        Tab::Graph => &mut app.commit_detail.file_diff_scroll,
+        _ => return,
+    };
+    let max_scroll = rows_len.saturating_sub(view_h as usize);
+    let new_scroll = if step < 0 {
+        scroll_field.saturating_sub(step.unsigned_abs() as usize)
+    } else {
+        (*scroll_field + step as usize).min(max_scroll)
+    };
+    if new_scroll == *scroll_field {
+        return;
+    }
+    *scroll_field = new_scroll;
+    app.diff_autoscroll_at = Some(now);
+
+    // Sync the cached hit's scroll snapshot in place so `coord_for` picks
+    // up the new value this tick — otherwise selection.active lags by a
+    // frame and looks like a stutter against the smooth scroll.
+    if let Some(hit) = app.last_diff_hit.as_mut() {
+        hit.scroll = new_scroll;
+    }
+
+    if let Some(hit) = app.last_diff_hit.as_ref() {
+        let clamped_col = clamp_col_to_side(hit, mx, dsel.side);
+        if let Some(pos) = hit.coord_for(clamped_col, my, dsel.side) {
+            if let Some(s) = app.diff_selection.as_mut() {
+                s.sel.active = pos;
+            }
+        }
+    }
 }
 
 /// `true` when a cursor at `column` lands on the left half of an SBS panel
@@ -3385,6 +3601,102 @@ mod axis_lock_tests {
         // And after the swipe ends, the lock decays within
         // AXIS_LOCK_WINDOW after the final event (285 + 120 = 405).
         assert!(!lock.locked_at(at(410)));
+    }
+}
+
+#[cfg(test)]
+mod autoscroll_tests {
+    use super::*;
+
+    // ── autoscroll_step ─────────────────────────────────────────────────
+
+    #[test]
+    fn step_zero_inside_viewport() {
+        // Viewport rows [10, 30). Mouse comfortably inside.
+        assert_eq!(autoscroll_step(15, 10, 30), 0);
+        assert_eq!(autoscroll_step(10, 10, 30), 0); // top edge inclusive
+        assert_eq!(autoscroll_step(29, 10, 30), 0); // bottom edge inclusive
+    }
+
+    #[test]
+    fn step_one_just_above_top() {
+        // 1 row above the top → minimum step of -1.
+        assert_eq!(autoscroll_step(9, 10, 30), -1);
+    }
+
+    #[test]
+    fn step_one_just_below_bottom() {
+        // content_bottom is exclusive, so row 30 itself is "1 outside".
+        assert_eq!(autoscroll_step(30, 10, 30), 1);
+    }
+
+    #[test]
+    fn step_caps_at_four_far_above() {
+        // Very far above the viewport — distance grows but step caps at 4.
+        assert_eq!(autoscroll_step(0, 100, 130), -4);
+    }
+
+    #[test]
+    fn step_caps_at_four_far_below() {
+        // distance = my - bottom + 1 = 200 - 30 + 1 = 171, step = (1 + 57).min(4) = 4
+        assert_eq!(autoscroll_step(200, 10, 30), 4);
+    }
+
+    #[test]
+    fn step_scales_gently_near_edge() {
+        // dist 3 (mouse_y = top-3): step = -(1 + 3/3).min(4) = -2
+        assert_eq!(autoscroll_step(7, 10, 30), -2);
+        // dist 6: step = -(1 + 6/3).min(4) = -3
+        assert_eq!(autoscroll_step(4, 10, 30), -3);
+        // dist 9: step = -(1 + 9/3).min(4) = -4 (cap)
+        assert_eq!(autoscroll_step(1, 10, 30), -4);
+    }
+
+    // ── autoscroll_distance ─────────────────────────────────────────────
+
+    #[test]
+    fn distance_zero_when_inside() {
+        assert_eq!(autoscroll_distance(15, 10, 30), 0);
+        assert_eq!(autoscroll_distance(10, 10, 30), 0);
+        assert_eq!(autoscroll_distance(29, 10, 30), 0);
+    }
+
+    #[test]
+    fn distance_above_top_counts_rows_up() {
+        assert_eq!(autoscroll_distance(9, 10, 30), 1);
+        assert_eq!(autoscroll_distance(0, 10, 30), 10);
+    }
+
+    #[test]
+    fn distance_below_bottom_counts_rows_down() {
+        // content_bottom = 30 exclusive: row 30 is "1 below".
+        assert_eq!(autoscroll_distance(30, 10, 30), 1);
+        assert_eq!(autoscroll_distance(40, 10, 30), 11);
+    }
+
+    // ── autoscroll_interval ─────────────────────────────────────────────
+
+    #[test]
+    fn interval_at_boundary_is_around_90ms() {
+        // distance 1 → denom = 1 + 0 = 1 → 90 ms.
+        assert_eq!(autoscroll_interval(1), Duration::from_millis(90));
+    }
+
+    #[test]
+    fn interval_shrinks_with_distance() {
+        // distance grows → interval shrinks (faster scroll).
+        let a = autoscroll_interval(1);
+        let b = autoscroll_interval(5);
+        let c = autoscroll_interval(20);
+        assert!(b < a);
+        assert!(c < b);
+    }
+
+    #[test]
+    fn interval_floors_at_15ms() {
+        // Way past the viewport — must not run away faster than 15ms/step.
+        assert_eq!(autoscroll_interval(500), Duration::from_millis(15));
+        assert_eq!(autoscroll_interval(u16::MAX), Duration::from_millis(15));
     }
 }
 

--- a/tests/drag_autoscroll.rs
+++ b/tests/drag_autoscroll.rs
@@ -1,0 +1,483 @@
+//! Integration tests for `tick_drag_autoscroll` — the tick-driven loop
+//! that scrolls the preview / diff viewport (and extends the active
+//! selection) when the user drags past the viewport vertically.
+//!
+//! The pure helpers (step / distance / interval) have their own unit
+//! tests in `src/input.rs`. These tests cover the orchestration: gate
+//! conditions, scroll-field routing, clamp-at-bounds, throttle, and the
+//! `selection.active` refresh that makes the selection appear to "follow"
+//! the autoscroll.
+
+use reef::app::{App, DiffLayout, Tab};
+use reef::file_tree::{PreviewBody, PreviewContent};
+use reef::input::tick_drag_autoscroll;
+use reef::ui::selection::{DiffHit, DiffRowText, DiffSelection, DiffSide, PreviewSelection};
+use reef::ui::theme::Theme;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+use test_support::CwdGuard;
+
+// `App::new` walks the cwd to find a repo. Tests that build an App must
+// own the process cwd for the duration of construction.
+static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+fn fresh_app() -> (App, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+    let app = App::new(Theme::dark(), None);
+    drop(_g);
+    (app, tmp)
+}
+
+fn text_preview(line_count: usize) -> PreviewContent {
+    PreviewContent {
+        file_path: "test.txt".into(),
+        body: PreviewBody::Text {
+            lines: (0..line_count).map(|i| format!("line {}", i)).collect(),
+            highlighted: None,
+        },
+    }
+}
+
+// ── preview ──────────────────────────────────────────────────────────────
+
+#[test]
+fn preview_scrolls_up_and_extends_active_when_mouse_above_viewport() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp) = fresh_app();
+
+    // Viewport: content_y = 5, view_h = 20 → content rows 5..25.
+    // Mouse at row 2 (3 cells above the top). Scroll currently at 30.
+    app.preview_content = Some(text_preview(200));
+    app.preview_scroll = 30;
+    app.last_preview_view_h = 20;
+    app.last_preview_content_origin = Some((0, 5, 0));
+    app.last_drag_mouse = Some((0, 2));
+    app.preview_selection = Some(PreviewSelection {
+        anchor: (50, 0),
+        active: (30, 0),
+        dragging: true,
+    });
+
+    tick_drag_autoscroll(&mut app);
+
+    // dist=3, step=-(1+1)=-2 → scroll moves from 30 to 28.
+    assert_eq!(app.preview_scroll, 28, "scroll up by step magnitude");
+
+    // selection.active follows the scroll — at the new scroll, the
+    // visible row 0 (where the clamped mouse Y lands) maps to file line
+    // = new_scroll = 28.
+    let sel = app.preview_selection.expect("selection retained");
+    assert_eq!(sel.active.0, 28, "active row follows scroll up");
+    assert!(sel.dragging, "still dragging after autoscroll step");
+
+    assert!(
+        app.preview_autoscroll_at.is_some(),
+        "throttle stamp set after a scroll step"
+    );
+}
+
+#[test]
+fn preview_scroll_down_clamps_at_max_scroll() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp) = fresh_app();
+
+    // 30 lines, view_h 20 → max_scroll = 10. Already at scroll=9, view
+    // mouse far below content_bottom (=25): should clamp at 10, not
+    // overshoot.
+    app.preview_content = Some(text_preview(30));
+    app.preview_scroll = 9;
+    app.last_preview_view_h = 20;
+    app.last_preview_content_origin = Some((0, 5, 0));
+    app.last_drag_mouse = Some((0, 200));
+    app.preview_selection = Some(PreviewSelection {
+        anchor: (0, 0),
+        active: (10, 0),
+        dragging: true,
+    });
+
+    tick_drag_autoscroll(&mut app);
+
+    assert_eq!(app.preview_scroll, 10, "clamped at max_scroll");
+}
+
+#[test]
+fn preview_already_at_top_stays_put_with_no_throttle_stamp() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp) = fresh_app();
+
+    app.preview_content = Some(text_preview(200));
+    app.preview_scroll = 0;
+    app.last_preview_view_h = 20;
+    app.last_preview_content_origin = Some((0, 5, 0));
+    app.last_drag_mouse = Some((0, 0)); // way above the viewport
+    app.preview_selection = Some(PreviewSelection {
+        anchor: (5, 0),
+        active: (0, 0),
+        dragging: true,
+    });
+    app.preview_autoscroll_at = None;
+
+    tick_drag_autoscroll(&mut app);
+
+    assert_eq!(app.preview_scroll, 0, "no scroll possible at top");
+    // No-op path → throttle stamp must NOT be set (else the next genuine
+    // step after a clamp would be delayed for no reason).
+    assert!(
+        app.preview_autoscroll_at.is_none(),
+        "throttle untouched when scroll didn't move"
+    );
+}
+
+#[test]
+fn preview_throttle_rejects_second_call_inside_interval() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp) = fresh_app();
+
+    app.preview_content = Some(text_preview(200));
+    app.preview_scroll = 30;
+    app.last_preview_view_h = 20;
+    app.last_preview_content_origin = Some((0, 5, 0));
+    app.last_drag_mouse = Some((0, 4)); // 1 above content_top=5, dist=1
+    app.preview_selection = Some(PreviewSelection {
+        anchor: (50, 0),
+        active: (30, 0),
+        dragging: true,
+    });
+
+    // First call: dist=1 step=-1 → scroll 29, stamp now.
+    tick_drag_autoscroll(&mut app);
+    assert_eq!(app.preview_scroll, 29);
+    let stamp_after_first = app.preview_autoscroll_at;
+    assert!(stamp_after_first.is_some());
+
+    // Immediate second call should be throttled out — at distance 1 the
+    // interval is 90ms, and we're firing back-to-back synchronously.
+    tick_drag_autoscroll(&mut app);
+    assert_eq!(
+        app.preview_scroll, 29,
+        "second call inside throttle is no-op"
+    );
+    assert_eq!(
+        app.preview_autoscroll_at, stamp_after_first,
+        "stamp unchanged"
+    );
+}
+
+#[test]
+fn preview_inside_viewport_does_nothing() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp) = fresh_app();
+
+    app.preview_content = Some(text_preview(200));
+    app.preview_scroll = 30;
+    app.last_preview_view_h = 20;
+    app.last_preview_content_origin = Some((0, 5, 0));
+    app.last_drag_mouse = Some((0, 15)); // squarely inside content area
+    app.preview_selection = Some(PreviewSelection {
+        anchor: (50, 0),
+        active: (40, 0),
+        dragging: true,
+    });
+
+    tick_drag_autoscroll(&mut app);
+
+    assert_eq!(
+        app.preview_scroll, 30,
+        "no scroll when mouse inside viewport"
+    );
+    assert!(app.preview_autoscroll_at.is_none());
+}
+
+#[test]
+fn preview_non_text_body_aborts() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp) = fresh_app();
+
+    // Construct a Binary body (an image picker isn't available in this
+    // test env, so use Binary which doesn't need image decoding).
+    app.preview_content = Some(PreviewContent {
+        file_path: "blob.bin".into(),
+        body: PreviewBody::Binary(reef::file_tree::BinaryInfo {
+            bytes_on_disk: 42,
+            mime: None,
+            reason: reef::file_tree::BinaryReason::NullBytes,
+            meta_line: "x".into(),
+        }),
+    });
+    app.preview_scroll = 30;
+    app.last_preview_view_h = 20;
+    app.last_preview_content_origin = Some((0, 5, 0));
+    app.last_drag_mouse = Some((0, 0));
+    app.preview_selection = Some(PreviewSelection {
+        anchor: (50, 0),
+        active: (30, 0),
+        dragging: true,
+    });
+
+    tick_drag_autoscroll(&mut app);
+
+    // Non-text bodies can't be selected; autoscroll must not pretend
+    // otherwise (would scroll past the cached line index and panic).
+    assert_eq!(app.preview_scroll, 30);
+}
+
+#[test]
+fn preview_no_drag_no_op() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp) = fresh_app();
+
+    app.preview_content = Some(text_preview(200));
+    app.preview_scroll = 30;
+    app.last_preview_view_h = 20;
+    app.last_preview_content_origin = Some((0, 5, 0));
+    app.last_drag_mouse = Some((0, 0));
+    // Selection present but NOT dragging — autoscroll must stay quiet
+    // (this is the "selection still rendered after Up" state).
+    app.preview_selection = Some(PreviewSelection {
+        anchor: (50, 0),
+        active: (30, 0),
+        dragging: false,
+    });
+
+    tick_drag_autoscroll(&mut app);
+
+    assert_eq!(app.preview_scroll, 30);
+}
+
+// ── diff ─────────────────────────────────────────────────────────────────
+
+fn unified_hit(rows: usize, scroll: usize) -> DiffHit {
+    DiffHit {
+        layout: DiffLayout::Unified,
+        content_y: 5,
+        content_x_unified: 0,
+        content_x_left: 0,
+        content_x_right: 0,
+        right_start_x: 0,
+        scroll,
+        h_scroll: 0,
+        sbs_left_h_scroll: 0,
+        sbs_right_h_scroll: 0,
+        rows: (0..rows)
+            .map(|i| DiffRowText::Unified(format!("row {}", i)))
+            .collect(),
+    }
+}
+
+#[test]
+fn diff_git_tab_scrolls_app_diff_scroll() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp) = fresh_app();
+
+    app.active_tab = Tab::Git;
+    app.diff_scroll = 30;
+    app.commit_detail.file_diff_scroll = 999; // bystander, must not move
+    app.last_diff_view_h = 20;
+    app.last_diff_hit = Some(unified_hit(200, 30));
+    app.last_drag_mouse = Some((0, 2));
+    app.diff_selection = Some(DiffSelection {
+        sel: PreviewSelection {
+            anchor: (50, 0),
+            active: (30, 0),
+            dragging: true,
+        },
+        side: DiffSide::Unified,
+    });
+
+    tick_drag_autoscroll(&mut app);
+
+    assert_eq!(app.diff_scroll, 28, "scroll up by step=-2");
+    assert_eq!(
+        app.commit_detail.file_diff_scroll, 999,
+        "graph diff scroll untouched on Git tab"
+    );
+    // Cached hit.scroll synced in place so the next coord_for is accurate.
+    let hit = app.last_diff_hit.as_ref().unwrap();
+    assert_eq!(
+        hit.scroll, 28,
+        "DiffHit scroll synced to new app.diff_scroll"
+    );
+
+    let sel = app.diff_selection.unwrap();
+    assert_eq!(sel.sel.active.0, 28, "active row follows scroll up");
+    assert!(app.diff_autoscroll_at.is_some());
+}
+
+#[test]
+fn diff_graph_tab_routes_to_commit_detail_field() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp) = fresh_app();
+
+    app.active_tab = Tab::Graph;
+    app.diff_scroll = 999; // bystander
+    app.commit_detail.file_diff_scroll = 30;
+    app.last_diff_view_h = 20;
+    app.last_diff_hit = Some(unified_hit(200, 30));
+    app.last_drag_mouse = Some((0, 2));
+    app.diff_selection = Some(DiffSelection {
+        sel: PreviewSelection {
+            anchor: (50, 0),
+            active: (30, 0),
+            dragging: true,
+        },
+        side: DiffSide::Unified,
+    });
+
+    tick_drag_autoscroll(&mut app);
+
+    assert_eq!(
+        app.commit_detail.file_diff_scroll, 28,
+        "graph 3-col diff scroll moved"
+    );
+    assert_eq!(
+        app.diff_scroll, 999,
+        "git-tab scroll untouched on Graph tab"
+    );
+}
+
+#[test]
+fn diff_files_tab_with_stuck_selection_is_safe_noop() {
+    // Defensive: if a diff selection somehow survives a tab switch to
+    // Files (last_diff_rect/hit may also linger from the last render),
+    // autoscroll must not blow up — it just has no scroll field to
+    // mutate.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp) = fresh_app();
+
+    app.active_tab = Tab::Files;
+    app.diff_scroll = 30;
+    app.commit_detail.file_diff_scroll = 30;
+    app.last_diff_view_h = 20;
+    app.last_diff_hit = Some(unified_hit(200, 30));
+    app.last_drag_mouse = Some((0, 2));
+    app.diff_selection = Some(DiffSelection {
+        sel: PreviewSelection {
+            anchor: (50, 0),
+            active: (30, 0),
+            dragging: true,
+        },
+        side: DiffSide::Unified,
+    });
+
+    tick_drag_autoscroll(&mut app);
+
+    assert_eq!(app.diff_scroll, 30);
+    assert_eq!(app.commit_detail.file_diff_scroll, 30);
+}
+
+#[test]
+fn diff_throttle_is_independent_of_preview_throttle() {
+    // The split into preview_autoscroll_at / diff_autoscroll_at exists so
+    // a preview drag step never delays a diff drag step (and vice
+    // versa). Verify by pre-stamping the preview throttle to "now" and
+    // confirming the diff side still fires.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp) = fresh_app();
+
+    app.preview_autoscroll_at = Some(Instant::now());
+    app.diff_autoscroll_at = None;
+
+    app.active_tab = Tab::Git;
+    app.diff_scroll = 30;
+    app.last_diff_view_h = 20;
+    app.last_diff_hit = Some(unified_hit(200, 30));
+    app.last_drag_mouse = Some((0, 2));
+    app.diff_selection = Some(DiffSelection {
+        sel: PreviewSelection {
+            anchor: (50, 0),
+            active: (30, 0),
+            dragging: true,
+        },
+        side: DiffSide::Unified,
+    });
+
+    tick_drag_autoscroll(&mut app);
+
+    assert_eq!(
+        app.diff_scroll, 28,
+        "diff autoscroll runs even though preview throttle is hot"
+    );
+}
+
+#[test]
+fn diff_no_drag_no_op() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp) = fresh_app();
+
+    app.active_tab = Tab::Git;
+    app.diff_scroll = 30;
+    app.last_diff_view_h = 20;
+    app.last_diff_hit = Some(unified_hit(200, 30));
+    app.last_drag_mouse = Some((0, 0));
+    app.diff_selection = Some(DiffSelection {
+        sel: PreviewSelection {
+            anchor: (50, 0),
+            active: (30, 0),
+            dragging: false, // not dragging
+        },
+        side: DiffSide::Unified,
+    });
+
+    tick_drag_autoscroll(&mut app);
+
+    assert_eq!(app.diff_scroll, 30);
+}
+
+#[test]
+fn diff_empty_rows_no_op() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp) = fresh_app();
+
+    app.active_tab = Tab::Git;
+    app.diff_scroll = 0;
+    app.last_diff_view_h = 20;
+    app.last_diff_hit = Some(unified_hit(0, 0)); // empty diff
+    app.last_drag_mouse = Some((0, 0));
+    app.diff_selection = Some(DiffSelection {
+        sel: PreviewSelection {
+            anchor: (0, 0),
+            active: (0, 0),
+            dragging: true,
+        },
+        side: DiffSide::Unified,
+    });
+
+    tick_drag_autoscroll(&mut app);
+
+    assert_eq!(app.diff_scroll, 0);
+}
+
+// ── elapsed throttle ─────────────────────────────────────────────────────
+
+#[test]
+fn preview_throttle_releases_after_interval_elapses() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp) = fresh_app();
+
+    app.preview_content = Some(text_preview(200));
+    app.preview_scroll = 30;
+    app.last_preview_view_h = 20;
+    app.last_preview_content_origin = Some((0, 5, 0));
+    app.last_drag_mouse = Some((0, 4)); // dist=1, interval=90ms
+    app.preview_selection = Some(PreviewSelection {
+        anchor: (50, 0),
+        active: (30, 0),
+        dragging: true,
+    });
+
+    // First step → scrolls + stamps.
+    tick_drag_autoscroll(&mut app);
+    assert_eq!(app.preview_scroll, 29);
+    // Manually backdate the stamp past the interval so we don't have to
+    // sleep in a unit test.
+    app.preview_autoscroll_at = Some(Instant::now() - Duration::from_millis(200));
+
+    // Second step now should pass the throttle.
+    tick_drag_autoscroll(&mut app);
+    assert_eq!(
+        app.preview_scroll, 28,
+        "second step fires after interval elapses"
+    );
+}


### PR DESCRIPTION
## Summary
- 拖拽选中文本时,鼠标越过 preview / diff 视口的上下边后视图会自动滚动,选区跟着延伸——和 VS Code 的体验一致。鼠标停下或松开左键即停。
- 步长按距离边缘 1→4 行渐进,90→15ms 节流,60Hz tick 也不会甩飞;preview 和 diff 各持独立节流 stamp,Up 丢事件时也不会互相干扰。
- 终端在鼠标不动时不会再发 Drag 事件,所以 `App::tick` 每帧重放最后已知的鼠标位置,并把冻结坐标重新翻译成 `(line, byte_offset)` 让 `selection.active` 跟着新 scroll 走。Diff 一侧顺手把 `last_diff_hit.scroll` 同帧同步,避免 active 比滚动滞后一帧产生抖动。

实现入口在 `App::tick` 里调 `crate::input::tick_drag_autoscroll(self)`,新增字段 `last_drag_mouse` + `preview_autoscroll_at` / `diff_autoscroll_at`。Files preview、Search preview、Git diff (Unified + SBS,SBS 沿用既有 side-lock)、Graph 3-col diff 都覆盖。

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features` —— lib 559 + 集成 14 (`tests/drag_autoscroll.rs`) 全过;仅 `fs_watcher_integration` 三例在 main 上同样失败,属本地 macOS 文件监视环境老问题,与本 PR 无关
- [x] `cargo test --workspace --doc`
- [ ] 手动:Files preview 拖拽,鼠标越过上/下边,视图自动滚动 + 选区延伸,松开停止
- [ ] 手动:Git diff Unified 拖拽,同上
- [ ] 手动:Git diff SBS 拖拽,侧锁定按既有行为生效,自动滚动只发生在锚定侧
- [ ] 手动:Graph 3-col diff 拖拽,同上
- [ ] 手动:松开后再拖一次,节流时钟正常重置,首帧立即生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)