### PR TITLE
feat(ui): VSCode-style find widget for preview / diff panels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,6 +2321,7 @@ dependencies = [
  "ratatui-image",
  "reef-proto",
  "reef-sqlite-preview",
+ "regex",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,11 @@ reef-sqlite-preview = { path = "crates/reef-sqlite-preview" }
 # uses; promoting from dev-dep to runtime so `LocalBackend::write_file`
 # can do the same temp+rename dance the agent does.
 tempfile     = "3"
+# Regex matching for the VSCode-style Find widget's `.*` toggle. Stays
+# disabled by default — only used when `find_widget.regex == true` —
+# but the crate is unavoidable once the toggle exists since literal
+# substring matching can't express word boundaries / alternation.
+regex        = "1"
 
 [dev-dependencies]
 insta        = { version = "1", features = ["filters"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -719,6 +719,13 @@ pub struct App {
     /// In-panel vim-style search (`/`, `?`, `n`, `N`). See `crate::search`.
     pub search: crate::search::SearchState,
 
+    /// VSCode-style "Find" widget. Independent of `search` (the vim `/`
+    /// state machine) and mutually exclusive with it — opening either
+    /// clears the other. Floats in the upper-right of the active content
+    /// panel; supports SBS diff (per-side targeting) and Match Case /
+    /// Whole Word / Regex toggles. See `crate::find_widget`.
+    pub find_widget: crate::find_widget::FindWidgetState,
+
     /// VSCode-style quick-open palette. While `active`, input is routed
     /// exclusively to `crate::quick_open::handle_key` (see input.rs).
     pub quick_open: crate::quick_open::QuickOpenState,
@@ -1086,6 +1093,7 @@ impl App {
             pending_edit: None,
             theme,
             search: crate::search::SearchState::default(),
+            find_widget: crate::find_widget::FindWidgetState::default(),
             quick_open: crate::quick_open::QuickOpenState::from_prefs(),
             global_search: crate::global_search::GlobalSearchState::default(),
             hosts_picker: crate::hosts_picker::HostsPickerState::default(),
@@ -4154,6 +4162,11 @@ impl App {
         // 3-col diff column share this state, and tab-switching between
         // them (or to Files/Search) should start fresh.
         self.clear_diff_selection();
+        // The find widget is anchored to whatever content panel was
+        // active when it opened; carrying it across tabs would paint
+        // highlights on rows the user can't see. Close (which also
+        // restores pre-find scroll) before the tab actually changes.
+        crate::find_widget::close(self);
         match tab {
             Tab::Git => self.git_status_load.mark_stale(),
             Tab::Graph => self.graph_load.mark_stale(),
@@ -4371,6 +4384,37 @@ impl App {
             }
             ClickAction::DbGotoPage(page) => {
                 self.db_navigate_to_page(page);
+            }
+            ClickAction::FindWidgetClose => {
+                crate::find_widget::close(self);
+            }
+            ClickAction::FindWidgetNext => {
+                if !self.find_widget.matches.is_empty() {
+                    crate::find_widget::step(self, /*reverse=*/ false);
+                }
+            }
+            ClickAction::FindWidgetPrev => {
+                if !self.find_widget.matches.is_empty() {
+                    crate::find_widget::step(self, /*reverse=*/ true);
+                }
+            }
+            ClickAction::FindWidgetToggleCase => {
+                if self.find_widget.active {
+                    self.find_widget.match_case = !self.find_widget.match_case;
+                    crate::find_widget::recompute(self);
+                }
+            }
+            ClickAction::FindWidgetToggleWord => {
+                if self.find_widget.active {
+                    self.find_widget.whole_word = !self.find_widget.whole_word;
+                    crate::find_widget::recompute(self);
+                }
+            }
+            ClickAction::FindWidgetToggleRegex => {
+                if self.find_widget.active {
+                    self.find_widget.regex = !self.find_widget.regex;
+                    crate::find_widget::recompute(self);
+                }
             }
             ClickAction::SearchToggleReplace => {
                 if self.active_tab == Tab::Search {

--- a/src/find_widget.rs
+++ b/src/find_widget.rs
@@ -1,0 +1,626 @@
+//! VSCode-style "Find" widget for the file-preview and diff panels.
+//!
+//! Independent of the vim-style `/` (`crate::search`). Opened via `Space+F`,
+//! anchored to the upper-right of the active content panel, supports
+//! side-by-side diff (targets one half based on selection side), and
+//! exposes Match Case / Whole Word / Regex toggles.
+//!
+//! Mutual exclusion: opening the widget force-clears `app.search` so there's
+//! exactly one source of match highlights at any time. Opening `/` is
+//! expected to call `find_widget::close` to do the reverse.
+
+use crate::app::App;
+use crate::input;
+use crate::input_edit;
+use crate::search::{
+    self, MatchLoc, Snapshot, center_scroll, find_all, restore_snapshot, take_snapshot,
+};
+use crate::ui::selection::{DiffRowText, DiffSide};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::ops::Range;
+use std::time::Instant;
+
+/// VSCode-style find widget state. Mutually exclusive with `app.search`:
+/// opening either side clears the other so a frame never paints two
+/// match colors over the same rows.
+#[derive(Debug, Default)]
+pub struct FindWidgetState {
+    pub active: bool,
+
+    pub query: String,
+    /// Byte offset into `query`; always on a char boundary.
+    pub cursor: usize,
+
+    pub match_case: bool,
+    pub whole_word: bool,
+    pub regex: bool,
+
+    pub target: Option<FindTarget>,
+    pub matches: Vec<MatchLoc>,
+    pub current: Option<usize>,
+    pub snapshot: Option<Snapshot>,
+
+    /// Cached widget rect for mouse hit-testing.
+    pub last_widget_rect: Option<ratatui::layout::Rect>,
+    /// Mirror leader slot so a second `Space+F` inside the widget toggles
+    /// it off (when the query is empty), same idiom as `quick_open` /
+    /// `global_search`.
+    pub space_leader_at: Option<Instant>,
+    /// `Some(msg)` when the regex toggle is on and the current query
+    /// fails to compile. UI surfaces this in place of the counter.
+    pub regex_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindTarget {
+    FilePreview,
+    DiffUnified,
+    DiffSbsLeft,
+    DiffSbsRight,
+    GraphDiffUnified,
+    GraphDiffSbsLeft,
+    GraphDiffSbsRight,
+}
+
+impl FindWidgetState {
+    /// Ranges of matches on `row` for `target` plus the current-match
+    /// range if it lives on this row. Render-time helper, mirrors
+    /// `SearchState::ranges_on_row`.
+    pub fn ranges_on_row(
+        &self,
+        target: FindTarget,
+        row: usize,
+    ) -> (Vec<Range<usize>>, Option<Range<usize>>) {
+        if self.target != Some(target) || self.matches.is_empty() {
+            return (Vec::new(), None);
+        }
+        let mut all = Vec::new();
+        let mut cur = None;
+        for (i, m) in self.matches.iter().enumerate() {
+            if m.row != row {
+                continue;
+            }
+            if Some(i) == self.current {
+                cur = Some(m.byte_range.clone());
+            }
+            all.push(m.byte_range.clone());
+        }
+        (all, cur)
+    }
+
+    pub fn clear(&mut self) {
+        *self = FindWidgetState::default();
+    }
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/// Open the widget on the active content panel, seeding the query from
+/// the current text selection (file-preview drag-select or diff
+/// drag-select). VSCode `Cmd+F` semantics: prompt stays active, cursor
+/// at query end, matches highlighted, scroll jumped to first hit.
+///
+/// No-op when the active panel has no in-panel find target (e.g. focus
+/// is on the Search tab's left list).
+pub fn begin_with_selection(app: &mut App) {
+    let Some(target) = resolve_target(app) else {
+        return;
+    };
+    // Force-close legacy `/` find first so we don't overlap highlights.
+    app.search.clear();
+    let snapshot = take_snapshot(app);
+    // Preserve the three toggles across re-opens so the user doesn't
+    // lose Aa/ab/.* selections each time they pop the widget.
+    let preserve_match_case = app.find_widget.match_case;
+    let preserve_whole_word = app.find_widget.whole_word;
+    let preserve_regex = app.find_widget.regex;
+    let query = crate::global_search::current_text_selection(app).unwrap_or_default();
+    let cursor = query.len();
+    app.find_widget = FindWidgetState {
+        active: true,
+        query,
+        cursor,
+        match_case: preserve_match_case,
+        whole_word: preserve_whole_word,
+        regex: preserve_regex,
+        target: Some(target),
+        snapshot: Some(snapshot),
+        ..FindWidgetState::default()
+    };
+    recompute(app);
+}
+
+/// Close the widget, restoring pre-find scroll. Idempotent — safe to call
+/// when widget is already inactive.
+pub fn close(app: &mut App) {
+    if let Some(snap) = app.find_widget.snapshot.clone() {
+        restore_snapshot(app, &snap);
+    }
+    app.find_widget.clear();
+}
+
+/// Step to next (`reverse=false`) or previous (`reverse=true`) match.
+/// `Space+G` / `Space+Shift+G` route here. Works regardless of whether
+/// the widget is currently `active` — as long as `matches` is non-empty
+/// and the target is set, navigation is meaningful.
+pub fn step(app: &mut App, reverse: bool) {
+    let state = &mut app.find_widget;
+    if state.matches.is_empty() {
+        return;
+    }
+    let n = state.matches.len();
+    let cur = state.current.unwrap_or(0);
+    let next = if reverse {
+        if cur == 0 { n - 1 } else { cur - 1 }
+    } else if cur + 1 >= n {
+        0
+    } else {
+        cur + 1
+    };
+    state.current = Some(next);
+    jump_to_current(app);
+}
+
+/// Owned-input dispatch while `app.find_widget.active`. Mirrors the
+/// pattern in `search::handle_key_in_search_mode` — every key landing
+/// here either edits one of the inputs, navigates matches, toggles an
+/// option, or closes the widget.
+pub fn handle_key(key: KeyEvent, app: &mut App) {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
+    let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+
+    // In-widget leader chord: a second `Space+F` toggles the widget off
+    // when the query is empty (palette-style isolation).
+    let allow_arm = app.find_widget.query.is_empty();
+    match input::leader_decision(
+        &key,
+        allow_arm,
+        app.find_widget.space_leader_at,
+        Instant::now(),
+        input::LEADER_TIMEOUT,
+    ) {
+        input::LeaderVerdict::Arm => {
+            app.find_widget.space_leader_at = Some(Instant::now());
+            return;
+        }
+        input::LeaderVerdict::Fire => {
+            app.find_widget.space_leader_at = None;
+            // Plain Space+F closes the widget; other chord targets are
+            // swallowed so the palette behaves like other overlays.
+            if key.code == KeyCode::Char('f') && !ctrl && !alt {
+                close(app);
+            }
+            return;
+        }
+        input::LeaderVerdict::Consume => {
+            app.find_widget.space_leader_at = None;
+        }
+        input::LeaderVerdict::None => {}
+    }
+
+    match key.code {
+        KeyCode::Esc => {
+            close(app);
+            return;
+        }
+        KeyCode::Char('c') if ctrl => {
+            close(app);
+            return;
+        }
+        KeyCode::Enter => {
+            // Enter = next match (Shift+Enter = previous), VSCode-style.
+            if !app.find_widget.matches.is_empty() {
+                step(app, /*reverse=*/ shift);
+            }
+            return;
+        }
+        KeyCode::Down => {
+            step(app, /*reverse=*/ false);
+            return;
+        }
+        KeyCode::Up => {
+            step(app, /*reverse=*/ true);
+            return;
+        }
+        // Alt+C / Alt+W / Alt+R are the three toggles. Must match
+        // before `input_edit::dispatch_key`, which binds Alt+B / Alt+F /
+        // Alt+D and would otherwise eat them as word-motion / delete.
+        KeyCode::Char(c) if alt && !ctrl && matches!(c, 'c' | 'C') => {
+            app.find_widget.match_case = !app.find_widget.match_case;
+            recompute(app);
+            return;
+        }
+        KeyCode::Char(c) if alt && !ctrl && matches!(c, 'w' | 'W') => {
+            app.find_widget.whole_word = !app.find_widget.whole_word;
+            recompute(app);
+            return;
+        }
+        KeyCode::Char(c) if alt && !ctrl && matches!(c, 'r' | 'R') => {
+            app.find_widget.regex = !app.find_widget.regex;
+            recompute(app);
+            return;
+        }
+        _ => {}
+    }
+
+    let outcome = input_edit::dispatch_key(
+        &key,
+        &mut app.find_widget.query,
+        &mut app.find_widget.cursor,
+    );
+    if outcome == input_edit::Outcome::Edited {
+        recompute(app);
+    }
+}
+
+// ─── Internals ───────────────────────────────────────────────────────────────
+
+fn resolve_target(app: &App) -> Option<FindTarget> {
+    use crate::app::{Panel, Tab};
+
+    match (app.active_tab, app.active_panel) {
+        (Tab::Files, Panel::Diff) | (Tab::Search, Panel::Diff) => Some(FindTarget::FilePreview),
+        (Tab::Git, Panel::Diff) => Some(diff_target_from_layout(
+            app.diff_layout,
+            app.diff_selection.map(|s| s.side),
+            /*graph=*/ false,
+        )),
+        (Tab::Graph, Panel::Diff) => {
+            if app.graph_uses_three_col() {
+                Some(diff_target_from_layout(
+                    app.diff_layout,
+                    app.diff_selection.map(|s| s.side),
+                    /*graph=*/ true,
+                ))
+            } else {
+                // 2-col Graph view inlines the diff into the Commit
+                // detail panel; no in-panel widget target there yet.
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn diff_target_from_layout(
+    layout: crate::app::DiffLayout,
+    selection_side: Option<DiffSide>,
+    graph: bool,
+) -> FindTarget {
+    use crate::app::DiffLayout;
+    match layout {
+        DiffLayout::Unified => {
+            if graph {
+                FindTarget::GraphDiffUnified
+            } else {
+                FindTarget::DiffUnified
+            }
+        }
+        DiffLayout::SideBySide => match selection_side {
+            Some(DiffSide::SbsLeft) => {
+                if graph {
+                    FindTarget::GraphDiffSbsLeft
+                } else {
+                    FindTarget::DiffSbsLeft
+                }
+            }
+            Some(DiffSide::SbsRight) | Some(DiffSide::Unified) | None => {
+                // No selection / unified-side hint in SBS layout → default
+                // to the right (new code) side. Matches VSCode's "Find in
+                // selection" default of the modified side.
+                if graph {
+                    FindTarget::GraphDiffSbsRight
+                } else {
+                    FindTarget::DiffSbsRight
+                }
+            }
+        },
+    }
+}
+
+fn collect_rows(app: &App, target: FindTarget) -> Vec<String> {
+    match target {
+        FindTarget::FilePreview => match app.preview_content.as_ref().map(|p| &p.body) {
+            Some(crate::file_tree::PreviewBody::Text { lines, .. }) => lines.clone(),
+            _ => Vec::new(),
+        },
+        FindTarget::DiffUnified => match &app.diff_content {
+            Some(d) => search::unified_display_rows(&d.diff),
+            None => Vec::new(),
+        },
+        FindTarget::GraphDiffUnified => match &app.commit_detail.file_diff {
+            Some(d) => search::unified_display_rows(&d.diff),
+            None => Vec::new(),
+        },
+        FindTarget::DiffSbsLeft => match &app.diff_content {
+            Some(d) => sbs_side_rows(&d.diff, DiffSide::SbsLeft),
+            None => Vec::new(),
+        },
+        FindTarget::DiffSbsRight => match &app.diff_content {
+            Some(d) => sbs_side_rows(&d.diff, DiffSide::SbsRight),
+            None => Vec::new(),
+        },
+        FindTarget::GraphDiffSbsLeft => match &app.commit_detail.file_diff {
+            Some(d) => sbs_side_rows(&d.diff, DiffSide::SbsLeft),
+            None => Vec::new(),
+        },
+        FindTarget::GraphDiffSbsRight => match &app.commit_detail.file_diff {
+            Some(d) => sbs_side_rows(&d.diff, DiffSide::SbsRight),
+            None => Vec::new(),
+        },
+    }
+}
+
+fn sbs_side_rows(diff: &crate::git::DiffContent, side: DiffSide) -> Vec<String> {
+    crate::ui::diff_panel::build_sbs_row_texts(diff)
+        .into_iter()
+        .map(|r| match r {
+            DiffRowText::Separator => String::new(),
+            DiffRowText::Header(h) => h,
+            // `build_sbs_row_texts` only ever emits Separator / Header /
+            // Sbs (paired rows), never `Unified` — exhaustive match keeps
+            // the compiler honest if the row enum grows new variants.
+            DiffRowText::Unified(s) => s,
+            DiffRowText::Sbs { left, right } => match side {
+                DiffSide::SbsLeft => left,
+                DiffSide::SbsRight => right,
+                DiffSide::Unified => String::new(),
+            },
+        })
+        .collect()
+}
+
+fn baseline_row(app: &App, target: FindTarget) -> usize {
+    let snap = app.find_widget.snapshot.clone().unwrap_or_default();
+    match target {
+        FindTarget::FilePreview => snap.preview_scroll,
+        FindTarget::DiffUnified | FindTarget::DiffSbsLeft | FindTarget::DiffSbsRight => {
+            snap.diff_scroll
+        }
+        FindTarget::GraphDiffUnified
+        | FindTarget::GraphDiffSbsLeft
+        | FindTarget::GraphDiffSbsRight => snap.graph_diff_scroll,
+    }
+}
+
+fn jump_to_current(app: &mut App) {
+    let Some(cur) = app.find_widget.current else {
+        return;
+    };
+    let Some(m) = app.find_widget.matches.get(cur).cloned() else {
+        return;
+    };
+    let Some(target) = app.find_widget.target else {
+        return;
+    };
+    match target {
+        FindTarget::FilePreview => {
+            let view_h = app.last_preview_view_h as usize;
+            app.preview_scroll = center_scroll(m.row, view_h);
+        }
+        FindTarget::DiffUnified | FindTarget::DiffSbsLeft | FindTarget::DiffSbsRight => {
+            let view_h = app.last_diff_view_h as usize;
+            app.diff_scroll = center_scroll(m.row, view_h);
+        }
+        FindTarget::GraphDiffUnified
+        | FindTarget::GraphDiffSbsLeft
+        | FindTarget::GraphDiffSbsRight => {
+            let view_h = app.last_diff_view_h as usize;
+            app.commit_detail.file_diff_scroll = center_scroll(m.row, view_h);
+        }
+    }
+}
+
+/// Recompute matches for the current query + toggles. Called from:
+///   - `handle_key` after every keystroke that may have edited the query
+///   - `App::handle_action` when a mouse-driven toggle flips
+///   - Integration tests that poke `query` directly and need the match
+///     set rebuilt to reflect the change
+pub fn recompute(app: &mut App) {
+    let Some(target) = app.find_widget.target else {
+        return;
+    };
+    let query = app.find_widget.query.clone();
+
+    if query.is_empty() {
+        app.find_widget.matches.clear();
+        app.find_widget.current = None;
+        app.find_widget.regex_error = None;
+        // Re-apply snapshot scroll so the view rests at the starting
+        // position while the user is mid-edit. Matches the legacy
+        // `/`-prompt feel where deleting back to empty undoes the jump.
+        if let Some(snap) = app.find_widget.snapshot.clone() {
+            restore_snapshot(app, &snap);
+        }
+        return;
+    }
+
+    let opts = MatchOptions {
+        case_sensitive: app.find_widget.match_case,
+        whole_word: app.find_widget.whole_word,
+        regex: app.find_widget.regex,
+    };
+
+    let rows = collect_rows(app, target);
+    let mut matches: Vec<MatchLoc> = Vec::new();
+    let mut regex_error: Option<String> = None;
+    for (idx, text) in rows.iter().enumerate() {
+        match find_all_with(text, &query, &opts) {
+            Ok(rs) => {
+                for r in rs {
+                    matches.push(MatchLoc {
+                        row: idx,
+                        byte_range: r,
+                    });
+                }
+            }
+            Err(e) => {
+                // Regex compile error: surface once and bail — no
+                // partial matches across rows would be useful.
+                regex_error = Some(e.to_string());
+                matches.clear();
+                break;
+            }
+        }
+    }
+
+    app.find_widget.matches = matches;
+    app.find_widget.regex_error = regex_error;
+    app.find_widget.current = pick_current(app, target);
+    jump_to_current(app);
+}
+
+fn pick_current(app: &App, target: FindTarget) -> Option<usize> {
+    if app.find_widget.matches.is_empty() {
+        return None;
+    }
+    let base = baseline_row(app, target);
+    app.find_widget
+        .matches
+        .iter()
+        .position(|m| m.row >= base)
+        .or(Some(0))
+}
+
+// ─── Matching engine ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MatchOptions {
+    pub case_sensitive: bool,
+    pub whole_word: bool,
+    pub regex: bool,
+}
+
+/// All byte-range matches of `needle` in `haystack` honouring the three
+/// VSCode-style toggles. The `regex` toggle uses the standard `regex` crate;
+/// the literal-substring path reuses `search::find_all` and post-filters
+/// whole-word boundaries so CJK haystacks behave predictably.
+pub(crate) fn find_all_with(
+    haystack: &str,
+    needle: &str,
+    opts: &MatchOptions,
+) -> Result<Vec<Range<usize>>, regex::Error> {
+    if needle.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    if opts.regex {
+        let pattern = if opts.whole_word {
+            format!(r"\b(?:{}){}", needle, r"\b")
+        } else {
+            needle.to_string()
+        };
+        let re = regex::RegexBuilder::new(&pattern)
+            .case_insensitive(!opts.case_sensitive)
+            .multi_line(false)
+            .build()?;
+        let mut out = Vec::new();
+        for m in re.find_iter(haystack) {
+            // Zero-width matches (e.g. `(?:)`) can't anchor highlight ranges,
+            // and infinite-looping on them is pointless — skip silently.
+            if m.start() < m.end() {
+                out.push(m.start()..m.end());
+            }
+        }
+        return Ok(out);
+    }
+
+    let case_insensitive = !opts.case_sensitive;
+    let raw = find_all(haystack, needle, case_insensitive);
+    if !opts.whole_word {
+        return Ok(raw);
+    }
+    Ok(raw
+        .into_iter()
+        .filter(|r| is_word_boundary(haystack, r))
+        .collect())
+}
+
+fn is_word_boundary(text: &str, range: &Range<usize>) -> bool {
+    let before_ok = range.start == 0
+        || !text[..range.start]
+            .chars()
+            .next_back()
+            .is_some_and(input_edit::is_word_char);
+    let after_ok = range.end >= text.len()
+        || !text[range.end..]
+            .chars()
+            .next()
+            .is_some_and(input_edit::is_word_char);
+    before_ok && after_ok
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts(case_sensitive: bool, whole_word: bool, regex: bool) -> MatchOptions {
+        MatchOptions {
+            case_sensitive,
+            whole_word,
+            regex,
+        }
+    }
+
+    #[test]
+    fn literal_case_insensitive_by_default() {
+        let r = find_all_with("Foo FOO foo", "foo", &opts(false, false, false)).unwrap();
+        assert_eq!(r, vec![0..3, 4..7, 8..11]);
+    }
+
+    #[test]
+    fn literal_case_sensitive_when_toggled() {
+        let r = find_all_with("Foo FOO foo", "foo", &opts(true, false, false)).unwrap();
+        assert_eq!(r, vec![8..11]);
+    }
+
+    #[test]
+    fn whole_word_rejects_substring_match() {
+        // "food" should not match "foo" with whole_word.
+        let r = find_all_with("food foo foo!", "foo", &opts(false, true, false)).unwrap();
+        assert_eq!(r, vec![5..8, 9..12]);
+    }
+
+    #[test]
+    fn whole_word_at_string_boundaries_passes() {
+        let r = find_all_with("foo", "foo", &opts(false, true, false)).unwrap();
+        assert_eq!(r, vec![0..3]);
+    }
+
+    #[test]
+    fn regex_basic() {
+        let r = find_all_with("a1 b22 c333", r"\d+", &opts(false, false, true)).unwrap();
+        assert_eq!(r, vec![1..2, 4..6, 8..11]);
+    }
+
+    #[test]
+    fn regex_invalid_returns_err() {
+        let r = find_all_with("anything", "(unclosed", &opts(false, false, true));
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn regex_with_whole_word_anchors_boundaries() {
+        let r = find_all_with("foo food foo!", r"foo", &opts(false, true, true)).unwrap();
+        assert_eq!(r, vec![0..3, 9..12]);
+    }
+
+    #[test]
+    fn regex_case_sensitivity_obeys_toggle() {
+        let r_i = find_all_with("Foo foo FOO", r"foo", &opts(false, false, true)).unwrap();
+        let r_s = find_all_with("Foo foo FOO", r"foo", &opts(true, false, true)).unwrap();
+        assert_eq!(r_i, vec![0..3, 4..7, 8..11]);
+        assert_eq!(r_s, vec![4..7]);
+    }
+
+    #[test]
+    fn empty_needle_returns_no_matches() {
+        let r = find_all_with("anything", "", &opts(false, false, false)).unwrap();
+        assert!(r.is_empty());
+        let r = find_all_with("anything", "", &opts(false, false, true)).unwrap();
+        assert!(r.is_empty());
+    }
+}

--- a/src/global_search.rs
+++ b/src/global_search.rs
@@ -336,7 +336,11 @@ pub fn begin(app: &mut App) {
 /// trim leading/trailing whitespace: the global-search prompt is
 /// single-line and feeding it raw indentation produces zero matches
 /// for anything but the first line of a function.
-fn current_text_selection(app: &App) -> Option<String> {
+///
+/// Shared with `search::begin_with_selection` so both entry points
+/// (`Space+F` in-panel find, `Space+Shift+F` global search) interpret
+/// the selection identically.
+pub(crate) fn current_text_selection(app: &App) -> Option<String> {
     if let (Some(sel), Some(preview)) =
         (app.preview_selection.as_ref(), app.preview_content.as_ref())
         && !sel.is_empty()
@@ -358,7 +362,7 @@ fn current_text_selection(app: &App) -> Option<String> {
     None
 }
 
-fn first_nonempty_trimmed_line(s: &str) -> Option<String> {
+pub(crate) fn first_nonempty_trimmed_line(s: &str) -> Option<String> {
     s.lines()
         .map(str::trim)
         .find(|l| !l.is_empty())
@@ -455,10 +459,12 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         }
         crate::input::LeaderVerdict::Fire => {
             app.global_search.space_leader_at = None;
-            // Only close when the follow-up matches OUR chord target (`f`/`F`).
-            // Other chord targets (`p`/`P`) fall through to Consume so Space
-            // inside the palette stays a literal char in those cases.
-            if matches!(key.code, KeyCode::Char('f' | 'F')) && !ctrl && !alt {
+            // Only close when the follow-up matches OUR chord target — the
+            // palette's open chord moved to `Space+Shift+F`, so `Char('F')`
+            // is now the only key that toggles us off. Lower-case `f`
+            // (Space+F) is in-panel find and doesn't belong to this
+            // overlay; other chord targets fall through quietly.
+            if key.code == KeyCode::Char('F') && !ctrl && !alt {
                 app.global_search.active = false;
             }
             return;

--- a/src/input.rs
+++ b/src/input.rs
@@ -8,6 +8,7 @@
 
 use crate::app::{App, DbNav, Panel, Tab, ViewMode};
 use crate::clipboard;
+use crate::find_widget;
 use crate::global_search;
 use crate::i18n::{Msg, t};
 use crate::quick_open;
@@ -74,15 +75,21 @@ pub fn leader_decision(
     // Any chord target character fires the pending leader. The caller
     // inspects `key.code` at Fire time to decide which palette to open,
     // so the verdict itself stays a unit variant.
-    let is_chord_target = matches!(
+    //
+    // Lowercase letters arm on the bare key. Uppercase variants accept
+    // either no modifier (CapsLock-style) or just SHIFT — without the
+    // SHIFT branch most terminals would never deliver a `Space+Shift+F`
+    // chord because crossterm reports the SHIFT modifier alongside the
+    // uppercase char.
+    let is_lower_chord = matches!(
         key.code,
-        KeyCode::Char('p')
-            | KeyCode::Char('P')
-            | KeyCode::Char('f')
-            | KeyCode::Char('F')
-            | KeyCode::Char('h')
-            | KeyCode::Char('H')
+        KeyCode::Char('p') | KeyCode::Char('f') | KeyCode::Char('h')
     ) && key.modifiers.is_empty();
+    let is_upper_chord = matches!(
+        key.code,
+        KeyCode::Char('P') | KeyCode::Char('F') | KeyCode::Char('H')
+    ) && (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT);
+    let is_chord_target = is_lower_chord || is_upper_chord;
 
     // Fresh-arm path: no leader pending, space pressed, context allows.
     if allow_arm && leader_at.is_none() && is_bare_space {
@@ -122,6 +129,15 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
     // as the other overlays.
     if app.hosts_picker.active {
         handle_key_hosts_picker(key, app);
+        return;
+    }
+
+    // VSCode-style find widget — fully owns input while active. Sits
+    // above the global-search palette because the widget is opened by
+    // a Space leader chord (`Space+F`) and is the most-recently-opened
+    // overlay; routing should land here before any persistent palette.
+    if app.find_widget.active {
+        find_widget::handle_key(key, app);
         return;
     }
 
@@ -283,7 +299,13 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
             app.global_search.active = false;
             match key.code {
                 KeyCode::Char('p') | KeyCode::Char('P') => quick_open::begin(app),
-                KeyCode::Char('f') | KeyCode::Char('F') => global_search::begin(app),
+                // Space+F = VSCode-style find widget (selection-seeded,
+                // floating in the active content panel's upper-right).
+                // Space+Shift+F = global ripgrep search (VSCode
+                // Cmd+Shift+F). Case differentiation makes these distinct
+                // entry points.
+                KeyCode::Char('f') => find_widget::begin_with_selection(app),
+                KeyCode::Char('F') => global_search::begin(app),
                 KeyCode::Char('h') | KeyCode::Char('H') => {
                     // Open Tab::Search with the replace input pre-expanded
                     // and focused. Mirrors VSCode's Ctrl+Shift+H — the
@@ -2174,6 +2196,32 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
     // (The fallthrough-close region is registered by the menu renderer
     // underneath the menu panel, so it goes through handle_action.)
 
+    // Find widget mouse intercept: when the user clicks a widget hit
+    // zone (close `×`, prev/next arrows, Aa/ab/.* toggles), route
+    // straight to `handle_action` BEFORE the preview/diff drag-select
+    // fast-paths grab the Down event. Without this, every widget click
+    // would silently start a text selection on the panel underneath.
+    //
+    // Non-widget clicks fall through — the widget is non-modal for
+    // mouse, matching VSCode's behavior where clicking outside the
+    // find widget doesn't dismiss it but does interact with the editor.
+    if app.find_widget.active
+        && let MouseEventKind::Down(MouseButton::Left) = mouse.kind
+        && let Some(action) = app.hit_registry.hit_test(mouse.column, mouse.row)
+        && matches!(
+            action,
+            ui::mouse::ClickAction::FindWidgetClose
+                | ui::mouse::ClickAction::FindWidgetNext
+                | ui::mouse::ClickAction::FindWidgetPrev
+                | ui::mouse::ClickAction::FindWidgetToggleCase
+                | ui::mouse::ClickAction::FindWidgetToggleWord
+                | ui::mouse::ClickAction::FindWidgetToggleRegex
+        )
+    {
+        app.handle_action(action);
+        return;
+    }
+
     // Preview drag-selection fast-path. Owns Down/Drag/Up(Left) when the
     // gesture starts inside the preview panel. Scroll wheel, right-click,
     // and Down outside the panel fall through to the normal match below.
@@ -3866,6 +3914,34 @@ mod leader_tests {
         let f = ke(KeyCode::Char('F'), KeyModifiers::empty());
         let v = leader_decision(&f, true, Some(now), now, LEADER_TIMEOUT);
         assert_eq!(v, LeaderVerdict::Fire);
+    }
+
+    #[test]
+    fn shift_uppercase_f_after_arm_fires_for_global_search() {
+        // Most terminals report SHIFT alongside the uppercase char. The
+        // upper-case chord branch must accept SHIFT, otherwise
+        // `Space+Shift+F` (the global-search chord) is unreachable on
+        // those terminals.
+        let now = Instant::now();
+        let shift_f = ke(KeyCode::Char('F'), KeyModifiers::SHIFT);
+        let v = leader_decision(&shift_f, true, Some(now), now, LEADER_TIMEOUT);
+        assert_eq!(v, LeaderVerdict::Fire);
+    }
+
+    #[test]
+    fn g_is_not_a_chord_target_and_consumes_leader() {
+        // `g` / `G` used to step the find widget; the chord was removed.
+        // Make sure no future commit re-adds it without updating intent —
+        // and make sure today's behavior is "consume the leader, drop the
+        // key" rather than "fire something stale".
+        let now = Instant::now();
+        let g = ke(KeyCode::Char('g'), KeyModifiers::empty());
+        let v = leader_decision(&g, true, Some(now), now, LEADER_TIMEOUT);
+        assert_eq!(v, LeaderVerdict::Consume);
+
+        let shift_g = ke(KeyCode::Char('G'), KeyModifiers::SHIFT);
+        let v = leader_decision(&shift_g, true, Some(now), now, LEADER_TIMEOUT);
+        assert_eq!(v, LeaderVerdict::Consume);
     }
 
     #[test]

--- a/src/input_edit.rs
+++ b/src/input_edit.rs
@@ -181,7 +181,7 @@ pub fn delete_word_backward(text: &mut String, cursor: &mut usize) {
     *cursor = start;
 }
 
-fn is_word_char(c: char) -> bool {
+pub(crate) fn is_word_char(c: char) -> bool {
     c.is_alphanumeric() || c == '_'
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod editor;
 pub mod file_clipboard;
 pub mod file_selection;
 pub mod file_tree;
+pub mod find_widget;
 pub mod fs_watcher;
 pub mod git;
 pub mod global_search;

--- a/src/search.rs
+++ b/src/search.rs
@@ -419,13 +419,13 @@ pub(crate) fn unified_display_rows(diff: &crate::git::DiffContent) -> Vec<String
 
 // ─── Matching ─────────────────────────────────────────────────────────────────
 
-fn smart_case(query: &str) -> bool {
+pub(crate) fn smart_case(query: &str) -> bool {
     query.chars().all(|c| !c.is_uppercase())
 }
 
 /// All byte-range matches of `needle` in `haystack`, non-overlapping, with
 /// smart-case folding. Needle must be non-empty.
-fn find_all(haystack: &str, needle: &str, case_insensitive: bool) -> Vec<Range<usize>> {
+pub(crate) fn find_all(haystack: &str, needle: &str, case_insensitive: bool) -> Vec<Range<usize>> {
     if needle.is_empty() {
         return Vec::new();
     }
@@ -529,7 +529,7 @@ fn baseline_row(target: SearchTarget, snap: &Snapshot) -> usize {
 
 // ─── Snapshot / restore ───────────────────────────────────────────────────────
 
-fn take_snapshot(app: &App) -> Snapshot {
+pub(crate) fn take_snapshot(app: &App) -> Snapshot {
     Snapshot {
         preview_scroll: app.preview_scroll,
         preview_h_scroll: app.preview_h_scroll,
@@ -546,7 +546,7 @@ fn take_snapshot(app: &App) -> Snapshot {
     }
 }
 
-fn restore_snapshot(app: &mut App, snap: &Snapshot) {
+pub(crate) fn restore_snapshot(app: &mut App, snap: &Snapshot) {
     app.preview_scroll = snap.preview_scroll;
     app.preview_h_scroll = snap.preview_h_scroll;
     app.diff_scroll = snap.diff_scroll;

--- a/src/ui/diff_panel.rs
+++ b/src/ui/diff_panel.rs
@@ -1,4 +1,5 @@
 use crate::app::{App, DiffHighlighted, DiffLayout, DiffMode, LineTokens};
+use crate::find_widget::{FindTarget, FindWidgetState};
 use crate::git::{DiffContent, DiffHunk, LineTag};
 use crate::i18n::{Msg, t};
 use crate::search::{SearchState, SearchTarget};
@@ -58,6 +59,8 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
         app.theme,
         &app.search,
         SearchTarget::Diff,
+        &app.find_widget,
+        FindTarget::DiffUnified,
         selection.as_ref(),
         &mut DiffView {
             scroll: &mut app.diff_scroll,
@@ -89,6 +92,8 @@ pub fn render_diff(
     theme: Theme,
     search: &SearchState,
     search_target: SearchTarget,
+    find_widget: &FindWidgetState,
+    widget_unified_target: FindTarget,
     selection: Option<&DiffSelection>,
     view: &mut DiffView<'_>,
     hit_slot: &mut Option<DiffHit>,
@@ -103,6 +108,8 @@ pub fn render_diff(
             theme,
             search,
             search_target,
+            find_widget,
+            widget_unified_target,
             selection,
             view,
             hit_slot,
@@ -116,10 +123,44 @@ pub fn render_diff(
             theme,
             search,
             search_target,
+            find_widget,
+            widget_unified_target,
             selection,
             view,
             hit_slot,
         ),
+    }
+}
+
+/// Pick which match source owns the highlight overlay for a given row.
+/// Find widget and `/` are mutually exclusive (either side clears the
+/// other on open) so this is a strict "widget if its target matches,
+/// else search" lookup — no merging.
+fn unified_match_ranges_for(
+    row: usize,
+    search: &SearchState,
+    search_target: SearchTarget,
+    widget: &FindWidgetState,
+    widget_target: FindTarget,
+) -> (Vec<Range<usize>>, Option<Range<usize>>) {
+    if widget.target == Some(widget_target) {
+        widget.ranges_on_row(widget_target, row)
+    } else {
+        search.ranges_on_row(search_target, row)
+    }
+}
+
+/// Side-aware target derivation for SBS rendering. Callers pass the
+/// unified variant (`DiffUnified` / `GraphDiffUnified`) and we derive
+/// the corresponding SBS side targets.
+fn sbs_side_targets(unified: FindTarget) -> (FindTarget, FindTarget) {
+    match unified {
+        FindTarget::GraphDiffUnified
+        | FindTarget::GraphDiffSbsLeft
+        | FindTarget::GraphDiffSbsRight => {
+            (FindTarget::GraphDiffSbsLeft, FindTarget::GraphDiffSbsRight)
+        }
+        _ => (FindTarget::DiffSbsLeft, FindTarget::DiffSbsRight),
     }
 }
 
@@ -148,6 +189,8 @@ fn render_unified(
     theme: Theme,
     search: &SearchState,
     search_target: SearchTarget,
+    find_widget: &FindWidgetState,
+    widget_unified_target: FindTarget,
     selection: Option<&DiffSelection>,
     view: &mut DiffView<'_>,
     hit_slot: &mut Option<DiffHit>,
@@ -252,9 +295,16 @@ fn render_unified(
             break;
         }
         let row_idx = scroll + offset;
-        // `collect_rows(Diff)` in `search.rs` uses the exact same
-        // `UnifiedLine` order, so row_idx matches 1:1 with match row indices.
-        let (ranges, cur) = search.ranges_on_row(search_target, row_idx);
+        // `collect_rows(Diff)` in `search.rs` and `find_widget::collect_rows`
+        // for unified targets both use the same `UnifiedLine` order, so
+        // `row_idx` is 1:1 with match row indices on both sides.
+        let (ranges, cur) = unified_match_ranges_for(
+            row_idx,
+            search,
+            search_target,
+            find_widget,
+            widget_unified_target,
+        );
         let sel_range = selection
             .filter(|s| s.side == DiffSide::Unified)
             .and_then(|s| {
@@ -426,6 +476,33 @@ enum SbsDisplayLine {
     Row(SbsRow),
 }
 
+/// Flatten an entire diff into the SBS row layout used by `render_side_by_side`.
+/// Row indices in the returned vec line up 1:1 with `diff_scroll` in SBS mode,
+/// so match positions found by `find_widget` can be jump-targeted by setting
+/// `diff_scroll` directly.
+///
+/// Returns text-only `DiffRowText` entries (no tokens / line numbers); the
+/// find widget only needs the per-side string per row to run its matcher.
+pub(crate) fn build_sbs_row_texts(diff: &DiffContent) -> Vec<DiffRowText> {
+    let mut out: Vec<DiffRowText> = Vec::new();
+    for (hi, hunk) in diff.hunks.iter().enumerate() {
+        if hi > 0 {
+            out.push(DiffRowText::Separator);
+        }
+        for line in build_sbs_lines(hunk, None) {
+            match line {
+                SbsDisplayLine::Separator => out.push(DiffRowText::Separator),
+                SbsDisplayLine::HunkHeader(h) => out.push(DiffRowText::Header(h)),
+                SbsDisplayLine::Row(row) => out.push(DiffRowText::Sbs {
+                    left: row.left_text,
+                    right: row.right_text,
+                }),
+            }
+        }
+    }
+    out
+}
+
 fn build_sbs_lines(hunk: &DiffHunk, hunk_tokens: Option<&Vec<LineTokens>>) -> Vec<SbsDisplayLine> {
     let mut rows: Vec<SbsDisplayLine> = Vec::new();
     // Carry tokens alongside each pending removal so a later Added pairing
@@ -526,6 +603,8 @@ fn render_side_by_side(
     theme: Theme,
     search: &SearchState,
     _search_target: SearchTarget,
+    find_widget: &FindWidgetState,
+    widget_unified_target: FindTarget,
     selection: Option<&DiffSelection>,
     view: &mut DiffView<'_>,
     hit_slot: &mut Option<DiffHit>,
@@ -543,13 +622,16 @@ fn render_side_by_side(
         &mut y,
         max_y,
     );
-    // TODO(search-sbs): SBS layout doesn't overlay `/` match highlights
-    // on its rows — only Unified does. Row index inside `build_sbs_lines`
-    // diverges from `unified_display_rows` (it pairs Removed/Added into
-    // single rows), so wiring search in needs a parallel row collector
-    // before the renderer can light up matches. `search` is threaded
-    // through to keep the signature honest once that lands.
+    // The legacy `/` (`SearchState`) doesn't currently expose a SBS row
+    // collector — `collect_rows(SearchTarget::Diff)` only walks unified
+    // rows. The find widget *does*, via its `DiffSbsLeft` / `DiffSbsRight`
+    // targets, and the two state machines are mutually exclusive (open
+    // either side and the other clears). So SBS highlights flow only
+    // through `find_widget` here; `search` stays bound to keep the
+    // signature symmetric with `render_unified` for future work that
+    // wires `/` into SBS.
     let _ = search;
+    let (widget_left_target, widget_right_target) = sbs_side_targets(widget_unified_target);
 
     // Build all display lines
     let mut all_lines: Vec<SbsDisplayLine> = Vec::new();
@@ -665,6 +747,12 @@ fn render_side_by_side(
             },
             None => (None, None),
         };
+        // Per-side widget-match ranges. `ranges_on_row` filters by
+        // `widget.target`, so at most one side returns a non-empty vec
+        // — they can't double-paint.
+        let (match_left, match_left_cur) = find_widget.ranges_on_row(widget_left_target, row_idx);
+        let (match_right, match_right_cur) =
+            find_widget.ranges_on_row(widget_right_target, row_idx);
         match dl {
             SbsDisplayLine::Separator => {
                 let line = Line::from(Span::styled(
@@ -678,22 +766,72 @@ fn render_side_by_side(
                 f.render_widget(line, Rect::new(area.x, y, area.width, 1));
             }
             SbsDisplayLine::HunkHeader(header) => {
-                let line = Line::from(Span::styled(
-                    format!(" {}", header),
-                    Style::default()
-                        .fg(theme.accent)
-                        .add_modifier(Modifier::DIM),
-                ));
-                f.render_widget(line, Rect::new(area.x, y, area.width, 1));
+                // The widget can target headers too (e.g. searching `@@`).
+                // For SBS, the header is shared across sides; combine left
+                // + right ranges (one of them is always empty) and paint
+                // a single overlay.
+                let combined: Vec<Range<usize>> = match_left
+                    .iter()
+                    .chain(match_right.iter())
+                    .cloned()
+                    .collect();
+                let combined_cur = match_left_cur.clone().or(match_right_cur.clone());
+                let base = Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::DIM);
+                let tokens = if combined.is_empty() {
+                    vec![(base, header.clone())]
+                } else {
+                    overlay_match_highlight(
+                        vec![(base, header.clone())],
+                        &combined,
+                        combined_cur,
+                        theme.search_match,
+                        theme.search_current,
+                    )
+                };
+                let prefix = Span::styled(" ", base);
+                let mut spans = vec![prefix];
+                for (style, text) in tokens {
+                    spans.push(Span::styled(text, style));
+                }
+                f.render_widget(Line::from(spans), Rect::new(area.x, y, area.width, 1));
             }
             SbsDisplayLine::Row(row) => {
                 render_sbs_row(
-                    f, area, y, row, half_w, right_w, h_left, h_right, &theme, sel_left, sel_right,
+                    f,
+                    area,
+                    y,
+                    row,
+                    half_w,
+                    right_w,
+                    h_left,
+                    h_right,
+                    &theme,
+                    SideOverlays {
+                        selection: sel_left,
+                        match_ranges: &match_left,
+                        match_current: match_left_cur.clone(),
+                    },
+                    SideOverlays {
+                        selection: sel_right,
+                        match_ranges: &match_right,
+                        match_current: match_right_cur.clone(),
+                    },
                 );
             }
         }
         y += 1;
     }
+}
+
+/// Per-side overlay payload for `render_sbs_row`. Bundles the row-scoped
+/// selection range and search-match ranges so the renderer's signature
+/// stays compact even with multiple highlight sources.
+pub(crate) struct SideOverlays<'a> {
+    pub selection: Option<Range<usize>>,
+    pub match_ranges: &'a [Range<usize>],
+    pub match_current: Option<Range<usize>>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -707,8 +845,8 @@ fn render_sbs_row(
     h_scroll_left: usize,
     h_scroll_right: usize,
     theme: &Theme,
-    sel_left: Option<Range<usize>>,
-    sel_right: Option<Range<usize>>,
+    left: SideOverlays<'_>,
+    right: SideOverlays<'_>,
 ) {
     // Gutter: " XXXXX " = 7 cols
     let gutter = 7usize;
@@ -719,7 +857,20 @@ fn render_sbs_row(
     let left_no = fmt_lineno(row.left_no);
     let left_body =
         build_sbs_body_tokens(&row.left_text, row.left_tokens.as_ref(), left_fg, left_bg);
-    let left_body = match sel_left {
+    // Search-match highlight first (so the drag-selection's REVERSED
+    // modifier composes on top, mirroring `render_unified_line`).
+    let left_body = if left.match_ranges.is_empty() {
+        left_body
+    } else {
+        overlay_match_highlight(
+            left_body,
+            left.match_ranges,
+            left.match_current,
+            theme.search_match,
+            theme.search_current,
+        )
+    };
+    let left_body = match left.selection {
         Some(r) if r.start < r.end => overlay_selection_highlight(left_body, r),
         _ => left_body,
     };
@@ -756,7 +907,18 @@ fn render_sbs_row(
         right_fg,
         right_bg,
     );
-    let right_body = match sel_right {
+    let right_body = if right.match_ranges.is_empty() {
+        right_body
+    } else {
+        overlay_match_highlight(
+            right_body,
+            right.match_ranges,
+            right.match_current,
+            theme.search_match,
+            theme.search_current,
+        )
+    };
+    let right_body = match right.selection {
         Some(r) if r.start < r.end => overlay_selection_highlight(right_body, r),
         _ => right_body,
     };

--- a/src/ui/file_preview_panel.rs
+++ b/src/ui/file_preview_panel.rs
@@ -1,5 +1,6 @@
 use crate::app::App;
 use crate::file_tree::{BinaryInfo, BinaryReason, ImagePreview, PreviewBody, PreviewContent};
+use crate::find_widget::FindTarget;
 use crate::i18n::{Msg, t};
 use crate::search::SearchTarget;
 use crate::ui::focus::header_title_style;
@@ -395,9 +396,16 @@ fn render_text(f: &mut Frame, app: &mut App, area: Rect, preview: &PreviewConten
                 Some(tokens) => tokens.clone(),
                 None => vec![(Style::default().fg(th.fg_primary), line.clone())],
             };
-        let (mut ranges, mut cur) = app
-            .search
-            .ranges_on_row(SearchTarget::FilePreview, real_idx);
+        // Find widget owns highlights when it targets the preview; the
+        // legacy `/` search is mutually exclusive (either side clears
+        // the other on open), so the order is "widget else search".
+        let (mut ranges, mut cur) = if app.find_widget.target == Some(FindTarget::FilePreview) {
+            app.find_widget
+                .ranges_on_row(FindTarget::FilePreview, real_idx)
+        } else {
+            app.search
+                .ranges_on_row(SearchTarget::FilePreview, real_idx)
+        };
         // `global_search::accept` stashes a single-row highlight at the
         // matching line so we can light it up once the async preview lands.
         // Applied alongside the `/` search ranges using the same overlay

--- a/src/ui/find_widget_panel.rs
+++ b/src/ui/find_widget_panel.rs
@@ -1,0 +1,404 @@
+//! VSCode-style floating find widget. Anchored to the upper-right of
+//! the active content panel (`app.last_preview_rect` for Files / Search
+//! tabs, `app.last_diff_rect` for Git / Graph tabs). Renders as a flat
+//! solid-color slab — no border, just `chrome_active_bg` filled across
+//! a top pad row + content row + bottom pad row — so it reads as an
+//! inset toolbar with breathing room rather than a framed modal.
+//!
+//! Hover affordances: while the widget is open, the `app.hover_col` /
+//! `app.hover_row` slots fed by `MouseEventKind::Moved` light up the
+//! cell under the cursor so the user can see exactly what the next
+//! click will hit.
+//!
+//! PR A renders only the find row (no Replace expansion); the chevron
+//! and replace input row are reserved for PR B.
+
+use crate::app::App;
+use crate::find_widget::{FindTarget, FindWidgetState};
+use crate::ui::mouse::ClickAction;
+use crate::ui::theme::Theme;
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Clear;
+use unicode_width::UnicodeWidthStr;
+
+/// Target visible width of the widget. Caller clamps against the anchor
+/// panel; very narrow panels degrade gracefully (toggles + counter still
+/// fit at 36 cols, the query area becomes a small editor).
+const TARGET_WIDTH: u16 = 64;
+const MIN_WIDTH: u16 = 36;
+/// Total visible height: top blank pad + content row + bottom blank pad.
+const WIDGET_HEIGHT: u16 = 3;
+/// Horizontal padding inside the chip — keeps glyphs from sitting
+/// flush against the painted edges.
+const H_PAD: u16 = 2;
+
+const TOGGLE_LEN: u16 = 4; // " Aa " etc.
+const BUTTON_LEN: u16 = 3; // " ↑ "
+const COUNTER_LEN: u16 = 11; // " 1234/1234 "
+
+pub fn render(f: &mut Frame, app: &mut App) {
+    if !app.find_widget.active {
+        return;
+    }
+    let Some(target) = app.find_widget.target else {
+        return;
+    };
+    // Pick the anchor rect from whichever content panel hosts the
+    // widget's target. Falling through with `None` is the right call
+    // for transient states (tab mid-switch) — the widget will simply
+    // not draw this frame.
+    let anchor = match target {
+        FindTarget::FilePreview => app.last_preview_rect,
+        FindTarget::DiffUnified
+        | FindTarget::DiffSbsLeft
+        | FindTarget::DiffSbsRight
+        | FindTarget::GraphDiffUnified
+        | FindTarget::GraphDiffSbsLeft
+        | FindTarget::GraphDiffSbsRight => app.last_diff_rect,
+    };
+    let Some(anchor) = anchor else {
+        return;
+    };
+    if anchor.width < MIN_WIDTH || anchor.height < WIDGET_HEIGHT {
+        return;
+    }
+
+    let width = TARGET_WIDTH.min(anchor.width).max(MIN_WIDTH);
+    // Right-anchor flush to the panel's right edge.
+    let x = anchor.x + anchor.width.saturating_sub(width);
+    let y = anchor.y;
+    let rect = Rect::new(x, y, width, WIDGET_HEIGHT);
+    app.find_widget.last_widget_rect = Some(rect);
+
+    let th = app.theme;
+    let chip_bg = th.chrome_active_bg;
+
+    // Wipe glyphs behind the widget so the underlying panel doesn't
+    // bleed through. No border — just a flat solid-color slab spanning
+    // top pad / content / bottom pad rows.
+    f.render_widget(Clear, rect);
+    let fill_style = Style::default().bg(chip_bg);
+    let fill = " ".repeat(width as usize);
+    for row_y in y..y + WIDGET_HEIGHT {
+        f.render_widget(
+            Line::from(Span::styled(fill.clone(), fill_style)),
+            Rect::new(x, row_y, width, 1),
+        );
+    }
+
+    // Content sits on the middle row; outer rows are pure padding.
+    let content_y = y + 1;
+    render_find_row(f, app, &th, rect, content_y);
+}
+
+fn render_find_row(f: &mut Frame, app: &mut App, th: &Theme, area: Rect, content_y: u16) {
+    let usable_x = area.x + H_PAD;
+    let usable_end = area.x + area.width - H_PAD;
+
+    // Right-to-left allocation: the buttons and counter are fixed-width;
+    // the query input absorbs whatever's left after them.
+    let close_x = usable_end - BUTTON_LEN;
+    let down_x = close_x - BUTTON_LEN;
+    let up_x = down_x - BUTTON_LEN;
+    let counter_x = up_x.saturating_sub(COUNTER_LEN);
+    let regex_x = counter_x.saturating_sub(TOGGLE_LEN);
+    let word_x = regex_x.saturating_sub(TOGGLE_LEN);
+    let case_x = word_x.saturating_sub(TOGGLE_LEN);
+    let query_x = usable_x;
+    let query_w = case_x.saturating_sub(query_x).saturating_sub(1);
+
+    // ─── Query input ───
+    let query_text = visible_query_text(
+        &app.find_widget.query,
+        app.find_widget.cursor,
+        query_w as usize,
+    );
+    let query_style = Style::default()
+        .fg(th.chrome_active_fg)
+        .bg(th.chrome_active_bg);
+    let placeholder_style = Style::default()
+        .fg(th.chrome_muted_fg)
+        .bg(th.chrome_active_bg)
+        .add_modifier(Modifier::ITALIC);
+    let query_span = if app.find_widget.query.is_empty() {
+        Span::styled(
+            format!("{:<w$}", "Find", w = query_w as usize),
+            placeholder_style,
+        )
+    } else {
+        Span::styled(
+            format!("{:<w$}", query_text, w = query_w as usize),
+            query_style,
+        )
+    };
+    f.render_widget(
+        Line::from(query_span),
+        Rect::new(query_x, content_y, query_w, 1),
+    );
+
+    // Cursor lands at column = display width of query[..cursor]
+    let cursor_col = UnicodeWidthStr::width(
+        &app.find_widget.query[..app.find_widget.cursor.min(app.find_widget.query.len())],
+    ) as u16;
+    let cursor_x_actual = query_x + cursor_col.min(query_w.saturating_sub(1));
+    f.set_cursor_position((cursor_x_actual, content_y));
+
+    let hover = (app.hover_col, app.hover_row);
+
+    let toggles: [(&str, u16, bool, ClickAction); 3] = [
+        (
+            "Aa",
+            case_x,
+            app.find_widget.match_case,
+            ClickAction::FindWidgetToggleCase,
+        ),
+        (
+            "ab",
+            word_x,
+            app.find_widget.whole_word,
+            ClickAction::FindWidgetToggleWord,
+        ),
+        (
+            ".*",
+            regex_x,
+            app.find_widget.regex,
+            ClickAction::FindWidgetToggleRegex,
+        ),
+    ];
+    let buttons: [(&str, u16, ClickAction); 3] = [
+        (" ↑ ", up_x, ClickAction::FindWidgetPrev),
+        (" ↓ ", down_x, ClickAction::FindWidgetNext),
+        (" × ", close_x, ClickAction::FindWidgetClose),
+    ];
+
+    for (label, x, on, _) in &toggles {
+        paint_toggle(
+            f,
+            th,
+            label,
+            *x,
+            content_y,
+            *on,
+            hover_in(hover, *x, content_y, TOGGLE_LEN),
+        );
+    }
+
+    let counter_text = match &app.find_widget.regex_error {
+        Some(_) => " regex! ".to_string(),
+        None => format_counter(&app.find_widget),
+    };
+    let counter_padded = format!("{:^w$}", counter_text, w = COUNTER_LEN as usize);
+    let counter_fg = if app.find_widget.regex_error.is_some() {
+        th.removed_accent
+    } else if app.find_widget.matches.is_empty() {
+        th.chrome_muted_fg
+    } else {
+        th.chrome_active_fg
+    };
+    f.render_widget(
+        Line::from(Span::styled(
+            counter_padded,
+            Style::default().fg(counter_fg).bg(th.chrome_active_bg),
+        )),
+        Rect::new(counter_x, content_y, COUNTER_LEN, 1),
+    );
+
+    for (glyph, x, _) in &buttons {
+        paint_button(
+            f,
+            th,
+            glyph,
+            *x,
+            content_y,
+            hover_in(hover, *x, content_y, BUTTON_LEN),
+        );
+    }
+
+    let registry = &mut app.hit_registry;
+    for (_, x, _, action) in &toggles {
+        registry.register_row(*x, content_y, TOGGLE_LEN, action.clone());
+    }
+    for (_, x, action) in &buttons {
+        registry.register_row(*x, content_y, BUTTON_LEN, action.clone());
+    }
+}
+
+/// Mouse-hover hit test for a single-row strip starting at `(x, y)` with
+/// the given width. `app.hover_col / hover_row` are the last MouseMoved
+/// position; missing values just return false (no hover indication).
+fn hover_in(hover: (Option<u16>, Option<u16>), x: u16, y: u16, width: u16) -> bool {
+    matches!(hover, (Some(c), Some(r)) if r == y && c >= x && c < x + width)
+}
+
+fn paint_toggle(f: &mut Frame, th: &Theme, label: &str, x: u16, y: u16, on: bool, hover: bool) {
+    // Four visual states:
+    // - On  + hover → reversed accent fill (extra "you're on this") punch
+    // - On         → accent bg, chip fg
+    // - Off + hover → chrome_bg fill so off cells "light up" on hover
+    //                 without committing to the accent color
+    // - Off        → fully blended into chip background
+    let style = match (on, hover) {
+        (true, true) => Style::default()
+            .fg(th.chrome_active_bg)
+            .bg(th.accent)
+            .add_modifier(Modifier::BOLD)
+            .add_modifier(Modifier::REVERSED),
+        (true, false) => Style::default()
+            .fg(th.chrome_active_bg)
+            .bg(th.accent)
+            .add_modifier(Modifier::BOLD),
+        (false, true) => Style::default().fg(th.chrome_active_fg).bg(th.chrome_bg),
+        (false, false) => Style::default()
+            .fg(th.chrome_muted_fg)
+            .bg(th.chrome_active_bg),
+    };
+    let text = format!(" {} ", label);
+    f.render_widget(
+        Line::from(Span::styled(text, style)),
+        Rect::new(x, y, TOGGLE_LEN, 1),
+    );
+}
+
+fn paint_button(f: &mut Frame, th: &Theme, glyph: &str, x: u16, y: u16, hover: bool) {
+    // Hover swaps the cell to a slightly darker `chrome_bg` so it
+    // visually pops against the chip surface, with bold glyph for
+    // the "this is clickable now" cue.
+    let style = if hover {
+        Style::default()
+            .fg(th.chrome_active_fg)
+            .bg(th.chrome_bg)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+            .fg(th.chrome_active_fg)
+            .bg(th.chrome_active_bg)
+    };
+    f.render_widget(
+        Line::from(Span::styled(glyph.to_string(), style)),
+        Rect::new(x, y, BUTTON_LEN, 1),
+    );
+}
+
+/// Pick what slice of the query string to show inside the given visible
+/// width. We keep the cursor in view by sliding a window over the
+/// string when it would otherwise overflow.
+fn visible_query_text(query: &str, cursor: usize, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    let total = UnicodeWidthStr::width(query);
+    if total <= width {
+        return query.to_string();
+    }
+    // Cursor-anchored sliding window. Show as much of the prefix that
+    // ends at the cursor as fits; if the cursor is near the start,
+    // anchor at start.
+    let prefix = &query[..cursor.min(query.len())];
+    let prefix_w = UnicodeWidthStr::width(prefix);
+    if prefix_w < width {
+        // Cursor near start — show from byte 0, truncate tail.
+        let mut acc = 0usize;
+        let mut end = 0usize;
+        for (i, c) in query.char_indices() {
+            let cw = UnicodeWidthStr::width(c.to_string().as_str());
+            if acc + cw > width {
+                break;
+            }
+            acc += cw;
+            end = i + c.len_utf8();
+        }
+        query[..end].to_string()
+    } else {
+        // Show width chars ending at cursor.
+        let mut acc = 0usize;
+        let mut start = prefix.len();
+        for (i, c) in prefix.char_indices().rev() {
+            let cw = UnicodeWidthStr::width(c.to_string().as_str());
+            if acc + cw > width.saturating_sub(1) {
+                break;
+            }
+            acc += cw;
+            start = i;
+        }
+        prefix[start..].to_string()
+    }
+}
+
+fn format_counter(state: &FindWidgetState) -> String {
+    if state.matches.is_empty() {
+        if state.query.is_empty() {
+            " ".to_string()
+        } else {
+            "No results".to_string()
+        }
+    } else {
+        let total = state.matches.len();
+        let cur = state.current.map(|i| i + 1).unwrap_or(0);
+        format!("{}/{}", cur, total)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counter_no_query_is_blank() {
+        let s = FindWidgetState::default();
+        assert_eq!(format_counter(&s).trim(), "");
+    }
+
+    #[test]
+    fn counter_query_no_matches() {
+        let s = FindWidgetState {
+            query: "x".to_string(),
+            ..FindWidgetState::default()
+        };
+        assert_eq!(format_counter(&s), "No results");
+    }
+
+    #[test]
+    fn counter_with_matches() {
+        let s = FindWidgetState {
+            matches: vec![
+                crate::search::MatchLoc {
+                    row: 0,
+                    byte_range: 0..1,
+                },
+                crate::search::MatchLoc {
+                    row: 0,
+                    byte_range: 2..3,
+                },
+            ],
+            current: Some(0),
+            ..FindWidgetState::default()
+        };
+        assert_eq!(format_counter(&s), "1/2");
+    }
+
+    #[test]
+    fn visible_query_short_fits_entirely() {
+        assert_eq!(visible_query_text("foo", 3, 20), "foo");
+    }
+
+    #[test]
+    fn visible_query_long_window_anchors_to_cursor_tail() {
+        // 30-char string, cursor at the end, 10-char window.
+        let q: String = "abcdefghijklmnopqrstuvwxyz0123".to_string();
+        let v = visible_query_text(&q, q.len(), 10);
+        // Tail end stays visible.
+        assert!(q.ends_with(&v));
+        assert!(UnicodeWidthStr::width(v.as_str()) <= 10);
+    }
+
+    #[test]
+    fn visible_query_long_cursor_at_start_anchors_to_start() {
+        let q = "abcdefghijklmnopqrstuvwxyz".to_string();
+        let v = visible_query_text(&q, 0, 5);
+        assert!(q.starts_with(&v));
+        assert!(UnicodeWidthStr::width(v.as_str()) <= 5);
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,6 +5,7 @@ pub mod db_preview;
 pub mod diff_panel;
 pub mod file_preview_panel;
 pub mod file_tree_panel;
+pub mod find_widget_panel;
 pub mod focus;
 pub mod git_graph_panel;
 pub mod git_status_panel;
@@ -192,6 +193,11 @@ pub fn render(f: &mut Frame, app: &mut App) {
 
     render_status_bar(f, app, main_layout[3]);
 
+    // VSCode-style find widget overlays its host panel after status bar
+    // so its borders and hit zones sit above any panel chrome. Skips
+    // itself when not active.
+    find_widget_panel::render(f, app);
+
     if app.show_help {
         render_help(f, app, size);
     }
@@ -355,6 +361,8 @@ fn render_graph_diff_column(f: &mut Frame, app: &mut App, area: Rect) {
         app.theme,
         &app.search,
         crate::search::SearchTarget::GraphDiff,
+        &app.find_widget,
+        crate::find_widget::FindTarget::GraphDiffUnified,
         selection.as_ref(),
         &mut diff_panel::DiffView {
             scroll: &mut app.commit_detail.file_diff_scroll,

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -93,6 +93,20 @@ pub enum ClickAction {
     /// Jump directly to a 1-based page index. Clicking the `[5]` chip
     /// dispatches `DbGotoPage(5)`.
     DbGotoPage(u64),
+
+    // ── Find widget (VSCode-style floating find, src/find_widget.rs) ──
+    /// Click the `×` close button on the find widget.
+    FindWidgetClose,
+    /// Click the `↓` next-match button.
+    FindWidgetNext,
+    /// Click the `↑` previous-match button.
+    FindWidgetPrev,
+    /// Click the `Aa` Match Case toggle.
+    FindWidgetToggleCase,
+    /// Click the `ab` Whole Word toggle.
+    FindWidgetToggleWord,
+    /// Click the `.*` Regex toggle.
+    FindWidgetToggleRegex,
     /// Click on a row in the Settings page. The `usize` indexes into
     /// `crate::settings::SettingItem::ALL`. Clicking just moves the
     /// selection cursor — activation (toggle / open inline editor) is

--- a/src/ui/text.rs
+++ b/src/ui/text.rs
@@ -190,17 +190,31 @@ fn styled_segment(
 ) -> (Style, String) {
     let style = match kind {
         MatchKind::None => base,
-        MatchKind::Match => apply_search_bg(base, match_bg),
-        MatchKind::Current => apply_search_bg(base, current_bg),
+        MatchKind::Match => apply_search_bg(base, match_bg, /*is_current=*/ false),
+        MatchKind::Current => apply_search_bg(base, current_bg, /*is_current=*/ true),
     };
     (style, text.to_string())
 }
 
-fn apply_search_bg(base: Style, bg: Color) -> Style {
-    if base.bg.is_none() {
+fn apply_search_bg(base: Style, bg: Color, is_current: bool) -> Style {
+    // Color-only distinction (no modifiers like UNDERLINED): the two
+    // theme colors `search_match` / `search_current` carry the visual
+    // difference between match and active-match.
+    //
+    // - Current match: set bg = current_bg AND force fg to pure black.
+    //   Syntect tokens (keyword purple, string green, …) would otherwise
+    //   land on the bright amber/yellow `search_current` with weak
+    //   contrast; both themes' current-bg colors pop against black so
+    //   one hardcoded fg works for both presets.
+    // - Non-current match on a clean row (base has no bg): just set bg.
+    //   The dim `search_match` color tolerates the original syntect fg.
+    // - Non-current match on a diff row (base has bg): REVERSED so the
+    //   diff add/remove color stays visible under the highlight.
+    if is_current {
+        base.bg(bg).fg(Color::Rgb(0, 0, 0))
+    } else if base.bg.is_none() {
         base.bg(bg)
     } else {
-        // Diff rows already carry a bg — flip fg/bg so the match stays visible.
         base.add_modifier(Modifier::REVERSED)
     }
 }
@@ -505,6 +519,8 @@ mod tests {
 
     #[test]
     fn overlay_reverses_when_bg_already_set() {
+        // Non-current match on a diff (bg-bearing) row uses REVERSED so
+        // the diff add/remove color stays visible under the highlight.
         let base = Style::default().bg(ratatui::style::Color::Green);
         let tokens = vec![(base, "abcdef".to_string())];
         let r = 2..4;
@@ -517,6 +533,52 @@ mod tests {
         );
         assert_eq!(out[1].0.bg, Some(ratatui::style::Color::Green));
         assert!(out[1].0.add_modifier.contains(Modifier::REVERSED));
+    }
+
+    #[test]
+    fn overlay_current_match_uses_current_color_and_forces_black_fg() {
+        // Clean (no-bg) base + current match: bg = current_bg, fg gets
+        // hardcoded to pure black so syntect token colors don't leave
+        // the active match unreadable on the amber highlight.
+        let tokens = vec![(
+            Style::default().fg(ratatui::style::Color::Magenta),
+            "foobar".to_string(),
+        )];
+        let r = 0..3;
+        let out = overlay_match_highlight(
+            tokens,
+            std::slice::from_ref(&r),
+            Some(r.clone()),
+            ratatui::style::Color::Yellow,
+            ratatui::style::Color::Red,
+        );
+        assert_eq!(out[0].0.bg, Some(ratatui::style::Color::Red));
+        assert_eq!(out[0].0.fg, Some(ratatui::style::Color::Rgb(0, 0, 0)));
+        assert!(!out[0].0.add_modifier.contains(Modifier::BOLD));
+        assert!(!out[0].0.add_modifier.contains(Modifier::UNDERLINED));
+    }
+
+    #[test]
+    fn overlay_current_match_overrides_bg_and_fg_on_diff_row() {
+        // Diff rows already carry a bg — current match hard-overrides
+        // both bg and fg so the active hit is unmistakable. Non-current
+        // matches still go through REVERSED to keep the diff color.
+        let base = Style::default()
+            .bg(ratatui::style::Color::Green)
+            .fg(ratatui::style::Color::Magenta);
+        let tokens = vec![(base, "abcdef".to_string())];
+        let r = 2..4;
+        let out = overlay_match_highlight(
+            tokens,
+            std::slice::from_ref(&r),
+            Some(r.clone()),
+            ratatui::style::Color::Yellow,
+            ratatui::style::Color::Red,
+        );
+        assert_eq!(out[1].0.bg, Some(ratatui::style::Color::Red));
+        assert_eq!(out[1].0.fg, Some(ratatui::style::Color::Rgb(0, 0, 0)));
+        assert!(!out[1].0.add_modifier.contains(Modifier::REVERSED));
+        assert!(!out[1].0.add_modifier.contains(Modifier::UNDERLINED));
     }
 
     #[test]

--- a/tests/find_widget_mouse.rs
+++ b/tests/find_widget_mouse.rs
@@ -1,0 +1,217 @@
+//! Mouse hit-zone routing for the find widget. Renders a frame so the
+//! `find_widget_panel` registers its button rects, then queries
+//! `hit_registry` at the widget's content row to confirm each control
+//! resolves to the right `ClickAction`. Finally drives `handle_action`
+//! to verify the state transitions match expectations.
+//!
+//! Skips `input::handle_mouse` itself — that wrapper is exercised by
+//! manual QA. This test covers the registration + dispatch layers,
+//! which is where the actual logic lives.
+
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use reef::app::{App, Panel, Tab};
+use reef::file_tree::{PreviewBody, PreviewContent};
+use reef::find_widget;
+use reef::ui;
+use reef::ui::mouse::ClickAction;
+use reef::ui::selection::PreviewSelection;
+use reef::ui::theme::Theme;
+use std::sync::Mutex;
+use tempfile::TempDir;
+use test_support::CwdGuard;
+
+static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+fn fresh_app() -> (App, TempDir, CwdGuard) {
+    let tmp = TempDir::new().unwrap();
+    let g = CwdGuard::enter(tmp.path());
+    let mut app = App::new(Theme::dark(), None);
+    app.active_tab = Tab::Files;
+    app.active_panel = Panel::Diff;
+    app.preview_content = Some(PreviewContent {
+        file_path: "scratch.txt".to_string(),
+        body: PreviewBody::Text {
+            lines: vec![
+                "foo bar baz".to_string(),
+                "    bar();".to_string(),
+                "    bar();".to_string(),
+            ],
+            highlighted: None,
+        },
+    });
+    (app, tmp, g)
+}
+
+/// Render once into a `TestBackend` so `find_widget_panel` populates
+/// `app.hit_registry` and `app.find_widget.last_widget_rect`.
+fn render_once(app: &mut App) {
+    let backend = TestBackend::new(100, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(|f| ui::render(f, app)).unwrap();
+}
+
+/// Walk the widget's content row left-to-right, returning the first
+/// column whose hit zone resolves to a `ClickAction` matching `target`
+/// by enum discriminant. Avoids hardcoding the widget's internal x-
+/// layout in the test.
+fn find_button_col(app: &App, target: &ClickAction) -> Option<u16> {
+    let rect = app.find_widget.last_widget_rect?;
+    let content_row = rect.y + 1;
+    for col in rect.x..rect.x + rect.width {
+        if let Some(action) = app.hit_registry.hit_test(col, content_row)
+            && std::mem::discriminant(&action) == std::mem::discriminant(target)
+        {
+            return Some(col);
+        }
+    }
+    None
+}
+
+fn select(app: &mut App, line: usize, start: usize, end: usize) {
+    let mut sel = PreviewSelection::new((line, start));
+    sel.active = (line, end);
+    sel.dragging = false;
+    app.preview_selection = Some(sel);
+}
+
+#[test]
+fn close_button_dispatches_to_widget_close() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    select(&mut app, 0, 0, 3); // "foo"
+    find_widget::begin_with_selection(&mut app);
+    assert!(app.find_widget.active);
+    render_once(&mut app);
+
+    let col = find_button_col(&app, &ClickAction::FindWidgetClose)
+        .expect("close button hit zone must be registered");
+    let row = app.find_widget.last_widget_rect.unwrap().y + 1;
+    let action = app.hit_registry.hit_test(col, row).unwrap();
+    app.handle_action(action);
+
+    assert!(!app.find_widget.active);
+}
+
+#[test]
+fn next_button_advances_current_match() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    select(&mut app, 1, 4, 7); // "bar"
+    find_widget::begin_with_selection(&mut app);
+    assert_eq!(app.find_widget.current, Some(0));
+    render_once(&mut app);
+
+    let col = find_button_col(&app, &ClickAction::FindWidgetNext).unwrap();
+    let row = app.find_widget.last_widget_rect.unwrap().y + 1;
+    let action = app.hit_registry.hit_test(col, row).unwrap();
+    app.handle_action(action);
+
+    assert_eq!(app.find_widget.current, Some(1));
+}
+
+#[test]
+fn prev_button_steps_backward() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    select(&mut app, 1, 4, 7);
+    find_widget::begin_with_selection(&mut app);
+    render_once(&mut app);
+    // Step forward twice via API so prev has somewhere to go.
+    find_widget::step(&mut app, false);
+    find_widget::step(&mut app, false);
+    assert_eq!(app.find_widget.current, Some(2));
+
+    let col = find_button_col(&app, &ClickAction::FindWidgetPrev).unwrap();
+    let row = app.find_widget.last_widget_rect.unwrap().y + 1;
+    let action = app.hit_registry.hit_test(col, row).unwrap();
+    app.handle_action(action);
+
+    assert_eq!(app.find_widget.current, Some(1));
+}
+
+#[test]
+fn match_case_toggle_flips_and_rematches() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    // Use a query that proves case-sensitivity matters: "Bar" vs "bar".
+    app.preview_content = Some(PreviewContent {
+        file_path: "scratch.txt".to_string(),
+        body: PreviewBody::Text {
+            lines: vec!["Bar bar BAR".to_string()],
+            highlighted: None,
+        },
+    });
+    select(&mut app, 0, 0, 3); // "Bar"
+    find_widget::begin_with_selection(&mut app);
+    // match_case starts off → insensitive → 3 hits
+    assert_eq!(app.find_widget.matches.len(), 3);
+    render_once(&mut app);
+
+    let col = find_button_col(&app, &ClickAction::FindWidgetToggleCase).unwrap();
+    let row = app.find_widget.last_widget_rect.unwrap().y + 1;
+    let action = app.hit_registry.hit_test(col, row).unwrap();
+    app.handle_action(action);
+
+    assert!(app.find_widget.match_case);
+    // Case-sensitive "Bar" → only the literal "Bar" matches.
+    assert_eq!(app.find_widget.matches.len(), 1);
+}
+
+#[test]
+fn whole_word_toggle_flips_and_filters_matches() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    app.preview_content = Some(PreviewContent {
+        file_path: "scratch.txt".to_string(),
+        body: PreviewBody::Text {
+            lines: vec!["foo food foobar foo!".to_string()],
+            highlighted: None,
+        },
+    });
+    select(&mut app, 0, 0, 3);
+    find_widget::begin_with_selection(&mut app);
+    // Without whole_word: "foo" appears in food, foobar, foo, foo —
+    // 4 substring hits.
+    assert_eq!(app.find_widget.matches.len(), 4);
+    render_once(&mut app);
+
+    let col = find_button_col(&app, &ClickAction::FindWidgetToggleWord).unwrap();
+    let row = app.find_widget.last_widget_rect.unwrap().y + 1;
+    let action = app.hit_registry.hit_test(col, row).unwrap();
+    app.handle_action(action);
+
+    assert!(app.find_widget.whole_word);
+    // With whole_word: only standalone "foo" and "foo!" match. food
+    // and foobar are filtered out.
+    assert_eq!(app.find_widget.matches.len(), 2);
+}
+
+#[test]
+fn regex_toggle_reinterprets_query() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    app.preview_content = Some(PreviewContent {
+        file_path: "scratch.txt".to_string(),
+        body: PreviewBody::Text {
+            lines: vec!["abc 12 d345 ef".to_string()],
+            highlighted: None,
+        },
+    });
+    // Seed with the literal "\d+" — without regex it matches no chars.
+    find_widget::begin_with_selection(&mut app);
+    app.find_widget.query = r"\d+".to_string();
+    app.find_widget.cursor = 3;
+    find_widget::recompute(&mut app);
+    assert!(app.find_widget.matches.is_empty());
+    render_once(&mut app);
+
+    let col = find_button_col(&app, &ClickAction::FindWidgetToggleRegex).unwrap();
+    let row = app.find_widget.last_widget_rect.unwrap().y + 1;
+    let action = app.hit_registry.hit_test(col, row).unwrap();
+    app.handle_action(action);
+
+    assert!(app.find_widget.regex);
+    // `\d+` as a regex now matches "12" and "345".
+    assert_eq!(app.find_widget.matches.len(), 2);
+}

--- a/tests/find_widget_mutex.rs
+++ b/tests/find_widget_mutex.rs
@@ -1,0 +1,83 @@
+//! Find widget and vim-style `/` (`SearchState`) are independent state
+//! machines that must not coexist with active matches — otherwise the
+//! diff/preview renderer would have to decide between two highlight
+//! colors per row. `find_widget::begin_with_selection` clears
+//! `app.search` on open; conversely, opening `/` is expected to clear
+//! the widget (caller responsibility — exercised manually for now).
+
+use reef::app::{App, Panel, Tab};
+use reef::file_tree::{PreviewBody, PreviewContent};
+use reef::find_widget;
+use reef::search::{MatchLoc, SearchState, SearchTarget};
+use reef::ui::theme::Theme;
+use std::sync::Mutex;
+use tempfile::TempDir;
+use test_support::CwdGuard;
+
+static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+fn fresh_app() -> (App, TempDir, CwdGuard) {
+    let tmp = TempDir::new().unwrap();
+    let g = CwdGuard::enter(tmp.path());
+    let mut app = App::new(Theme::dark(), None);
+    app.active_tab = Tab::Files;
+    app.active_panel = Panel::Diff;
+    app.preview_content = Some(PreviewContent {
+        file_path: "scratch.txt".to_string(),
+        body: PreviewBody::Text {
+            lines: vec!["foo bar foo".to_string(), "bar foo".to_string()],
+            highlighted: None,
+        },
+    });
+    (app, tmp, g)
+}
+
+#[test]
+fn opening_widget_clears_legacy_search() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+
+    // Park the legacy `/` in a dormant-but-non-empty state — the
+    // "user committed a search, then went back to navigating" shape.
+    app.search = SearchState {
+        active: false,
+        backwards: false,
+        query: "foo".to_string(),
+        cursor: 3,
+        target: Some(SearchTarget::FilePreview),
+        matches: vec![MatchLoc {
+            row: 0,
+            byte_range: 0..3,
+        }],
+        current: Some(0),
+        snapshot: None,
+        wrap_msg: None,
+    };
+    assert_eq!(app.search.target, Some(SearchTarget::FilePreview));
+
+    // Opening the widget must wipe `app.search` so its highlights stop
+    // painting.
+    find_widget::begin_with_selection(&mut app);
+
+    assert!(app.find_widget.active);
+    assert!(
+        app.search.target.is_none(),
+        "widget open should clear legacy `/` state"
+    );
+    assert!(app.search.matches.is_empty());
+}
+
+#[test]
+fn widget_close_does_not_resurrect_legacy_search() {
+    // Reverse direction is just a sanity check: closing the widget
+    // restores its own snapshot but should NOT re-arm `app.search`.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+
+    find_widget::begin_with_selection(&mut app);
+    assert!(app.find_widget.active);
+    find_widget::close(&mut app);
+
+    assert!(!app.find_widget.active);
+    assert!(app.search.target.is_none());
+}

--- a/tests/find_widget_sbs.rs
+++ b/tests/find_widget_sbs.rs
@@ -1,0 +1,178 @@
+//! SBS diff targeting: `find_widget::begin_with_selection` must pick
+//! `DiffSbsLeft` / `DiffSbsRight` based on the user's drag-selection
+//! side, and run the match only against that side's content. No
+//! selection in SBS layout defaults to the right (new code) side.
+
+use reef::app::{App, DiffLayout, HighlightedDiff, Panel, Tab};
+use reef::find_widget;
+use reef::find_widget::FindTarget;
+use reef::git::{DiffContent, DiffHunk, DiffLine, LineTag};
+use reef::ui::selection::{DiffSelection, DiffSide, PreviewSelection};
+use reef::ui::theme::Theme;
+use std::sync::Mutex;
+use tempfile::TempDir;
+use test_support::CwdGuard;
+
+static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+fn fresh_app() -> (App, TempDir, CwdGuard) {
+    let tmp = TempDir::new().unwrap();
+    let g = CwdGuard::enter(tmp.path());
+    let mut app = App::new(Theme::dark(), None);
+    app.active_tab = Tab::Git;
+    app.active_panel = Panel::Diff;
+    app.diff_layout = DiffLayout::SideBySide;
+    (app, tmp, g)
+}
+
+/// A diff whose paired `Removed`/`Added` lines stay on the same row in
+/// SBS mode, with the two sides carrying different needle text — so a
+/// left-vs-right targeted search can distinguish them.
+fn install_paired_diff(app: &mut App) {
+    let hunk = DiffHunk {
+        header: "@@ -1,3 +1,3 @@".to_string(),
+        lines: vec![
+            DiffLine {
+                tag: LineTag::Context,
+                content: "ctx 1".to_string(),
+                old_lineno: Some(1),
+                new_lineno: Some(1),
+            },
+            DiffLine {
+                tag: LineTag::Removed,
+                content: "old needle here".to_string(),
+                old_lineno: Some(2),
+                new_lineno: None,
+            },
+            DiffLine {
+                tag: LineTag::Added,
+                content: "new needle there".to_string(),
+                old_lineno: None,
+                new_lineno: Some(2),
+            },
+            DiffLine {
+                tag: LineTag::Context,
+                content: "ctx 3".to_string(),
+                old_lineno: Some(3),
+                new_lineno: Some(3),
+            },
+        ],
+    };
+    app.diff_content = Some(HighlightedDiff {
+        diff: DiffContent {
+            file_path: "scratch.rs".to_string(),
+            hunks: vec![hunk],
+        },
+        highlighted: None,
+    });
+}
+
+fn diff_selection(side: DiffSide) -> DiffSelection {
+    // Anchor / active byte offsets are irrelevant for the
+    // selection-side decision; `current_text_selection` reads the
+    // text via the cached `DiffHit`, but `begin_with_selection`
+    // tolerates a missing `DiffHit` — the selection seed just falls
+    // back to empty in that case.
+    let mut sel = PreviewSelection::new((0, 0));
+    sel.active = (0, 0);
+    sel.dragging = false;
+    DiffSelection { sel, side }
+}
+
+#[test]
+fn left_side_selection_targets_sbs_left() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    install_paired_diff(&mut app);
+    app.diff_selection = Some(diff_selection(DiffSide::SbsLeft));
+
+    find_widget::begin_with_selection(&mut app);
+
+    assert_eq!(app.find_widget.target, Some(FindTarget::DiffSbsLeft));
+}
+
+#[test]
+fn right_side_selection_targets_sbs_right() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    install_paired_diff(&mut app);
+    app.diff_selection = Some(diff_selection(DiffSide::SbsRight));
+
+    find_widget::begin_with_selection(&mut app);
+
+    assert_eq!(app.find_widget.target, Some(FindTarget::DiffSbsRight));
+}
+
+#[test]
+fn no_selection_defaults_to_sbs_right() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    install_paired_diff(&mut app);
+    app.diff_selection = None;
+
+    find_widget::begin_with_selection(&mut app);
+
+    assert_eq!(app.find_widget.target, Some(FindTarget::DiffSbsRight));
+}
+
+#[test]
+fn unified_layout_targets_diff_unified() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    app.diff_layout = DiffLayout::Unified;
+    install_paired_diff(&mut app);
+
+    find_widget::begin_with_selection(&mut app);
+
+    assert_eq!(app.find_widget.target, Some(FindTarget::DiffUnified));
+}
+
+#[test]
+fn left_search_finds_old_text_not_new_text() {
+    // Targeted at SbsLeft, the query "old" should match the Removed
+    // line; "new" (only present on the Added side) should produce
+    // zero matches.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    install_paired_diff(&mut app);
+    app.diff_selection = Some(diff_selection(DiffSide::SbsLeft));
+
+    find_widget::begin_with_selection(&mut app);
+    // No selection text to seed with — type manually via handle_key.
+    // Simpler: poke `app.find_widget.query` directly and recompute via
+    // the public re-match entry point.
+    app.find_widget.query = "old".to_string();
+    app.find_widget.cursor = 3;
+    find_widget::recompute(&mut app);
+    assert!(
+        !app.find_widget.matches.is_empty(),
+        "'old' is on the left side and should match"
+    );
+
+    app.find_widget.query = "new".to_string();
+    app.find_widget.cursor = 3;
+    find_widget::recompute(&mut app);
+    assert!(
+        app.find_widget.matches.is_empty(),
+        "'new' lives only on the right side; SbsLeft target shouldn't see it"
+    );
+}
+
+#[test]
+fn right_search_finds_new_text_not_old_text() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    install_paired_diff(&mut app);
+    app.diff_selection = Some(diff_selection(DiffSide::SbsRight));
+
+    find_widget::begin_with_selection(&mut app);
+    app.find_widget.query = "new".to_string();
+    app.find_widget.cursor = 3;
+    find_widget::recompute(&mut app);
+    assert!(!app.find_widget.matches.is_empty());
+
+    app.find_widget.query = "old".to_string();
+    app.find_widget.cursor = 3;
+    find_widget::recompute(&mut app);
+    assert!(app.find_widget.matches.is_empty());
+}

--- a/tests/find_widget_seed.rs
+++ b/tests/find_widget_seed.rs
@@ -1,0 +1,219 @@
+//! `find_widget::begin_with_selection` contract on the file preview:
+//! pressing `Space+F` while text is selected pops the floating widget,
+//! seeds the query with the first non-empty trimmed line of the
+//! selection, runs the search, and leaves the prompt focused so the
+//! user can refine the query or just navigate with `Space+G`.
+
+use reef::app::{App, Panel, Tab};
+use reef::file_tree::{PreviewBody, PreviewContent};
+use reef::find_widget;
+use reef::find_widget::FindTarget;
+use reef::ui::selection::PreviewSelection;
+use reef::ui::theme::Theme;
+use std::sync::Mutex;
+use tempfile::TempDir;
+use test_support::CwdGuard;
+
+static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+fn fresh_app() -> (App, TempDir, CwdGuard) {
+    let tmp = TempDir::new().unwrap();
+    let g = CwdGuard::enter(tmp.path());
+    let mut app = App::new(Theme::dark(), None);
+    // Preview pane is hosted under `Panel::Diff` in the Files tab.
+    app.active_tab = Tab::Files;
+    app.active_panel = Panel::Diff;
+    (app, tmp, g)
+}
+
+fn install_text_preview(app: &mut App, lines: &[&str]) {
+    app.preview_content = Some(PreviewContent {
+        file_path: "scratch.txt".to_string(),
+        body: PreviewBody::Text {
+            lines: lines.iter().map(|s| s.to_string()).collect(),
+            highlighted: None,
+        },
+    });
+}
+
+fn select_byte_range(app: &mut App, start: (usize, usize), end: (usize, usize)) {
+    let mut sel = PreviewSelection::new(start);
+    sel.active = end;
+    sel.dragging = false;
+    app.preview_selection = Some(sel);
+}
+
+#[test]
+fn seeds_query_and_runs_match_from_preview_selection() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    install_text_preview(
+        &mut app,
+        &["fn foo() { bar(); }", "    bar();", "    bar();"],
+    );
+    select_byte_range(&mut app, (1, 4), (1, 7));
+
+    find_widget::begin_with_selection(&mut app);
+
+    assert!(app.find_widget.active);
+    assert_eq!(app.find_widget.query, "bar");
+    assert_eq!(app.find_widget.cursor, "bar".len());
+    assert_eq!(app.find_widget.target, Some(FindTarget::FilePreview));
+    assert_eq!(app.find_widget.matches.len(), 3);
+    assert_eq!(app.find_widget.current, Some(0));
+}
+
+#[test]
+fn trims_indentation_when_selection_grabs_full_line() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    install_text_preview(&mut app, &["fn foo() {", "    bar();", "}"]);
+    select_byte_range(&mut app, (1, 0), (1, "    bar();".len()));
+
+    find_widget::begin_with_selection(&mut app);
+
+    assert_eq!(app.find_widget.query, "bar();");
+    assert!(!app.find_widget.matches.is_empty());
+}
+
+#[test]
+fn no_selection_opens_empty_widget() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    install_text_preview(&mut app, &["hello world"]);
+
+    find_widget::begin_with_selection(&mut app);
+
+    assert!(app.find_widget.active);
+    assert!(app.find_widget.query.is_empty());
+    assert_eq!(app.find_widget.target, Some(FindTarget::FilePreview));
+    assert!(app.find_widget.matches.is_empty());
+}
+
+#[test]
+fn collapsed_selection_falls_back_to_empty_widget() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    install_text_preview(&mut app, &["hello world"]);
+    select_byte_range(&mut app, (0, 5), (0, 5));
+
+    find_widget::begin_with_selection(&mut app);
+
+    assert!(app.find_widget.active);
+    assert!(app.find_widget.query.is_empty());
+}
+
+#[test]
+fn step_after_seed_advances_current() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    install_text_preview(&mut app, &["bar", "bar", "bar"]);
+    select_byte_range(&mut app, (0, 0), (0, 3));
+
+    find_widget::begin_with_selection(&mut app);
+    assert_eq!(app.find_widget.current, Some(0));
+
+    find_widget::step(&mut app, /*reverse=*/ false);
+    assert_eq!(app.find_widget.current, Some(1));
+    find_widget::step(&mut app, /*reverse=*/ false);
+    assert_eq!(app.find_widget.current, Some(2));
+    // Wraps back to start.
+    find_widget::step(&mut app, /*reverse=*/ false);
+    assert_eq!(app.find_widget.current, Some(0));
+    // Reverse wraps to last.
+    find_widget::step(&mut app, /*reverse=*/ true);
+    assert_eq!(app.find_widget.current, Some(2));
+}
+
+#[test]
+fn close_restores_pre_find_scroll_and_clears_state() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    install_text_preview(
+        &mut app,
+        &[
+            "line 0", "line 1", "line 2", "bar 3", "line 4", "line 5", "line 6", "line 7",
+            "line 8", "line 9",
+        ],
+    );
+    app.preview_scroll = 0;
+    app.last_preview_view_h = 4;
+    select_byte_range(&mut app, (3, 0), (3, 3));
+
+    find_widget::begin_with_selection(&mut app);
+    // Match landed on row 3 — center-scroll pushes preview_scroll
+    // away from 0.
+    assert!(app.find_widget.active);
+
+    find_widget::close(&mut app);
+    assert!(!app.find_widget.active);
+    assert_eq!(app.find_widget.query, "");
+    assert_eq!(app.preview_scroll, 0, "snapshot should restore scroll");
+}
+
+#[test]
+fn tab_switch_closes_widget_and_restores_scroll() {
+    // `App::set_active_tab` calls `find_widget::close` so a widget
+    // anchored on one tab's panel doesn't bleed into another. Verifies
+    // both halves: `active` flips off and pre-find scroll is restored.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    install_text_preview(
+        &mut app,
+        &[
+            "line 0", "line 1", "line 2", "bar 3", "line 4", "line 5", "line 6", "line 7",
+            "line 8", "line 9",
+        ],
+    );
+    app.preview_scroll = 0;
+    app.last_preview_view_h = 4;
+    select_byte_range(&mut app, (3, 0), (3, 3));
+
+    find_widget::begin_with_selection(&mut app);
+    assert!(app.find_widget.active);
+
+    // Switch away — should auto-close.
+    app.set_active_tab(Tab::Git);
+
+    assert!(!app.find_widget.active);
+    assert_eq!(app.find_widget.query, "");
+    assert_eq!(app.find_widget.target, None);
+    assert_eq!(
+        app.preview_scroll, 0,
+        "tab switch must restore pre-find scroll via the same snapshot path as Esc",
+    );
+}
+
+#[test]
+fn step_after_close_is_a_noop_not_a_panic() {
+    // Calling `step` once the widget has been closed (matches drained)
+    // should silently no-op — the close-then-step ordering can happen
+    // when a chord fires between widget Esc and the next frame.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    install_text_preview(&mut app, &["bar", "bar"]);
+    select_byte_range(&mut app, (0, 0), (0, 3));
+
+    find_widget::begin_with_selection(&mut app);
+    find_widget::close(&mut app);
+    // Must not panic; current stays None.
+    find_widget::step(&mut app, false);
+    find_widget::step(&mut app, true);
+    assert_eq!(app.find_widget.current, None);
+    assert!(app.find_widget.matches.is_empty());
+}
+
+#[test]
+fn no_target_panel_is_a_noop() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    // Tab::Search left panel has no in-panel find target.
+    app.active_tab = Tab::Search;
+    app.active_panel = Panel::Files;
+
+    find_widget::begin_with_selection(&mut app);
+
+    assert!(!app.find_widget.active);
+    assert!(app.find_widget.query.is_empty());
+    assert_eq!(app.find_widget.target, None);
+}

--- a/tests/snapshots/ui_snapshots__find_widget_on_preview.snap
+++ b/tests/snapshots/ui_snapshots__find_widget_on_preview.snap
@@ -1,0 +1,28 @@
+---
+source: tests/ui_snapshots.rs
+expression: output
+---
+ reef  [TMPDIR]  ⎇ master
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph                            ⊟  1:Files 2:Search 3:Git 4:Graph
+ + New File   📁  New Folder  │ scra
+   scratch.txt               │ ────  bar                          Aa  ab  .*     1/2     ↑  ↓  ×
+                             │
+                             │     2     bar();
+                             │     3     bar();
+                             │     4 }
+                             │
+                             │
+                             │
+                             │
+                             │
+                             │
+                             │
+                             │
+                             │
+                             │
+                             │
+                             │
+                             │
+                             │
+                             │
+                                 ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Preview]

--- a/tests/ui_snapshots.rs
+++ b/tests/ui_snapshots.rs
@@ -677,3 +677,59 @@ fn snapshot_settings_page_editing_editor_command() {
         insta::assert_snapshot!("settings_page_editing_editor_command", output)
     });
 }
+
+#[test]
+fn snapshot_find_widget_on_preview() {
+    // Locks in the floating Find widget's layout: bordered popup
+    // anchored to the upper-right of the file-preview panel, query
+    // pre-seeded from selection, Aa/ab/.* toggles + counter + ↑↓×
+    // buttons on the same row. If this regresses, the widget would
+    // either misalign over the panel chrome or lose one of its
+    // controls.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    force_en_lang();
+    let (tmp, raw) = tempdir_repo();
+    commit_file(
+        &raw,
+        "scratch.txt",
+        "fn foo() {\n    bar();\n    bar();\n}\n",
+        "init",
+    );
+    let home = tempfile::TempDir::new().expect("home tempdir");
+    let _h = HomeGuard::enter(home.path());
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    wait_for_file_tree(&mut app);
+    // Drive the preview pane: select the scratch file, wait for the
+    // worker to land the body, then drop a selection on row 1 so
+    // `begin_with_selection` has something to seed from.
+    if let Some(idx) = app
+        .file_tree
+        .entries
+        .iter()
+        .position(|e| e.name == "scratch.txt")
+    {
+        app.file_tree.selected = idx;
+        app.load_preview();
+        wait_for_preview(&mut app);
+    } else {
+        panic!("scratch.txt missing from tree");
+    }
+    app.set_active_tab(reef::app::Tab::Files);
+    app.active_panel = reef::app::Panel::Diff;
+    // Run a frame so `last_preview_rect` lands — `find_widget_panel`
+    // reads it to anchor the popup. With no rect cached, the widget
+    // skips rendering.
+    let _ = render_app(&mut app, 100, 24);
+    let mut sel = reef::ui::selection::PreviewSelection::new((1, 4));
+    sel.active = (1, 7);
+    sel.dragging = false;
+    app.preview_selection = Some(sel);
+    reef::find_widget::begin_with_selection(&mut app);
+
+    let output = render_app(&mut app, 100, 24);
+    with_filters(&[], || {
+        insta::assert_snapshot!("find_widget_on_preview", output)
+    });
+}


### PR DESCRIPTION
## Summary

- Floating Find widget in the upper-right of the active preview / diff panel — independent state machine from vim `/`, mutually exclusive so highlights never double-paint
- Side-by-side diff support fills the existing `TODO(search-sbs)` in `diff_panel.rs`: `DiffSbsLeft` / `DiffSbsRight` targets light up matches only on the side the user selected text in
- Match Case / Whole Word / Regex toggles (Alt+C / Alt+W / Alt+R), VSCode-style hover feedback, mouse-clickable buttons (×, ↑, ↓, Aa, ab, .*)

## Key bindings

| Binding | Behavior |
|---|---|
| `Space + F` | Open widget; selection seeds the query (VSCode `Cmd+F`) |
| `Space + Shift + F` | Global ripgrep search (was `Space + F`) |
| `Esc` / `×` | Close, restore pre-find scroll |
| `Enter` / `↓` | Next match (`Shift+Enter` / `↑`: previous) |
| `Alt + C / W / R` | Toggle Match Case / Whole Word / Regex |
| `/`, `?`, `n`, `N` | Unchanged — vim-style stays parallel |

## Notable design choices

- `regex = \"1\"` added to deps for the `.*` toggle; literal-substring path still goes through the existing `search::find_all` so non-regex queries pay no overhead
- Mouse intercept in `input::handle_mouse` runs **before** `handle_preview_selection` / `handle_diff_selection` so widget hit zones don't get swallowed by drag-select fast-paths
- `overlay_match_highlight` forces black fg on the current match so syntect token colors (purple keywords etc) stay readable against the bright amber highlight bg
- Widget is non-modal for mouse — clicks outside it still reach the underlying panel, matching VSCode's behavior

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features` — 578 lib tests + 23 widget integration tests (9 seed + 6 sbs + 2 mutex + 6 mouse) + 16 UI snapshots
- [x] `cargo test --workspace --doc`
- [ ] Manual: Files tab → drag-select → `Space+F` → see widget anchored top-right, matches highlighted, click ↑↓× and Aa/ab/.* toggles, `Esc` closes
- [ ] Manual: Git tab unified diff → drag-select diff chars → `Space+F` → widget targets diff
- [ ] Manual: Git tab SBS diff → select on **left** side → `Space+F` → highlights only on left; switch to right selection → re-trigger → highlights flip side
- [ ] Manual: invalid regex query (`(`) → counter shows `regex!` in red, no panic
- [ ] Manual: open `/` after widget is active → widget closes; reverse also holds

## Out of scope (future)

- **Replace expansion**: chevron + replace input row + write-through to preview. Skipped per the original PR plan; will come as a follow-up.
- Some efficiency optimizations flagged in review (regex compile caching, SBS row caching) are low-priority for typical file sizes — revisit if profiling shows frame drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)