### PR TITLE
feat(ui): replace first-run hosts-picker auto-open with status-bar button

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4231,6 +4231,9 @@ impl App {
             ClickAction::OpenSettings => {
                 self.open_settings();
             }
+            ClickAction::OpenHostsPicker => {
+                self.open_hosts_picker();
+            }
             ClickAction::TreeClick(index) => {
                 self.file_tree.selected = index;
                 if let Some(entry) = self.file_tree.entries.get(index) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,20 +261,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             app.open_hosts_picker();
         }
 
-        // First-run heuristic: if the user launched reef without `--ssh`
-        // and the cwd isn't a repo, auto-open the hosts picker so they
-        // have a visible path to an ssh connection instead of staring at
-        // the "Not a git repository" placeholder. Skipped on the subsequent
-        // session swaps — those always have a backend picked already.
-        if parsed.ssh_target.is_none()
-            && parsed.agent_exec.is_none()
-            && parsed.path.is_none()
-            && !app.backend.has_repo()
-            && app.hosts_picker.all_hosts.is_empty()
-        {
-            app.open_hosts_picker();
-        }
-
         // Main loop
         loop {
             app.tick();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -644,6 +644,12 @@ fn render_status_bar(f: &mut Frame, app: &mut App, area: Rect) {
     let chip_w = UnicodeWidthStr::width(chip.as_str()) as u16;
     let notif_w = UnicodeWidthStr::width(notif.as_str()) as u16;
 
+    // Mouse-only hosts-picker entry — Ctrl+O fallback. Sits at the very
+    // leftmost cell of the status bar so it stays reachable even when
+    // the notification text is empty.
+    let hosts_btn = " 🔗 SSH ";
+    let hosts_btn_w = UnicodeWidthStr::width(hosts_btn) as u16;
+
     // Mouse-only settings entry — Ctrl+, fallback for terminals that
     // swallow the chord. Glyph mirrors `SettingsTitle` so the icon is
     // visually self-explanatory.
@@ -652,12 +658,16 @@ fn render_status_bar(f: &mut Frame, app: &mut App, area: Rect) {
 
     let pad_w = area
         .width
+        .saturating_sub(hosts_btn_w)
         .saturating_sub(notif_w)
         .saturating_sub(settings_btn_w)
         .saturating_sub(hint_w)
         .saturating_sub(chip_w);
 
-    let settings_btn_x = area.x + notif_w + pad_w;
+    app.hit_registry
+        .register_row(area.x, area.y, hosts_btn_w, ClickAction::OpenHostsPicker);
+
+    let settings_btn_x = area.x + hosts_btn_w + notif_w + pad_w;
     app.hit_registry.register_row(
         settings_btn_x,
         area.y,
@@ -666,6 +676,13 @@ fn render_status_bar(f: &mut Frame, app: &mut App, area: Rect) {
     );
 
     let status = Line::from(vec![
+        Span::styled(
+            hosts_btn,
+            Style::default()
+                .fg(th.accent)
+                .bg(th.chrome_bg)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled(notif, Style::default().fg(notif_color).bg(th.chrome_bg)),
         Span::styled(
             " ".repeat(pad_w as usize),

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -20,6 +20,10 @@ pub enum ClickAction {
     /// 或终端吞掉 Ctrl+, 的用户兜底。仅在常规状态栏分支注册,
     /// 各类模态接管(搜索/select/place/paste-conflict 等)期间不出现。
     OpenSettings,
+    /// 状态栏左侧的 SSH 按钮。等价于 Ctrl+O,给鼠标用户一条
+    /// 进入 hosts picker 的路径。注册位置与 `OpenSettings` 一致 ——
+    /// 只在常规状态栏分支出现,模态接管期间隐藏。
+    OpenHostsPicker,
     SwitchTab(Tab),
     TreeClick(usize),
     /// Click on a row in the quick-open palette. The `usize` indexes

--- a/tests/snapshots/ui_snapshots__binary_info_pdf.snap
+++ b/tests/snapshots/ui_snapshots__binary_info_pdf.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 579
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -21,4 +22,4 @@ expression: output
                        │
                        │
                        │
-               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+ 🔗  SSH        ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__empty_repo.snap
+++ b/tests/snapshots/ui_snapshots__empty_repo.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 104
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -21,4 +22,4 @@ expression: output
                        │
                        │
                        │
-               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+ 🔗  SSH        ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__find_widget_on_preview.snap
+++ b/tests/snapshots/ui_snapshots__find_widget_on_preview.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 733
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
@@ -25,4 +26,4 @@ expression: output
                              │
                              │
                              │
-                                 ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Preview]
+ 🔗  SSH                          ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Preview]

--- a/tests/snapshots/ui_snapshots__hosts_picker_empty.snap
+++ b/tests/snapshots/ui_snapshots__hosts_picker_empty.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 338
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -21,4 +22,4 @@ expression: output
       │   Enter connect · Ctrl+P path mode · Esc cancel                  │
       └──────────────────────────────────────────────────────────────────┘
                        │
-               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+ 🔗  SSH        ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__hosts_picker_path_mode.snap
+++ b/tests/snapshots/ui_snapshots__hosts_picker_path_mode.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 417
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -21,4 +22,4 @@ expression: output
       │   Enter connect · Esc back to filter                             │
       └──────────────────────────────────────────────────────────────────┘
                        │
-               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+ 🔗  SSH        ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__hosts_picker_populated.snap
+++ b/tests/snapshots/ui_snapshots__hosts_picker_populated.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 385
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -21,4 +22,4 @@ expression: output
       │   Enter connect · Ctrl+P path mode · Esc cancel                  │
       └──────────────────────────────────────────────────────────────────┘
                        │
-               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+ 🔗  SSH        ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__image_preview_halfblocks.snap
+++ b/tests/snapshots/ui_snapshots__image_preview_halfblocks.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 540
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -21,4 +22,4 @@ expression: output
                        │
                        │
                        │
-               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+ 🔗  SSH        ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__search_tab_replace_open_with_excluded_row.snap
+++ b/tests/snapshots/ui_snapshots__search_tab_replace_open_with_excluded_row.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 631
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
@@ -17,4 +18,4 @@ expression: output
 │                            │
 │1 / 2 · 1 to replace ·  Apply
 └────────────────────────────┘
-                                  ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Search]
+ 🔗  SSH                           ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Search]

--- a/tests/snapshots/ui_snapshots__tree_context_menu.snap
+++ b/tests/snapshots/ui_snapshots__tree_context_menu.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 251
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
@@ -21,4 +22,4 @@ expression: output
     │  Reveal in Finder    │
     └──────────────────────┘
                        │
-               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+ 🔗  SSH        ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__tree_edit_row_new_file.snap
+++ b/tests/snapshots/ui_snapshots__tree_edit_row_new_file.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 214
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
@@ -21,4 +22,4 @@ expression: output
                        │
                        │
                        │
-               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+ 🔗  SSH        ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__with_staged_and_unstaged.snap
+++ b/tests/snapshots/ui_snapshots__with_staged_and_unstaged.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 126
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
@@ -21,4 +22,4 @@ expression: output
                        │
                        │
                        │
-               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+ 🔗  SSH        ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__with_staged_and_unstaged_light.snap
+++ b/tests/snapshots/ui_snapshots__with_staged_and_unstaged_light.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ui_snapshots.rs
+assertion_line: 444
 expression: output
 ---
  reef  [TMPDIR]  ⎇ master
@@ -21,4 +22,4 @@ expression: output
                        │
                        │
                        │
-               ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]
+ 🔗  SSH        ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]


### PR DESCRIPTION
## Summary
- Drop the first-run heuristic in `src/main.rs` that auto-opened the hosts picker whenever cwd wasn't a git repo — it surprised users every launch in non-repo dirs.
- Add a mouse-only `🔗 SSH` button at the leftmost cell of the bottom status bar that opens the hosts picker. Mirrors the existing `⚙` settings button pattern: registered through `HitTestRegistry`, dispatched via `App::handle_action`, hidden during status-bar modal takeovers (search / place / paste-conflict / range / toast).
- Ctrl+O still works as the keyboard path; new `ClickAction::OpenHostsPicker` just adds a mouse path.
- 12 snapshot tests updated — the only delta in each is the new ` 🔗 SSH ` prefix on the bottom row.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features` (pre-existing `fs_watcher_integration` flake on macOS unrelated; reproduces on main)
- [x] `cargo test --workspace --doc`
- [x] Manually launch reef in a non-repo dir → no picker pops; bottom-left shows `🔗 SSH`; click opens the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)