### PR TITLE
perf(git): scope unstaged-diff untracked check to one path

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -383,12 +383,17 @@ impl GitRepo {
             let _ = idx.read(true);
         }
 
-        // Check if file is untracked — use similar for full-file diff
-        let statuses = self.repo.statuses(None).ok()?;
-        for entry in statuses.iter() {
-            if entry.path() == Some(path) && entry.status().contains(git2::Status::WT_NEW) {
-                return self.get_untracked_diff(path);
-            }
+        // Check if file is untracked — use similar for full-file diff.
+        // `status_file` scopes the check to this one path; the previous
+        // `statuses(None)` enumerated the whole worktree on every keystroke,
+        // costing hundreds of ms on large repos.
+        let is_untracked = self
+            .repo
+            .status_file(Path::new(path))
+            .map(|st| st.contains(git2::Status::WT_NEW))
+            .unwrap_or(false);
+        if is_untracked {
+            return self.get_untracked_diff(path);
         }
 
         // Unstaged: compare index to workdir


### PR DESCRIPTION
## Summary

- `get_unstaged_diff` was calling `repo.statuses(None)` on every file selection in the Git tab just to ask "is this one path untracked?" — that call enumerates the entire worktree with default `StatusOptions` (rename detection, recursive untracked dirs, etc.), costing hundreds of ms per keystroke on non-trivial repos and dominating the 1–2 s lag when switching files.
- Replace with `repo.status_file(Path::new(path))`, which performs the same status calculation scoped to a single path.
- Behaviour on error is slightly safer: we fall through to the normal diff path instead of blanking the preview, since a single-file status failure shouldn't suppress a diff that `diff_index_to_workdir` can still compute.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --test git_repo_integration` (26 passed — covers untracked / unstaged / staged / rename paths)
- [x] `cargo test --test git_graph_properties` (5 passed)
- [ ] Manual: open Git tab in a large repo, mash j/k through unstaged files, confirm preview updates feel near-instant instead of stalling for ~1 s
- [ ] Manual: select an untracked file, confirm the full-file diff still renders
- [ ] Manual: stage a file, switch to it under "Staged", confirm staged diff still renders (this path was unchanged but worth a smoke)

Note: pre-existing `fs_watcher_integration` failures on macOS reproduce on clean `main` and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)