### PR TITLE
feat(sqlite): multi-schema browser with grouped sidebar and detail pane

### DIFF
--- a/crates/reef-agent/src/main.rs
+++ b/crates/reef-agent/src/main.rs
@@ -459,6 +459,26 @@ fn dispatch(backend: &dyn Backend, workdir: &Path, env: Envelope) -> Option<Resp
             offset,
             limit,
         } => load_db_page_handler(workdir, &rel_path, &table, offset, limit),
+
+        // ── v9: SQLite preview, multi-schema ────
+        Request::LoadDbInitialV2 {
+            rel_path,
+            page_size,
+        } => load_db_initial_v2_handler(workdir, &rel_path, page_size),
+        Request::LoadDbPageV2 {
+            rel_path,
+            schema,
+            kind,
+            name,
+            offset,
+            limit,
+        } => load_db_page_v2_handler(workdir, &rel_path, &schema, kind, &name, offset, limit),
+        Request::LoadDbObjectDetail {
+            rel_path,
+            schema,
+            kind,
+            name,
+        } => load_db_object_detail_handler(workdir, &rel_path, &schema, kind, &name),
     };
 
     match result {
@@ -838,6 +858,8 @@ fn column_info_to_dto(c: reef_sqlite_preview::ColumnInfo) -> reef_proto::ColumnI
     reef_proto::ColumnInfoDto {
         name: c.name,
         decl_type: c.decl_type,
+        notnull: c.notnull,
+        pk: c.pk,
     }
 }
 
@@ -864,5 +886,227 @@ fn sqlite_value_to_dto(v: reef_sqlite_preview::SqliteValue) -> reef_proto::Sqlit
         reef_sqlite_preview::SqliteValue::Blob { len } => {
             reef_proto::SqliteValueDto::Blob { len: len as u64 }
         }
+    }
+}
+
+// ── v9: SQLite preview, multi-schema handlers ─────────────────────────────
+
+/// V2 of [`load_db_initial_handler`]. Walks every schema (main/temp/
+/// attached) via `read_initial_v2` and returns the full graph.
+fn load_db_initial_v2_handler(
+    workdir: &Path,
+    rel: &str,
+    page_size: u32,
+) -> Result<serde_json::Value, (ErrorCode, String)> {
+    use reef::backend::BackendError;
+    use reef::backend::local::canonical_child_within;
+    let none_value = || {
+        serde_json::to_value(None::<reef_proto::DatabaseInfoV2Dto>)
+            .map_err(|e| (ErrorCode::Protocol, format!("encode: {e}")))
+    };
+    let abs = match canonical_child_within(workdir, Path::new(rel)) {
+        Ok(p) => p,
+        Err(BackendError::NotFound) => return none_value(),
+        Err(e) => return Err(backend_err(e)),
+    };
+    if !abs.is_file() {
+        return none_value();
+    }
+    if !reef_sqlite_preview::has_sqlite_extension(Path::new(rel)) {
+        return none_value();
+    }
+    match reef_sqlite_preview::probe_magic(&abs) {
+        Ok(false) => return none_value(),
+        Err(e) => return Err((ErrorCode::Io, e.to_string())),
+        Ok(true) => {}
+    }
+    match reef_sqlite_preview::read_initial_v2(&abs, page_size) {
+        Ok(info) => serde_json::to_value(Some(database_info_v2_to_dto(info)))
+            .map_err(|e| (ErrorCode::Protocol, format!("encode: {e}"))),
+        Err(e) => Err((ErrorCode::Other, format!("sqlite: {e}"))),
+    }
+}
+
+fn load_db_page_v2_handler(
+    workdir: &Path,
+    rel: &str,
+    schema: &str,
+    kind: reef_proto::DbObjectKindDto,
+    name: &str,
+    offset: u64,
+    limit: u32,
+) -> Result<serde_json::Value, (ErrorCode, String)> {
+    use reef::backend::BackendError;
+    use reef::backend::local::canonical_child_within;
+    let abs = match canonical_child_within(workdir, Path::new(rel)) {
+        Ok(p) => p,
+        Err(BackendError::NotFound) => return Err((ErrorCode::NotFound, "file not found".into())),
+        Err(e) => return Err(backend_err(e)),
+    };
+    if !abs.is_file() {
+        return Err((ErrorCode::NotFound, "not a regular file".into()));
+    }
+    match reef_sqlite_preview::load_page_qualified(
+        &abs,
+        schema,
+        db_object_kind_from_dto(kind),
+        name,
+        offset,
+        limit,
+    ) {
+        Ok(page) => serde_json::to_value(db_page_to_dto(page))
+            .map_err(|e| (ErrorCode::Protocol, format!("encode: {e}"))),
+        Err(e) => Err((ErrorCode::Other, format!("sqlite: {e}"))),
+    }
+}
+
+fn load_db_object_detail_handler(
+    workdir: &Path,
+    rel: &str,
+    schema: &str,
+    kind: reef_proto::DbObjectKindDto,
+    name: &str,
+) -> Result<serde_json::Value, (ErrorCode, String)> {
+    use reef::backend::BackendError;
+    use reef::backend::local::canonical_child_within;
+    let abs = match canonical_child_within(workdir, Path::new(rel)) {
+        Ok(p) => p,
+        Err(BackendError::NotFound) => return Err((ErrorCode::NotFound, "file not found".into())),
+        Err(e) => return Err(backend_err(e)),
+    };
+    if !abs.is_file() {
+        return Err((ErrorCode::NotFound, "not a regular file".into()));
+    }
+    match reef_sqlite_preview::read_object_detail_at(
+        &abs,
+        schema,
+        db_object_kind_from_dto(kind),
+        name,
+    ) {
+        Ok(detail) => serde_json::to_value(db_object_detail_to_dto(detail))
+            .map_err(|e| (ErrorCode::Protocol, format!("encode: {e}"))),
+        Err(e) => Err((ErrorCode::Other, format!("sqlite: {e}"))),
+    }
+}
+
+fn database_info_v2_to_dto(
+    d: reef_sqlite_preview::DatabaseInfoV2,
+) -> reef_proto::DatabaseInfoV2Dto {
+    reef_proto::DatabaseInfoV2Dto {
+        schemas: d.schemas.into_iter().map(schema_summary_to_dto).collect(),
+        default_schema: d.default_schema,
+        default_object: d.default_object.map(db_object_key_to_dto),
+        initial_page: db_page_to_dto(d.initial_page),
+        bytes_on_disk: d.bytes_on_disk,
+    }
+}
+
+fn schema_summary_to_dto(s: reef_sqlite_preview::SchemaSummary) -> reef_proto::SchemaSummaryDto {
+    reef_proto::SchemaSummaryDto {
+        name: s.name,
+        kind: schema_kind_to_dto(s.kind),
+        file: s.file,
+        objects: s.objects.into_iter().map(db_object_to_dto).collect(),
+        truncated: s.truncated,
+    }
+}
+
+fn db_object_to_dto(o: reef_sqlite_preview::DbObject) -> reef_proto::DbObjectDto {
+    reef_proto::DbObjectDto {
+        schema: o.schema,
+        name: o.name,
+        kind: db_object_kind_to_dto(o.kind),
+        tbl_name: o.tbl_name,
+        row_count: o.row_count,
+        columns: o.columns.into_iter().map(column_info_to_dto).collect(),
+        is_virtual: o.is_virtual,
+        is_without_rowid: o.is_without_rowid,
+        is_strict: o.is_strict,
+    }
+}
+
+fn db_object_key_to_dto(k: reef_sqlite_preview::DbObjectKey) -> reef_proto::DbObjectKeyDto {
+    reef_proto::DbObjectKeyDto {
+        schema: k.schema,
+        name: k.name,
+        kind: db_object_kind_to_dto(k.kind),
+    }
+}
+
+fn db_object_kind_to_dto(k: reef_sqlite_preview::DbObjectKind) -> reef_proto::DbObjectKindDto {
+    match k {
+        reef_sqlite_preview::DbObjectKind::Table => reef_proto::DbObjectKindDto::Table,
+        reef_sqlite_preview::DbObjectKind::View => reef_proto::DbObjectKindDto::View,
+        reef_sqlite_preview::DbObjectKind::Index => reef_proto::DbObjectKindDto::Index,
+        reef_sqlite_preview::DbObjectKind::Trigger => reef_proto::DbObjectKindDto::Trigger,
+    }
+}
+
+fn db_object_kind_from_dto(k: reef_proto::DbObjectKindDto) -> reef_sqlite_preview::DbObjectKind {
+    match k {
+        reef_proto::DbObjectKindDto::Table => reef_sqlite_preview::DbObjectKind::Table,
+        reef_proto::DbObjectKindDto::View => reef_sqlite_preview::DbObjectKind::View,
+        reef_proto::DbObjectKindDto::Index => reef_sqlite_preview::DbObjectKind::Index,
+        reef_proto::DbObjectKindDto::Trigger => reef_sqlite_preview::DbObjectKind::Trigger,
+    }
+}
+
+fn schema_kind_to_dto(k: reef_sqlite_preview::SchemaKind) -> reef_proto::SchemaKindDto {
+    match k {
+        reef_sqlite_preview::SchemaKind::Main => reef_proto::SchemaKindDto::Main,
+        reef_sqlite_preview::SchemaKind::Temp => reef_proto::SchemaKindDto::Temp,
+        reef_sqlite_preview::SchemaKind::Attached => reef_proto::SchemaKindDto::Attached,
+    }
+}
+
+fn db_object_detail_to_dto(
+    d: reef_sqlite_preview::DbObjectDetail,
+) -> reef_proto::DbObjectDetailDto {
+    use reef_sqlite_preview::DbObjectDetail as D;
+    match d {
+        D::Table { create_sql } => reef_proto::DbObjectDetailDto::Table { create_sql },
+        D::View { create_sql } => reef_proto::DbObjectDetailDto::View { create_sql },
+        D::Index {
+            unique,
+            columns,
+            partial_where,
+            tbl_name,
+            create_sql,
+        } => reef_proto::DbObjectDetailDto::Index {
+            unique,
+            columns,
+            partial_where,
+            tbl_name,
+            create_sql,
+        },
+        D::Trigger {
+            timing,
+            event,
+            tbl_name,
+            sql,
+        } => reef_proto::DbObjectDetailDto::Trigger {
+            timing: trigger_timing_to_dto(timing),
+            event: trigger_event_to_dto(event),
+            tbl_name,
+            sql,
+        },
+    }
+}
+
+fn trigger_timing_to_dto(t: reef_sqlite_preview::TriggerTiming) -> reef_proto::TriggerTimingDto {
+    match t {
+        reef_sqlite_preview::TriggerTiming::Before => reef_proto::TriggerTimingDto::Before,
+        reef_sqlite_preview::TriggerTiming::After => reef_proto::TriggerTimingDto::After,
+        reef_sqlite_preview::TriggerTiming::InsteadOf => reef_proto::TriggerTimingDto::InsteadOf,
+        reef_sqlite_preview::TriggerTiming::Unknown => reef_proto::TriggerTimingDto::Unknown,
+    }
+}
+
+fn trigger_event_to_dto(e: reef_sqlite_preview::TriggerEvent) -> reef_proto::TriggerEventDto {
+    match e {
+        reef_sqlite_preview::TriggerEvent::Insert => reef_proto::TriggerEventDto::Insert,
+        reef_sqlite_preview::TriggerEvent::Update => reef_proto::TriggerEventDto::Update,
+        reef_sqlite_preview::TriggerEvent::Delete => reef_proto::TriggerEventDto::Delete,
+        reef_sqlite_preview::TriggerEvent::Unknown => reef_proto::TriggerEventDto::Unknown,
     }
 }

--- a/crates/reef-proto/src/lib.rs
+++ b/crates/reef-proto/src/lib.rs
@@ -69,7 +69,16 @@ pub const MAX_FRAME_SIZE: u32 = 16 * 1024 * 1024;
 ///       their bytes. A v7 agent would respond `Unknown op` to either,
 ///       so a hard bump surfaces the stale agent as a toast and
 ///       triggers auto-redeploy.
-pub const PROTOCOL_VERSION: u32 = 8;
+/// - v9: SQLite preview goes multi-schema. Adds `LoadDbInitialV2`,
+///       `LoadDbPageV2`, and `LoadDbObjectDetail` alongside the v7
+///       single-schema requests. The new variants carry schema +
+///       object-kind qualifiers (the V1 ones assumed `main` + table).
+///       A v8 agent would respond `Unknown op` on a v9 request; the
+///       client downgrades to V1 when handshake reports
+///       `protocol_version < 9` (or on `Unimplemented`) and wraps the
+///       single-schema result back into the V2 shape so the renderer
+///       stays unified.
+pub const PROTOCOL_VERSION: u32 = 9;
 
 /// Encode a single envelope-level value to `writer` using the
 /// length-prefixed framing. The caller is expected to flush.
@@ -356,6 +365,42 @@ pub enum Request {
         table: String,
         offset: u64,
         limit: u32,
+    },
+    // ── M5+v9: SQLite preview, multi-schema variant ────
+    /// V2 of `LoadDbInitial`. Returns the full schema graph
+    /// (`PRAGMA database_list` + tables/views/indexes/triggers across
+    /// all schemas) plus the first page of rows for the default
+    /// selection. Response is `Option<DatabaseInfoV2Dto>` — `None`
+    /// when the agent's magic-bytes probe rejects the file. v8-and-
+    /// older agents respond `Unimplemented`; the client downgrades to
+    /// `LoadDbInitial`.
+    LoadDbInitialV2 {
+        rel_path: String,
+        page_size: u32,
+    },
+    /// V2 of `LoadDbPage`. `schema` + `kind` qualify the object so the
+    /// agent can route to the correct schema-qualified `SELECT`. The
+    /// response is `DbPageDto`; on `kind = Index | Trigger` the agent
+    /// returns `ErrorCode::Other` with `UnsupportedObjectKind`
+    /// stringified — callers should route those to
+    /// [`LoadDbObjectDetail`] instead.
+    LoadDbPageV2 {
+        rel_path: String,
+        schema: String,
+        kind: DbObjectKindDto,
+        name: String,
+        offset: u64,
+        limit: u32,
+    },
+    /// Structural detail for a single schema-qualified object. Used by
+    /// the UI when the user selects an index / trigger (data pane swaps
+    /// for a definition card). Tables / views also work — they return
+    /// their `CREATE` SQL.
+    LoadDbObjectDetail {
+        rel_path: String,
+        schema: String,
+        kind: DbObjectKindDto,
+        name: String,
     },
 }
 
@@ -789,6 +834,16 @@ pub struct ColumnInfoDto {
     /// empty for typeless columns or non-standard like
     /// `"VARCHAR(255)"`).
     pub decl_type: String,
+    /// `true` when the column has a `NOT NULL` constraint. Defaulted on
+    /// the wire so a v8 agent's payload (which doesn't include this
+    /// field) deserialises cleanly into the v9 client's struct.
+    #[serde(default)]
+    pub notnull: bool,
+    /// `true` when the column participates in the primary key (matches
+    /// `PRAGMA table_info.pk != 0`). Same defaulting story as
+    /// `notnull` — see above.
+    #[serde(default)]
+    pub pk: bool,
 }
 
 /// One page of rows from a table. Each inner Vec aligns positionally
@@ -821,6 +876,127 @@ pub enum SqliteValueDto {
     },
     Blob {
         len: u64,
+    },
+}
+
+// ── v9: multi-schema preview DTOs ──────────────────────────────────────────
+//
+// Mirrors the V2 type set in `reef-sqlite-preview` 1:1. The `From<Domain>`
+// impls live alongside the V1 ones in `src/backend/remote.rs`.
+
+/// Kind tag used in [`LoadDbPageV2`] / [`LoadDbObjectDetail`] payloads
+/// and inside [`DbObjectDto`]. Mirror of
+/// `reef_sqlite_preview::DbObjectKind`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum DbObjectKindDto {
+    Table,
+    View,
+    Index,
+    Trigger,
+}
+
+/// Classification of a row in `PRAGMA database_list`. Mirror of
+/// `reef_sqlite_preview::SchemaKind`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum SchemaKindDto {
+    Main,
+    Temp,
+    Attached,
+}
+
+/// Identifier for one schema-qualified object. Hashable so client-side
+/// state can key on it (e.g. selection caches, generation tokens).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct DbObjectKeyDto {
+    pub schema: String,
+    pub name: String,
+    pub kind: DbObjectKindDto,
+}
+
+/// One object discovered in a schema's `sqlite_master`. Wire mirror of
+/// `reef_sqlite_preview::DbObject` — see that doc comment for field
+/// semantics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DbObjectDto {
+    pub schema: String,
+    pub name: String,
+    pub kind: DbObjectKindDto,
+    pub tbl_name: Option<String>,
+    pub row_count: Option<u64>,
+    pub columns: Vec<ColumnInfoDto>,
+    pub is_virtual: bool,
+    pub is_without_rowid: bool,
+    pub is_strict: bool,
+}
+
+/// One schema's worth of objects plus identifying metadata. Mirror of
+/// `reef_sqlite_preview::SchemaSummary`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchemaSummaryDto {
+    pub name: String,
+    pub kind: SchemaKindDto,
+    pub file: Option<String>,
+    pub objects: Vec<DbObjectDto>,
+    pub truncated: bool,
+}
+
+/// Top-level v9 payload. Wire mirror of
+/// `reef_sqlite_preview::DatabaseInfoV2`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DatabaseInfoV2Dto {
+    pub schemas: Vec<SchemaSummaryDto>,
+    pub default_schema: String,
+    pub default_object: Option<DbObjectKeyDto>,
+    pub initial_page: DbPageDto,
+    pub bytes_on_disk: u64,
+}
+
+/// Trigger timing mirror.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TriggerTimingDto {
+    Before,
+    After,
+    InsteadOf,
+    Unknown,
+}
+
+/// Trigger DML event mirror.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TriggerEventDto {
+    Insert,
+    Update,
+    Delete,
+    Unknown,
+}
+
+/// Detail-pane payload. Tag-style enum so the client can dispatch on
+/// the `kind` discriminator. Mirror of
+/// `reef_sqlite_preview::DbObjectDetail`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DbObjectDetailDto {
+    Table {
+        create_sql: Option<String>,
+    },
+    View {
+        create_sql: Option<String>,
+    },
+    Index {
+        unique: bool,
+        columns: Vec<String>,
+        partial_where: Option<String>,
+        tbl_name: String,
+        create_sql: Option<String>,
+    },
+    Trigger {
+        timing: TriggerTimingDto,
+        event: TriggerEventDto,
+        tbl_name: String,
+        sql: String,
     },
 }
 

--- a/crates/reef-sqlite-preview/src/lib.rs
+++ b/crates/reef-sqlite-preview/src/lib.rs
@@ -80,6 +80,15 @@ pub enum PreviewError {
     /// File IO error at the magic-bytes probe stage (file vanished,
     /// permission denied, etc.).
     Io(String),
+    /// Caller asked for row data on a kind that doesn't have rows
+    /// (Index / Trigger). Surfaced as a typed error so the UI can
+    /// route to the detail pane instead of querying a bogus page.
+    UnsupportedObjectKind,
+    /// A specific schema-qualified object wasn't found in `sqlite_master`.
+    /// Happens when the cached UI state refers to an object that has
+    /// been dropped underneath us (rare with `mode=ro`, but possible
+    /// across reconnects).
+    ObjectNotFound { schema: String, name: String },
 }
 
 impl std::fmt::Display for PreviewError {
@@ -90,6 +99,12 @@ impl std::fmt::Display for PreviewError {
             PreviewError::OpenFailed(s) => write!(f, "open failed: {s}"),
             PreviewError::QueryFailed(s) => write!(f, "query failed: {s}"),
             PreviewError::Io(s) => write!(f, "io: {s}"),
+            PreviewError::UnsupportedObjectKind => {
+                f.write_str("object kind has no rows (index/trigger)")
+            }
+            PreviewError::ObjectNotFound { schema, name } => {
+                write!(f, "object not found: {schema}.{name}")
+            }
         }
     }
 }
@@ -101,10 +116,16 @@ impl std::error::Error for PreviewError {}
 /// strict, so the declared type may be empty (no declared type) or
 /// a non-standard string ("VARCHAR(255)", "DATETIME", …). We pass it
 /// through verbatim and let the render layer truncate if needed.
+///
+/// `notnull` and `pk` are populated from the same `PRAGMA table_info`
+/// row; renderers use them for inline column annotations (PK / NOT NULL
+/// chips in detail views) without an extra round-trip.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ColumnInfo {
     pub name: String,
     pub decl_type: String,
+    pub notnull: bool,
+    pub pk: bool,
 }
 
 /// One table or view in the database.
@@ -185,6 +206,252 @@ pub struct DatabaseInfo {
     /// here so the reader is the single source of truth for size.
     pub bytes_on_disk: u64,
 }
+
+// ─── V2 multi-schema types ──────────────────────────────────────────────
+//
+// The V1 [`DatabaseInfo`] above assumes a single `main` schema with only
+// tables + views. V2 widens the model to mirror what SQLite actually
+// exposes: `PRAGMA database_list` returns `main` plus `temp` plus any
+// ATTACHed files, each with its own `sqlite_master` table covering
+// tables, views, indexes, triggers, and virtual tables. The wire DTOs
+// in `reef-proto` (V2 variants) mirror these structs 1:1.
+
+/// One kind of database object as recorded in `sqlite_master.type`.
+/// Virtual tables share the `Table` variant — the distinction is
+/// carried separately on [`DbObject::is_virtual`] so existing
+/// kind-based dispatch (has-rows? has-detail-pane?) stays clean.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DbObjectKind {
+    Table,
+    View,
+    Index,
+    Trigger,
+}
+
+impl DbObjectKind {
+    /// Tables and views have queryable rows; indexes and triggers don't.
+    /// The renderer routes the data pane vs the detail pane on this
+    /// boolean, and [`load_page_qualified`] rejects non-row kinds.
+    pub fn has_rows(self) -> bool {
+        matches!(self, Self::Table | Self::View)
+    }
+
+    /// Value seen in `sqlite_master.type`.
+    pub fn as_master_type(self) -> &'static str {
+        match self {
+            Self::Table => "table",
+            Self::View => "view",
+            Self::Index => "index",
+            Self::Trigger => "trigger",
+        }
+    }
+
+    /// Inverse of [`Self::as_master_type`]. Returns `None` for unknown
+    /// strings so we can gracefully skip any future type SQLite adds.
+    pub fn from_master_type(s: &str) -> Option<Self> {
+        match s {
+            "table" => Some(Self::Table),
+            "view" => Some(Self::View),
+            "index" => Some(Self::Index),
+            "trigger" => Some(Self::Trigger),
+            _ => None,
+        }
+    }
+
+    /// Title-case plural form used by the sidebar's subsection header
+    /// (e.g. `Tables (12)`).
+    pub fn section_label(self) -> &'static str {
+        match self {
+            Self::Table => "Tables",
+            Self::View => "Views",
+            Self::Index => "Indexes",
+            Self::Trigger => "Triggers",
+        }
+    }
+}
+
+/// Classification for a row in `PRAGMA database_list`. The renderer
+/// uses this to group schemas (Main first, then Temp, then Attached).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SchemaKind {
+    /// The default `main` schema — the on-disk file itself.
+    Main,
+    /// The implicit `temp` schema for CREATE TEMP TABLE / VIEW. Only
+    /// populated when the connection has temp objects, but the entry
+    /// itself appears in `PRAGMA database_list` whether or not any
+    /// temp objects exist.
+    Temp,
+    /// A schema attached via `ATTACH DATABASE … AS name`. The reader
+    /// never issues ATTACH itself; this variant exists so a UI feature
+    /// that does (or a connection inherited from an external source)
+    /// renders correctly.
+    Attached,
+}
+
+/// Identifier for a single schema-qualified object. Hashable + Clone
+/// so the UI can use it as a HashMap / BTreeSet key (e.g. for the
+/// "currently selected object" pointer in `DbPreviewState`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DbObjectKey {
+    pub schema: String,
+    pub name: String,
+    pub kind: DbObjectKind,
+}
+
+/// One object discovered in a schema's `sqlite_master`. Carries every
+/// field the UI needs to render its sidebar row + decide whether to
+/// load a page (`kind.has_rows()`) or a detail pane.
+///
+/// `columns` is populated eagerly for Table / View so the initial RPC
+/// payload covers the whole schema in one round-trip; Index / Trigger
+/// leave it empty.
+#[derive(Debug, Clone)]
+pub struct DbObject {
+    pub schema: String,
+    pub name: String,
+    pub kind: DbObjectKind,
+    /// For Index / Trigger: the table they reference. For Table / View:
+    /// `Some(name)` (sqlite_master sets `tbl_name = name` for those).
+    pub tbl_name: Option<String>,
+    /// `None` for non-row kinds and for views (where COUNT(*) might be
+    /// expensive). Tables always populate this eagerly.
+    pub row_count: Option<u64>,
+    /// Empty for Index / Trigger.
+    pub columns: Vec<ColumnInfo>,
+    /// `true` when the table was created via `CREATE VIRTUAL TABLE`
+    /// (FTS, RTree, etc.). The renderer adds a `ⓥ` glyph to the
+    /// sidebar row.
+    pub is_virtual: bool,
+    /// Best-effort: parsed from the trailing `WITHOUT ROWID` modifier
+    /// in `sqlite_master.sql`. Display-only, doesn't affect querying.
+    pub is_without_rowid: bool,
+    /// Best-effort: parsed from a trailing `STRICT` modifier.
+    pub is_strict: bool,
+}
+
+impl DbObject {
+    pub fn key(&self) -> DbObjectKey {
+        DbObjectKey {
+            schema: self.schema.clone(),
+            name: self.name.clone(),
+            kind: self.kind,
+        }
+    }
+}
+
+/// One schema in `PRAGMA database_list`, with its full object inventory.
+#[derive(Debug, Clone)]
+pub struct SchemaSummary {
+    pub name: String,
+    pub kind: SchemaKind,
+    /// File path SQLite reports for this schema. Empty for `temp`
+    /// (in-memory), `Some` for `main` (the opened file) and any
+    /// attached schemas. We expose the raw string; the renderer
+    /// shortens it for display.
+    pub file: Option<String>,
+    pub objects: Vec<DbObject>,
+    /// `true` when [`MAX_OBJECTS_PER_SCHEMA`] kicked in and trimmed
+    /// the list. The renderer shows a "+N more" hint when set.
+    pub truncated: bool,
+}
+
+/// Top-level V2 payload. Built once per `.db` open; pagination still
+/// goes through [`load_page_qualified`].
+#[derive(Debug, Clone)]
+pub struct DatabaseInfoV2 {
+    pub schemas: Vec<SchemaSummary>,
+    /// Schema chosen as the initial selection — `main` when present.
+    pub default_schema: String,
+    /// Object the initial page was read from. `None` only when every
+    /// schema is empty.
+    pub default_object: Option<DbObjectKey>,
+    /// First page of rows for `default_object`, or empty.
+    pub initial_page: DbPage,
+    pub bytes_on_disk: u64,
+}
+
+impl DatabaseInfoV2 {
+    /// Look up an object by its schema-qualified key. Returns `None`
+    /// when the key references a schema or object that's not in the
+    /// graph (stale selection across previews).
+    pub fn lookup(&self, key: &DbObjectKey) -> Option<&DbObject> {
+        self.schemas
+            .iter()
+            .find(|s| s.name == key.schema)?
+            .objects
+            .iter()
+            .find(|o| o.name == key.name && o.kind == key.kind)
+    }
+
+    /// Flat iterator over every row-bearing object (Tables + Views)
+    /// across every schema. Used by the pagination footer to compute
+    /// `(i/N)` and by `db_navigate` to walk the navigation cycle.
+    pub fn iter_row_bearing(&self) -> impl Iterator<Item = &DbObject> {
+        self.schemas
+            .iter()
+            .flat_map(|s| s.objects.iter())
+            .filter(|o| o.kind.has_rows())
+    }
+}
+
+/// When a trigger fires relative to the row event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TriggerTiming {
+    Before,
+    After,
+    /// `INSTEAD OF` triggers, which only attach to views.
+    InsteadOf,
+    /// Couldn't parse the timing from the CREATE TRIGGER SQL. Renderer
+    /// falls back to displaying the raw SQL.
+    Unknown,
+}
+
+/// Which DML event the trigger reacts to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TriggerEvent {
+    Insert,
+    Update,
+    Delete,
+    Unknown,
+}
+
+/// Detail-pane payload for a non-row object (Index / Trigger) or a
+/// schema-level description of a Table / View. Indexes contribute
+/// uniqueness + column ordering + partial-WHERE clause; triggers
+/// contribute parsed timing/event plus the raw SQL body.
+#[derive(Debug, Clone)]
+pub enum DbObjectDetail {
+    Table {
+        create_sql: Option<String>,
+    },
+    View {
+        create_sql: Option<String>,
+    },
+    Index {
+        unique: bool,
+        /// Indexed column names in key order. Entries are `"<expr>"`
+        /// for expression indexes where SQLite can't surface a name.
+        columns: Vec<String>,
+        /// Tail of `CREATE INDEX … WHERE <expr>` when this is a
+        /// partial index. Best-effort string slice.
+        partial_where: Option<String>,
+        /// Table this index belongs to.
+        tbl_name: String,
+        create_sql: Option<String>,
+    },
+    Trigger {
+        timing: TriggerTiming,
+        event: TriggerEvent,
+        tbl_name: String,
+        sql: String,
+    },
+}
+
+/// Per-schema cap on object listing. Most real databases have ≤ a few
+/// hundred objects; this is defensive against pathological auto-generated
+/// schemas (per-tenant tables, ETL staging fan-out, etc.) so a single
+/// browse doesn't allocate a million strings.
+pub const MAX_OBJECTS_PER_SCHEMA: usize = 5_000;
 
 /// `true` when `path` has a SQLite-shaped extension. Cheap pre-filter —
 /// the actual gate is [`probe_magic`].
@@ -298,21 +565,44 @@ fn list_tables(conn: &Connection) -> Result<Vec<TableSummary>, PreviewError> {
     Ok(out)
 }
 
-/// Read column metadata via `PRAGMA table_info`. Order matches the
-/// table's declared column order — same as a `SELECT *` would yield.
+/// Read column metadata for a table in the default `main` schema. Thin
+/// wrapper over [`read_columns_qualified`] kept for the V1 wire path —
+/// internal callers (V2) should use the qualified version directly.
 fn read_columns(conn: &Connection, table: &str) -> Result<Vec<ColumnInfo>, PreviewError> {
-    // `PRAGMA table_info` doesn't accept bound parameters in older
-    // SQLite, but `pragma_table_info` (table-valued function) does.
-    // Use the latter so a malicious table name (none, here, but the
-    // habit is cheap) can't escape its quoting.
+    read_columns_qualified(conn, "main", table)
+}
+
+/// Read column metadata via `PRAGMA <schema>.table_info(<table>)`. Order
+/// matches the table's declared column order — same as a `SELECT *`
+/// would yield. Returns name, declared type, NOT NULL flag, and primary
+/// key flag.
+///
+/// PRAGMA statements don't accept bound parameters in SQLite, so the
+/// schema and table identifiers are interpolated through [`quote_ident`]
+/// — safe by construction (double-quote wrapping with embedded-quote
+/// doubling), and identifiers come from `sqlite_master` / `PRAGMA
+/// database_list` rather than user input.
+pub fn read_columns_qualified(
+    conn: &Connection,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<ColumnInfo>, PreviewError> {
+    let sql = format!(
+        "PRAGMA {}.table_info({})",
+        quote_ident(schema),
+        quote_ident(table)
+    );
     let mut stmt = conn
-        .prepare("SELECT name, type FROM pragma_table_info(?1)")
+        .prepare(&sql)
         .map_err(|e| PreviewError::QueryFailed(e.to_string()))?;
+    // PRAGMA table_info returns: cid, name, type, notnull, dflt_value, pk
     let cols: Vec<ColumnInfo> = stmt
-        .query_map([table], |row| {
+        .query_map([], |row| {
             Ok(ColumnInfo {
-                name: row.get::<_, String>(0)?,
-                decl_type: row.get::<_, String>(1).unwrap_or_default(),
+                name: row.get::<_, String>(1)?,
+                decl_type: row.get::<_, Option<String>>(2)?.unwrap_or_default(),
+                notnull: row.get::<_, i64>(3)? != 0,
+                pk: row.get::<_, i64>(5)? != 0,
             })
         })
         .map_err(|e| PreviewError::QueryFailed(e.to_string()))?
@@ -321,11 +611,21 @@ fn read_columns(conn: &Connection, table: &str) -> Result<Vec<ColumnInfo>, Previ
     Ok(cols)
 }
 
-/// `SELECT COUNT(*) FROM "table"`. Cheap on small/medium tables; gets
-/// pricier on multi-million-row tables but still fast enough for a
-/// preview load.
+/// `SELECT COUNT(*) FROM "schema"."table"`. Cheap on small/medium
+/// tables; gets pricier on multi-million-row tables but still fast
+/// enough for a preview load.
 fn count_rows(conn: &Connection, table: &str) -> Result<u64, PreviewError> {
-    let sql = format!("SELECT COUNT(*) FROM {}", quote_ident(table));
+    count_rows_qualified(conn, "main", table)
+}
+
+/// Schema-qualified variant of [`count_rows`]. Used by V2 to count rows
+/// in `temp` and attached schemas; V1 wraps this with `schema="main"`.
+pub fn count_rows_qualified(
+    conn: &Connection,
+    schema: &str,
+    table: &str,
+) -> Result<u64, PreviewError> {
+    let sql = format!("SELECT COUNT(*) FROM {}", quote_qualified(schema, table));
     conn.query_row(&sql, [], |row| row.get::<_, i64>(0))
         .map(|n| n.max(0) as u64)
         .map_err(|e| PreviewError::QueryFailed(e.to_string()))
@@ -336,7 +636,7 @@ fn count_rows(conn: &Connection, table: &str) -> Result<u64, PreviewError> {
 /// `https://sqlite.org/lang_keywords.html`. We can't bind table names
 /// as parameters in standard SQL — they're identifiers, not values —
 /// so this is the safe-by-construction path.
-fn quote_ident(ident: &str) -> String {
+pub fn quote_ident(ident: &str) -> String {
     let mut out = String::with_capacity(ident.len() + 2);
     out.push('"');
     for ch in ident.chars() {
@@ -351,6 +651,14 @@ fn quote_ident(ident: &str) -> String {
     out
 }
 
+/// Quote a schema-qualified identifier as `"schema"."name"`. Both halves
+/// go through [`quote_ident`] so a malicious-looking schema or object
+/// name (none in practice — both come from `sqlite_master` / `PRAGMA
+/// database_list`) can't escape the quoting.
+pub fn quote_qualified(schema: &str, name: &str) -> String {
+    format!("{}.{}", quote_ident(schema), quote_ident(name))
+}
+
 /// Read one page of rows from `table`. `offset` and `limit` map
 /// directly to the SQL clauses — note that SQLite's `LIMIT N OFFSET M`
 /// is O(M) for tables without a usable index, so high page numbers
@@ -363,26 +671,52 @@ pub fn load_page(
     offset: u64,
     limit: u32,
 ) -> Result<DbPage, PreviewError> {
+    load_page_qualified(path, "main", DbObjectKind::Table, table, offset, limit)
+}
+
+/// Schema + kind-aware variant of [`load_page`]. Used by the V2 wire
+/// path so the UI can browse `temp` schema tables, attached databases,
+/// and views (which are read identically to tables — `SELECT * FROM
+/// view_name`).
+///
+/// Returns [`PreviewError::UnsupportedObjectKind`] when called with
+/// `kind = Index | Trigger` — those don't have rows and should be
+/// routed through [`read_object_detail`] instead.
+pub fn load_page_qualified(
+    path: &Path,
+    schema: &str,
+    kind: DbObjectKind,
+    name: &str,
+    offset: u64,
+    limit: u32,
+) -> Result<DbPage, PreviewError> {
+    if !kind.has_rows() {
+        return Err(PreviewError::UnsupportedObjectKind);
+    }
     if !probe_magic(path)? {
         return Err(PreviewError::NotSqlite);
     }
     let conn = open_readonly(path)?;
-    read_page(&conn, table, offset, limit)
+    read_page_qualified(&conn, schema, name, offset, limit)
 }
 
-fn read_page(
+fn read_page_qualified(
     conn: &Connection,
-    table: &str,
+    schema: &str,
+    name: &str,
     offset: u64,
     limit: u32,
 ) -> Result<DbPage, PreviewError> {
-    let columns = read_columns(conn, table)?;
+    let columns = read_columns_qualified(conn, schema, name)?;
     if columns.is_empty() {
-        // Either the table doesn't exist or is genuinely zero-column —
+        // Either the object doesn't exist or is genuinely zero-column —
         // both rare and both handled identically (empty page).
         return Ok(DbPage { rows: Vec::new() });
     }
-    let sql = format!("SELECT * FROM {} LIMIT ?1 OFFSET ?2", quote_ident(table));
+    let sql = format!(
+        "SELECT * FROM {} LIMIT ?1 OFFSET ?2",
+        quote_qualified(schema, name)
+    );
     let mut stmt = conn
         .prepare(&sql)
         .map_err(|e| PreviewError::QueryFailed(e.to_string()))?;
@@ -481,7 +815,13 @@ pub fn read_initial(path: &Path, initial_page_size: u32) -> Result<DatabaseInfo,
         .map(|(i, _)| i)
         .unwrap_or(0);
 
-    let initial_page = read_page(&conn, &tables[selected_table].name, 0, initial_page_size)?;
+    let initial_page = read_page_qualified(
+        &conn,
+        "main",
+        &tables[selected_table].name,
+        0,
+        initial_page_size,
+    )?;
 
     Ok(DatabaseInfo {
         tables,
@@ -489,6 +829,525 @@ pub fn read_initial(path: &Path, initial_page_size: u32) -> Result<DatabaseInfo,
         initial_page,
         bytes_on_disk,
     })
+}
+
+// ─── V2 multi-schema reader ─────────────────────────────────────────────
+
+/// List schemas attached to this connection. Always returns at least one
+/// entry (`main`) — `temp` is also always listed even when empty, and
+/// any user-issued `ATTACH DATABASE` shows up here too.
+pub fn list_databases(
+    conn: &Connection,
+) -> Result<Vec<(String, SchemaKind, Option<String>)>, PreviewError> {
+    let mut stmt = conn
+        .prepare("PRAGMA database_list")
+        .map_err(|e| PreviewError::QueryFailed(e.to_string()))?;
+    // Columns: seq (int), name (text), file (text — may be empty for
+    // in-memory / temp). Map empty-string file to `None`.
+    let rows = stmt
+        .query_map([], |row| {
+            let name: String = row.get(1)?;
+            let file: Option<String> = row.get::<_, Option<String>>(2)?;
+            let kind = match name.as_str() {
+                "main" => SchemaKind::Main,
+                "temp" => SchemaKind::Temp,
+                _ => SchemaKind::Attached,
+            };
+            let file_opt = file.filter(|s| !s.is_empty());
+            Ok((name, kind, file_opt))
+        })
+        .map_err(|e| PreviewError::QueryFailed(e.to_string()))?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|e| PreviewError::QueryFailed(e.to_string()))
+}
+
+/// List every user-visible object in one schema, with eagerly-populated
+/// columns + row counts for tables. `max_count` caps the returned `Vec`;
+/// the second element of the returned tuple is `true` when the cap
+/// kicked in.
+///
+/// Filtering rules:
+/// - `name NOT LIKE 'sqlite_%'` excludes internal bookkeeping
+///   (`sqlite_sequence`, `sqlite_autoindex_*`, etc.).
+/// - FTS5 shadow tables (`<vt>_data`, `<vt>_idx`, `<vt>_content`,
+///   `<vt>_docsize`, `<vt>_config`) are hidden when their parent
+///   virtual table appears in the same schema. Modern SQLite populates
+///   `sqlite_master.sql` for these shadows so we can't rely on
+///   `sql IS NULL` as the discriminator.
+/// - Rows with NULL sql that we still can't classify are dropped — they
+///   represent auto-created bookkeeping the user almost never wants.
+/// - Ordering: tables, then views, then indexes, then triggers; within
+///   each, alphabetically.
+pub fn list_objects(
+    conn: &Connection,
+    schema: &str,
+    max_count: usize,
+) -> Result<(Vec<DbObject>, bool), PreviewError> {
+    let master = format!("{}.sqlite_master", quote_ident(schema));
+    let sql = format!(
+        "SELECT type, name, tbl_name, sql FROM {master} \
+         WHERE name NOT LIKE 'sqlite_%' \
+         ORDER BY \
+           CASE type WHEN 'table' THEN 0 WHEN 'view' THEN 1 \
+                     WHEN 'index' THEN 2 WHEN 'trigger' THEN 3 \
+                     ELSE 4 END, \
+           name"
+    );
+    let mut stmt = conn
+        .prepare(&sql)
+        .map_err(|e| PreviewError::QueryFailed(e.to_string()))?;
+    let raw: Vec<(String, String, Option<String>, Option<String>)> = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+            ))
+        })
+        .map_err(|e| PreviewError::QueryFailed(e.to_string()))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|e| PreviewError::QueryFailed(e.to_string()))?;
+
+    // Collect virtual-table names so we can recognise and drop their
+    // FTS shadow tables in the post-filter below. Modern FTS5 records
+    // shadow tables in sqlite_master with non-NULL sql, so we can't
+    // filter them out in the SQL WHERE clause alone.
+    let virtual_tables: std::collections::HashSet<String> = raw
+        .iter()
+        .filter(|(t, _, _, sql)| {
+            t == "table" && sql.as_deref().is_some_and(is_create_virtual_table)
+        })
+        .map(|(_, name, _, _)| name.clone())
+        .collect();
+
+    let is_fts_shadow = |name: &str| -> bool {
+        const SHADOW_SUFFIXES: &[&str] = &["_data", "_idx", "_content", "_docsize", "_config"];
+        for suffix in SHADOW_SUFFIXES {
+            if let Some(stripped) = name.strip_suffix(suffix)
+                && virtual_tables.contains(stripped)
+            {
+                return true;
+            }
+        }
+        false
+    };
+
+    let filtered: Vec<_> = raw
+        .into_iter()
+        .filter(|(t, name, _, sql)| {
+            // Drop FTS shadows (regardless of sql presence).
+            if t == "table" && is_fts_shadow(name) {
+                return false;
+            }
+            // Drop rows with NULL sql except for genuine virtual tables
+            // (their sql IS populated). NULL-sql rows that survive past
+            // the FTS shadow filter are auto-indexes / other internal
+            // helpers the user can't act on.
+            sql.is_some()
+        })
+        .collect();
+
+    let truncated = filtered.len() > max_count;
+    let mut out = Vec::with_capacity(filtered.len().min(max_count));
+    for (type_str, name, tbl_name, sql) in filtered.into_iter().take(max_count) {
+        let Some(kind) = DbObjectKind::from_master_type(&type_str) else {
+            continue;
+        };
+        let sql_ref = sql.as_deref();
+        let is_virtual = sql_ref.is_some_and(is_create_virtual_table);
+        let is_without_rowid = sql_ref.is_some_and(sql_has_without_rowid_suffix);
+        let is_strict = sql_ref.is_some_and(sql_has_strict_modifier);
+
+        // Eagerly populate columns for table / view so the UI can size
+        // its data grid without a follow-up RPC. For indexes / triggers
+        // we leave the vec empty — they don't have a row schema.
+        let columns = if matches!(kind, DbObjectKind::Table | DbObjectKind::View) {
+            read_columns_qualified(conn, schema, &name).unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+
+        // Row counts: tables only. Views might be expensive (arbitrary
+        // SELECT); indexes / triggers don't have rows. Failures here
+        // are soft — we'd rather show the object with `—` count than
+        // hide it.
+        let row_count = if matches!(kind, DbObjectKind::Table) {
+            count_rows_qualified(conn, schema, &name).ok()
+        } else {
+            None
+        };
+
+        out.push(DbObject {
+            schema: schema.to_string(),
+            name,
+            kind,
+            tbl_name,
+            row_count,
+            columns,
+            is_virtual,
+            is_without_rowid,
+            is_strict,
+        });
+    }
+    Ok((out, truncated))
+}
+
+/// Top-level V2 entry. Walks every schema, reads its objects, picks an
+/// initial selection (smallest non-empty table in `main`), and reads
+/// one page of rows. The returned [`DatabaseInfoV2`] is everything the
+/// UI needs to render its first frame.
+pub fn read_initial_v2(
+    path: &Path,
+    initial_page_size: u32,
+) -> Result<DatabaseInfoV2, PreviewError> {
+    let meta = std::fs::metadata(path).map_err(|e| PreviewError::Io(e.to_string()))?;
+    let bytes_on_disk = meta.len();
+    if bytes_on_disk > MAX_PREVIEW_BYTES {
+        return Err(PreviewError::TooLarge {
+            size: bytes_on_disk,
+        });
+    }
+    if !probe_magic(path)? {
+        return Err(PreviewError::NotSqlite);
+    }
+
+    let conn = open_readonly(path)?;
+
+    let dbs = list_databases(&conn)?;
+    let mut schemas = Vec::with_capacity(dbs.len());
+    for (db_name, kind, file) in dbs {
+        let (objects, truncated) = list_objects(&conn, &db_name, MAX_OBJECTS_PER_SCHEMA)?;
+        schemas.push(SchemaSummary {
+            name: db_name,
+            kind,
+            file,
+            objects,
+            truncated,
+        });
+    }
+
+    // Default schema: prefer `main`, then first schema with objects,
+    // then just the first schema.
+    let default_schema = schemas
+        .iter()
+        .find(|s| s.kind == SchemaKind::Main)
+        .map(|s| s.name.clone())
+        .or_else(|| {
+            schemas
+                .iter()
+                .find(|s| !s.objects.is_empty())
+                .map(|s| s.name.clone())
+        })
+        .or_else(|| schemas.first().map(|s| s.name.clone()))
+        .unwrap_or_else(|| "main".to_string());
+
+    // Default object: smallest non-empty table in default schema, else
+    // first table-or-view in default schema. Indexes / triggers never
+    // chosen as initial selection.
+    let default_object = schemas
+        .iter()
+        .find(|s| s.name == default_schema)
+        .and_then(pick_default_object);
+
+    let initial_page = match &default_object {
+        Some(key) if key.kind.has_rows() => {
+            read_page_qualified(&conn, &key.schema, &key.name, 0, initial_page_size)?
+        }
+        _ => DbPage { rows: Vec::new() },
+    };
+
+    Ok(DatabaseInfoV2 {
+        schemas,
+        default_schema,
+        default_object,
+        initial_page,
+        bytes_on_disk,
+    })
+}
+
+/// Path-level convenience: open a read-only connection on the file and
+/// dispatch to [`read_object_detail`]. Mirrors the V1 [`load_page`]
+/// shape so call sites (agent handlers, local backend) don't have to
+/// open the connection themselves.
+pub fn read_object_detail_at(
+    path: &Path,
+    schema: &str,
+    kind: DbObjectKind,
+    name: &str,
+) -> Result<DbObjectDetail, PreviewError> {
+    if !probe_magic(path)? {
+        return Err(PreviewError::NotSqlite);
+    }
+    let conn = open_readonly(path)?;
+    read_object_detail(&conn, schema, kind, name)
+}
+
+/// Dispatch detail-pane reads by object kind. Tables / Views return
+/// their `CREATE` SQL; Indexes / Triggers return parsed structural
+/// detail (see [`DbObjectDetail`]).
+pub fn read_object_detail(
+    conn: &Connection,
+    schema: &str,
+    kind: DbObjectKind,
+    name: &str,
+) -> Result<DbObjectDetail, PreviewError> {
+    match kind {
+        DbObjectKind::Index => read_index_detail(conn, schema, name),
+        DbObjectKind::Trigger => read_trigger_detail(conn, schema, name),
+        DbObjectKind::Table => Ok(DbObjectDetail::Table {
+            create_sql: read_create_sql(conn, schema, name)?,
+        }),
+        DbObjectKind::View => Ok(DbObjectDetail::View {
+            create_sql: read_create_sql(conn, schema, name)?,
+        }),
+    }
+}
+
+/// Read an index's structural detail: unique flag (from `index_list`),
+/// column ordering (from `index_info`), partial-WHERE expression
+/// (sliced from `sqlite_master.sql`).
+pub fn read_index_detail(
+    conn: &Connection,
+    schema: &str,
+    name: &str,
+) -> Result<DbObjectDetail, PreviewError> {
+    let master = format!("{}.sqlite_master", quote_ident(schema));
+    let master_sql = format!("SELECT tbl_name, sql FROM {master} WHERE type='index' AND name=?1");
+    let (tbl_name, create_sql): (String, Option<String>) = conn
+        .query_row(&master_sql, rusqlite::params![name], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+        })
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => PreviewError::ObjectNotFound {
+                schema: schema.to_string(),
+                name: name.to_string(),
+            },
+            other => PreviewError::QueryFailed(other.to_string()),
+        })?;
+
+    // PRAGMA index_info returns: seqno, cid, name (NULL for expressions).
+    let info_sql = format!(
+        "PRAGMA {}.index_info({})",
+        quote_ident(schema),
+        quote_ident(name)
+    );
+    let mut stmt = conn
+        .prepare(&info_sql)
+        .map_err(|e| PreviewError::QueryFailed(e.to_string()))?;
+    let columns: Vec<String> = stmt
+        .query_map([], |row| {
+            row.get::<_, Option<String>>(2)
+                .map(|n| n.unwrap_or_else(|| "<expr>".to_string()))
+        })
+        .map_err(|e| PreviewError::QueryFailed(e.to_string()))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|e| PreviewError::QueryFailed(e.to_string()))?;
+
+    // PRAGMA index_list returns: seq, name, unique, origin, partial.
+    // We could pull `partial` directly but the WHERE clause itself
+    // only lives in `sqlite_master.sql`, so parse it from there.
+    let list_sql = format!(
+        "PRAGMA {}.index_list({})",
+        quote_ident(schema),
+        quote_ident(&tbl_name)
+    );
+    let mut stmt = conn
+        .prepare(&list_sql)
+        .map_err(|e| PreviewError::QueryFailed(e.to_string()))?;
+    let unique = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(1)?, row.get::<_, i64>(2)? != 0))
+        })
+        .map_err(|e| PreviewError::QueryFailed(e.to_string()))?
+        .filter_map(|r| r.ok())
+        .find(|(n, _)| n == name)
+        .map(|(_, u)| u)
+        .unwrap_or(false);
+
+    let partial_where = create_sql.as_deref().and_then(extract_partial_where);
+
+    Ok(DbObjectDetail::Index {
+        unique,
+        columns,
+        partial_where,
+        tbl_name,
+        create_sql,
+    })
+}
+
+/// Read a trigger's structural detail. Timing + event are parsed from
+/// the header tokens of the CREATE TRIGGER SQL (best-effort) and the
+/// raw body is preserved for display.
+pub fn read_trigger_detail(
+    conn: &Connection,
+    schema: &str,
+    name: &str,
+) -> Result<DbObjectDetail, PreviewError> {
+    let master = format!("{}.sqlite_master", quote_ident(schema));
+    let master_sql = format!("SELECT tbl_name, sql FROM {master} WHERE type='trigger' AND name=?1");
+    let (tbl_name, sql): (String, String) = conn
+        .query_row(&master_sql, rusqlite::params![name], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+            ))
+        })
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => PreviewError::ObjectNotFound {
+                schema: schema.to_string(),
+                name: name.to_string(),
+            },
+            other => PreviewError::QueryFailed(other.to_string()),
+        })?;
+
+    let (timing, event) = parse_trigger_header(&sql);
+    Ok(DbObjectDetail::Trigger {
+        timing,
+        event,
+        tbl_name,
+        sql,
+    })
+}
+
+/// Helper: read `sqlite_master.sql` for an object, regardless of type.
+/// Used by [`read_object_detail`] for Table / View.
+fn read_create_sql(
+    conn: &Connection,
+    schema: &str,
+    name: &str,
+) -> Result<Option<String>, PreviewError> {
+    let master = format!("{}.sqlite_master", quote_ident(schema));
+    let sql = format!("SELECT sql FROM {master} WHERE name=?1");
+    match conn.query_row(&sql, rusqlite::params![name], |row| {
+        row.get::<_, Option<String>>(0)
+    }) {
+        Ok(s) => Ok(s),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(PreviewError::QueryFailed(e.to_string())),
+    }
+}
+
+// ─── V2 parsing helpers ─────────────────────────────────────────────────
+
+fn pick_default_object(schema: &SchemaSummary) -> Option<DbObjectKey> {
+    // Smallest non-empty table wins. Tied counts → alphabetical (the
+    // object list is already sorted that way, so min_by_key is stable
+    // on ties via insertion order).
+    let smallest_table = schema
+        .objects
+        .iter()
+        .filter(|o| matches!(o.kind, DbObjectKind::Table) && o.row_count.unwrap_or(0) > 0)
+        .min_by_key(|o| o.row_count.unwrap_or(u64::MAX));
+    if let Some(o) = smallest_table {
+        return Some(o.key());
+    }
+    // No non-empty tables → first table-or-view, so the user lands on
+    // something with a (possibly empty) data grid rather than a blank
+    // pane.
+    schema
+        .objects
+        .iter()
+        .find(|o| matches!(o.kind, DbObjectKind::Table | DbObjectKind::View))
+        .map(DbObject::key)
+}
+
+fn is_create_virtual_table(sql: &str) -> bool {
+    // "CREATE VIRTUAL TABLE" is 20 ASCII bytes; compare via byte slice
+    // to avoid the String allocation that `chars().take(20).collect()`
+    // would impose on every list_objects row.
+    const PREFIX: &[u8; 20] = b"CREATE VIRTUAL TABLE";
+    let bytes = sql.trim_start().as_bytes();
+    bytes.len() >= PREFIX.len() && bytes[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
+}
+
+fn sql_has_without_rowid_suffix(sql: &str) -> bool {
+    let trimmed = sql.trim_end_matches(|c: char| c.is_whitespace() || c == ';');
+    // Comparison target is pure ASCII, so we can byte-compare the tail
+    // without touching the UTF-8 boundaries elsewhere in the string —
+    // important because user table comments / column names commonly
+    // contain multi-byte characters (CJK, emoji, accented Latin) and
+    // a naive `&trimmed[trimmed.len()-N..]` slice can land mid-char
+    // and panic.
+    let tail = b"without rowid";
+    let bytes = trimmed.as_bytes();
+    bytes.len() >= tail.len() && bytes[bytes.len() - tail.len()..].eq_ignore_ascii_case(tail)
+}
+
+fn sql_has_strict_modifier(sql: &str) -> bool {
+    // STRICT can appear either at the trailing end (after the closing
+    // paren) or alongside WITHOUT ROWID separated by a comma. Cheap
+    // best-effort scan — display-only, no querying behavior depends on
+    // this.
+    let trimmed = sql.trim_end_matches(|c: char| c.is_whitespace() || c == ';');
+    let lower = trimmed.to_lowercase();
+    lower.ends_with("strict")
+        || lower.contains(", strict")
+        || lower.contains(",strict")
+        || lower.contains(" strict,")
+        || lower.contains(" strict ")
+}
+
+fn extract_partial_where(sql: &str) -> Option<String> {
+    // Last `WHERE` token in the CREATE INDEX is the partial predicate.
+    // Case-insensitive search by lowercasing only the ASCII letters
+    // in-place at the byte level, which preserves byte positions
+    // identical to `sql`'s — so the position from `rfind` can safely
+    // slice back into `sql`. (Calling `str::to_lowercase` would shift
+    // byte indices for non-ASCII chars like 'İ' or 'ß'.)
+    let mut lower_bytes = sql.as_bytes().to_vec();
+    for b in lower_bytes.iter_mut() {
+        b.make_ascii_lowercase();
+    }
+    let key = b" where ";
+    let pos = lower_bytes.windows(key.len()).rposition(|w| w == key)?;
+    let start = pos + key.len();
+    // `start` is guaranteed to be at a UTF-8 char boundary because
+    // it follows the ASCII space character — the byte after a single
+    // ASCII byte is always a boundary.
+    let rest = sql[start..].trim().trim_end_matches(';').trim();
+    if rest.is_empty() {
+        None
+    } else {
+        Some(rest.to_string())
+    }
+}
+
+fn parse_trigger_header(sql: &str) -> (TriggerTiming, TriggerEvent) {
+    // Header = everything before the `BEGIN` keyword. Splitting at a
+    // word boundary avoids matching `BEGIN` inside an identifier (rare,
+    // but possible since SQLite tolerates `BEGIN` quoted as an
+    // identifier).
+    let lower = sql.to_lowercase();
+    let header_end = lower
+        .find(" begin ")
+        .or_else(|| lower.find("\nbegin"))
+        .or_else(|| lower.find("\tbegin"))
+        .unwrap_or(lower.len());
+    let header: &str = &lower[..header_end];
+    let tokens: Vec<&str> = header.split_whitespace().collect();
+
+    let timing = if tokens.contains(&"before") {
+        TriggerTiming::Before
+    } else if tokens.contains(&"after") {
+        TriggerTiming::After
+    } else if tokens.windows(2).any(|w| w[0] == "instead" && w[1] == "of") {
+        TriggerTiming::InsteadOf
+    } else {
+        TriggerTiming::Unknown
+    };
+
+    let event = if tokens.contains(&"insert") {
+        TriggerEvent::Insert
+    } else if tokens.contains(&"update") {
+        TriggerEvent::Update
+    } else if tokens.contains(&"delete") {
+        TriggerEvent::Delete
+    } else {
+        TriggerEvent::Unknown
+    };
+
+    (timing, event)
 }
 
 #[cfg(test)]
@@ -790,5 +1649,49 @@ mod tests {
         let fake = tmp.path().join("fake.db");
         std::fs::write(&fake, b"definitely not a database").unwrap();
         assert!(!is_sqlite_file(&fake));
+    }
+
+    #[test]
+    fn read_initial_v2_handles_multibyte_comments_in_ddl() {
+        // Regression: SQL helpers were byte-slicing the trailing bytes
+        // of `sqlite_master.sql` to detect `WITHOUT ROWID`, which
+        // panicked when the boundary landed inside a multi-byte
+        // character. Real-world DBs frequently keep CJK column
+        // comments in their stored DDL (the user's `sofast.db`
+        // surfaced this).
+        let (_tmp, path) = setup_db(&[
+            "CREATE TABLE stars (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL, -- 收藏项的标题
+                description TEXT,    -- 收藏项的描述
+                type TEXT NOT NULL,  -- 内容类型，例如 'link', 'image', 'text'
+                content TEXT,         -- 实际内容
+                created_at INTEGER
+            )",
+            "INSERT INTO stars(id, title, type) VALUES \
+                ('1','示例','link'),('2','another','image')",
+            "CREATE INDEX idx_stars_type ON stars(type) WHERE type = 'link'",
+        ]);
+        let info = read_initial_v2(&path, 5).expect("read_initial_v2 must not panic on CJK DDL");
+        let main = info.schemas.iter().find(|s| s.name == "main").unwrap();
+        let stars = main.objects.iter().find(|o| o.name == "stars").unwrap();
+        assert!(!stars.is_without_rowid);
+        let idx = main
+            .objects
+            .iter()
+            .find(|o| o.name == "idx_stars_type")
+            .expect("partial index should be listed");
+        assert_eq!(idx.kind, DbObjectKind::Index);
+    }
+
+    #[test]
+    fn extract_partial_where_works_with_multibyte_surrounding_text() {
+        // Partial WHERE extraction used to slice the original sql at
+        // a byte index derived from `to_lowercase()` — which can
+        // shift indices for non-ASCII letters. Now we lowercase
+        // bytes in-place to keep positions stable.
+        let sql = "CREATE INDEX i ON stars(type) -- 注释 \n WHERE type = 'link'";
+        let got = extract_partial_where(sql).unwrap();
+        assert!(got.contains("type = 'link'"), "extracted WHERE was {got:?}");
     }
 }

--- a/crates/reef-sqlite-preview/tests/multi_schema.rs
+++ b/crates/reef-sqlite-preview/tests/multi_schema.rs
@@ -1,0 +1,392 @@
+//! Integration coverage for the V2 multi-schema API.
+//!
+//! These tests exercise the path that `reef-agent` will route over the
+//! wire for v9 protocol clients: `list_databases` + `list_objects` for
+//! each schema, schema-qualified column reads, index/trigger detail
+//! parsing, and the `UnsupportedObjectKind` guard on `load_page_qualified`.
+//!
+//! The crate's lib-level tests cover the V1 read path. We deliberately
+//! drive these from `tests/` so the public surface is exercised the
+//! way a real downstream caller (the agent, the local backend) would
+//! see it — no internal helpers reachable.
+
+use std::path::PathBuf;
+
+use reef_sqlite_preview::{
+    DbObjectDetail, DbObjectKind, MAX_OBJECTS_PER_SCHEMA, PreviewError, SchemaKind, TriggerEvent,
+    TriggerTiming, count_rows_qualified, list_databases, list_objects, load_page_qualified,
+    read_columns_qualified, read_index_detail, read_initial_v2, read_object_detail,
+    read_trigger_detail,
+};
+use rusqlite::Connection;
+
+/// Write a tempfile-backed SQLite database from one batch of DDL and
+/// return the path (kept alive by the returned `TempDir`). Mirrors the
+/// V1 lib-test helper but at integration scope.
+fn setup_file_db(setup_sql: &str) -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("fixture.db");
+    let conn = Connection::open(&path).unwrap();
+    conn.execute_batch(setup_sql).unwrap();
+    drop(conn);
+    (tmp, path)
+}
+
+/// Build an in-memory `Connection` populated with every object kind we
+/// care about plus an attached in-memory aux database. Returned
+/// connection keeps the ATTACH alive as long as the caller holds it.
+fn in_memory_with_attach() -> Connection {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        r#"
+        ATTACH DATABASE ':memory:' AS aux;
+
+        -- Plain table with PK + NOT NULL column for column-metadata
+        -- coverage.
+        CREATE TABLE main.users (
+            id INTEGER PRIMARY KEY,
+            email TEXT NOT NULL,
+            display_name TEXT
+        );
+        INSERT INTO main.users(id, email, display_name)
+            VALUES (1, 'a@x.io', 'Alice'),
+                   (2, 'b@x.io', 'Bob'),
+                   (3, 'c@x.io', NULL);
+
+        -- Empty table — exercises row_count = Some(0) path.
+        CREATE TABLE main.orders (id INTEGER, user_id INTEGER);
+
+        -- View — should be listed under Views, columns populated, but
+        -- row_count left as None per the policy in list_objects.
+        CREATE VIEW main.active_users AS
+            SELECT id, email FROM users WHERE display_name IS NOT NULL;
+
+        -- Plain unique index for read_index_detail coverage.
+        CREATE UNIQUE INDEX main.users_email_idx ON users(email);
+
+        -- Partial index — read_index_detail must surface the WHERE.
+        CREATE INDEX main.users_named_idx ON users(display_name)
+            WHERE display_name IS NOT NULL;
+
+        -- Trigger — parse_trigger_header must pick AFTER / INSERT.
+        CREATE TRIGGER main.users_audit
+            AFTER INSERT ON users
+            BEGIN
+                SELECT 1;
+            END;
+
+        -- Virtual table (fts5 if compiled in; fall back to a sentinel
+        -- module name otherwise so the prefix detection still fires).
+        CREATE VIRTUAL TABLE main.notes USING fts5(body);
+
+        -- Temp table — appears under the `temp` schema in
+        -- PRAGMA database_list.
+        CREATE TEMP TABLE temp_scratch (n INTEGER);
+        INSERT INTO temp_scratch VALUES (1), (2);
+
+        -- Object in the attached schema — must appear under `aux`.
+        CREATE TABLE aux.shadow (id INTEGER PRIMARY KEY, payload TEXT);
+        INSERT INTO aux.shadow VALUES (1, 'hi'), (2, 'world');
+        "#,
+    )
+    .unwrap();
+    conn
+}
+
+#[test]
+fn list_databases_returns_main_temp_and_attached() {
+    let conn = in_memory_with_attach();
+    let dbs = list_databases(&conn).unwrap();
+
+    let names: Vec<&str> = dbs.iter().map(|(n, _, _)| n.as_str()).collect();
+    assert!(names.contains(&"main"), "main missing: {names:?}");
+    assert!(names.contains(&"temp"), "temp missing: {names:?}");
+    assert!(names.contains(&"aux"), "aux missing: {names:?}");
+
+    // SchemaKind classification.
+    let kinds: std::collections::HashMap<_, _> =
+        dbs.iter().map(|(n, k, _)| (n.as_str(), *k)).collect();
+    assert_eq!(kinds["main"], SchemaKind::Main);
+    assert_eq!(kinds["temp"], SchemaKind::Temp);
+    assert_eq!(kinds["aux"], SchemaKind::Attached);
+}
+
+#[test]
+fn list_objects_main_covers_all_four_kinds_plus_virtual() {
+    let conn = in_memory_with_attach();
+    let (objects, truncated) = list_objects(&conn, "main", MAX_OBJECTS_PER_SCHEMA).unwrap();
+
+    assert!(!truncated, "truncation must not fire on a tiny fixture");
+
+    // Bucket by kind for readable assertions.
+    let by_kind: std::collections::HashMap<DbObjectKind, Vec<&str>> = {
+        let mut m: std::collections::HashMap<DbObjectKind, Vec<&str>> =
+            std::collections::HashMap::new();
+        for o in &objects {
+            m.entry(o.kind).or_default().push(o.name.as_str());
+        }
+        m
+    };
+
+    assert!(by_kind[&DbObjectKind::Table].contains(&"users"));
+    assert!(by_kind[&DbObjectKind::Table].contains(&"orders"));
+    assert!(by_kind[&DbObjectKind::Table].contains(&"notes")); // virtual
+    assert!(by_kind[&DbObjectKind::View].contains(&"active_users"));
+    assert!(by_kind[&DbObjectKind::Index].contains(&"users_email_idx"));
+    assert!(by_kind[&DbObjectKind::Index].contains(&"users_named_idx"));
+    assert!(by_kind[&DbObjectKind::Trigger].contains(&"users_audit"));
+
+    // Virtual table must flag `is_virtual`.
+    let notes = objects.iter().find(|o| o.name == "notes").unwrap();
+    assert!(notes.is_virtual, "notes must be flagged as virtual");
+
+    // Plain table must NOT flag `is_virtual`.
+    let users = objects.iter().find(|o| o.name == "users").unwrap();
+    assert!(!users.is_virtual);
+
+    // row_count is populated for tables, None for views / indexes /
+    // triggers.
+    assert_eq!(users.row_count, Some(3));
+    let view = objects.iter().find(|o| o.name == "active_users").unwrap();
+    assert_eq!(view.row_count, None);
+    let idx = objects
+        .iter()
+        .find(|o| o.name == "users_email_idx")
+        .unwrap();
+    assert_eq!(idx.row_count, None);
+    let trig = objects.iter().find(|o| o.name == "users_audit").unwrap();
+    assert_eq!(trig.row_count, None);
+
+    // Columns eagerly populated for table; NOT NULL + PK fields
+    // surface for the email + id columns respectively.
+    let id_col = users.columns.iter().find(|c| c.name == "id").unwrap();
+    assert!(id_col.pk);
+    let email_col = users.columns.iter().find(|c| c.name == "email").unwrap();
+    assert!(email_col.notnull);
+    assert!(!email_col.pk);
+}
+
+#[test]
+fn list_objects_excludes_sqlite_internal_and_fts_shadows() {
+    let conn = in_memory_with_attach();
+    let (objects, _) = list_objects(&conn, "main", MAX_OBJECTS_PER_SCHEMA).unwrap();
+    let names: Vec<&str> = objects.iter().map(|o| o.name.as_str()).collect();
+
+    // No internal bookkeeping leaks through.
+    assert!(
+        !names.iter().any(|n| n.starts_with("sqlite_")),
+        "found sqlite_* leak: {names:?}"
+    );
+
+    // FTS5 creates shadow tables `notes_data`, `notes_idx`,
+    // `notes_content`, `notes_docsize`, `notes_config`. All have
+    // sql=NULL in sqlite_master and must be filtered.
+    for shadow_suffix in &["_data", "_idx", "_content", "_docsize", "_config"] {
+        let leaked = format!("notes{shadow_suffix}");
+        assert!(
+            !names.contains(&leaked.as_str()),
+            "fts shadow {leaked} leaked into list"
+        );
+    }
+}
+
+#[test]
+fn list_objects_in_attached_schema() {
+    let conn = in_memory_with_attach();
+    let (objects, _) = list_objects(&conn, "aux", MAX_OBJECTS_PER_SCHEMA).unwrap();
+    let names: Vec<&str> = objects.iter().map(|o| o.name.as_str()).collect();
+    assert_eq!(names, vec!["shadow"]);
+
+    let shadow = &objects[0];
+    assert_eq!(shadow.kind, DbObjectKind::Table);
+    assert_eq!(shadow.row_count, Some(2));
+    assert_eq!(shadow.schema, "aux");
+}
+
+#[test]
+fn list_objects_in_temp_schema() {
+    let conn = in_memory_with_attach();
+    let (objects, _) = list_objects(&conn, "temp", MAX_OBJECTS_PER_SCHEMA).unwrap();
+    let names: Vec<&str> = objects.iter().map(|o| o.name.as_str()).collect();
+    assert!(names.contains(&"temp_scratch"), "{names:?}");
+}
+
+#[test]
+fn read_columns_qualified_round_trips_pk_and_notnull() {
+    let conn = in_memory_with_attach();
+    let cols = read_columns_qualified(&conn, "main", "users").unwrap();
+    let names: Vec<&str> = cols.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(names, vec!["id", "email", "display_name"]);
+    assert!(cols[0].pk);
+    assert!(cols[1].notnull);
+    assert!(!cols[1].pk);
+    assert!(!cols[2].notnull);
+}
+
+#[test]
+fn count_rows_qualified_works_across_schemas() {
+    let conn = in_memory_with_attach();
+    assert_eq!(count_rows_qualified(&conn, "main", "users").unwrap(), 3);
+    assert_eq!(count_rows_qualified(&conn, "main", "orders").unwrap(), 0);
+    assert_eq!(count_rows_qualified(&conn, "aux", "shadow").unwrap(), 2);
+    assert_eq!(
+        count_rows_qualified(&conn, "temp", "temp_scratch").unwrap(),
+        2
+    );
+}
+
+#[test]
+fn read_index_detail_surfaces_unique_and_partial() {
+    let conn = in_memory_with_attach();
+
+    let detail = read_index_detail(&conn, "main", "users_email_idx").unwrap();
+    match detail {
+        DbObjectDetail::Index {
+            unique,
+            columns,
+            partial_where,
+            tbl_name,
+            ..
+        } => {
+            assert!(unique, "users_email_idx must be unique");
+            assert_eq!(columns, vec!["email"]);
+            assert!(partial_where.is_none(), "not a partial index");
+            assert_eq!(tbl_name, "users");
+        }
+        other => panic!("expected Index, got {other:?}"),
+    }
+
+    let detail = read_index_detail(&conn, "main", "users_named_idx").unwrap();
+    match detail {
+        DbObjectDetail::Index {
+            unique,
+            partial_where,
+            ..
+        } => {
+            assert!(!unique);
+            let where_ = partial_where.expect("partial index must surface WHERE");
+            // Case from the CREATE INDEX is preserved.
+            assert!(
+                where_.to_lowercase().contains("display_name is not null"),
+                "where clause was: {where_:?}"
+            );
+        }
+        other => panic!("expected Index, got {other:?}"),
+    }
+}
+
+#[test]
+fn read_trigger_detail_parses_timing_and_event() {
+    let conn = in_memory_with_attach();
+    let detail = read_trigger_detail(&conn, "main", "users_audit").unwrap();
+    match detail {
+        DbObjectDetail::Trigger {
+            timing,
+            event,
+            tbl_name,
+            sql,
+        } => {
+            assert_eq!(timing, TriggerTiming::After);
+            assert_eq!(event, TriggerEvent::Insert);
+            assert_eq!(tbl_name, "users");
+            assert!(sql.to_uppercase().contains("BEGIN"));
+        }
+        other => panic!("expected Trigger, got {other:?}"),
+    }
+}
+
+#[test]
+fn read_object_detail_dispatches_by_kind() {
+    let conn = in_memory_with_attach();
+
+    let t = read_object_detail(&conn, "main", DbObjectKind::Table, "users").unwrap();
+    assert!(matches!(t, DbObjectDetail::Table { .. }));
+
+    let v = read_object_detail(&conn, "main", DbObjectKind::View, "active_users").unwrap();
+    assert!(matches!(v, DbObjectDetail::View { .. }));
+
+    let i = read_object_detail(&conn, "main", DbObjectKind::Index, "users_email_idx").unwrap();
+    assert!(matches!(i, DbObjectDetail::Index { .. }));
+
+    let trg = read_object_detail(&conn, "main", DbObjectKind::Trigger, "users_audit").unwrap();
+    assert!(matches!(trg, DbObjectDetail::Trigger { .. }));
+}
+
+#[test]
+fn read_object_detail_missing_object_is_typed_error() {
+    let conn = in_memory_with_attach();
+    let err = read_object_detail(&conn, "main", DbObjectKind::Index, "no_such_index").unwrap_err();
+    match err {
+        PreviewError::ObjectNotFound { schema, name } => {
+            assert_eq!(schema, "main");
+            assert_eq!(name, "no_such_index");
+        }
+        other => panic!("expected ObjectNotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn load_page_qualified_rejects_index_and_trigger() {
+    let (_tmp, path) = setup_file_db(
+        r#"
+        CREATE TABLE t(a INTEGER);
+        INSERT INTO t VALUES (1), (2), (3);
+        CREATE INDEX t_idx ON t(a);
+        CREATE TRIGGER t_trg AFTER INSERT ON t BEGIN SELECT 1; END;
+        "#,
+    );
+
+    for kind in [DbObjectKind::Index, DbObjectKind::Trigger] {
+        let err = load_page_qualified(&path, "main", kind, "t_idx", 0, 10).unwrap_err();
+        assert!(
+            matches!(err, PreviewError::UnsupportedObjectKind),
+            "expected UnsupportedObjectKind for {kind:?}, got {err:?}"
+        );
+    }
+
+    // Table / view still page successfully.
+    let page = load_page_qualified(&path, "main", DbObjectKind::Table, "t", 0, 10).unwrap();
+    assert_eq!(page.rows.len(), 3);
+}
+
+#[test]
+fn read_initial_v2_walks_real_file_main_schema() {
+    // `read_initial_v2` opens its own RO connection so it can't see
+    // ATTACH or temp objects from another writer. SQLite only lists
+    // `temp` in `PRAGMA database_list` once something on the connection
+    // touches it, so a freshly-opened RO connection on a file fixture
+    // returns just `main`.
+    let (_tmp, path) = setup_file_db(
+        r#"
+        CREATE TABLE rooms(id INTEGER PRIMARY KEY, name TEXT);
+        INSERT INTO rooms(name) VALUES ('alpha'), ('beta');
+        CREATE VIEW room_names AS SELECT name FROM rooms;
+        CREATE INDEX rooms_name_idx ON rooms(name);
+        "#,
+    );
+
+    let info = read_initial_v2(&path, 5).unwrap();
+
+    // At least main is present; temp/aux are connection-state-dependent.
+    let schema_names: Vec<&str> = info.schemas.iter().map(|s| s.name.as_str()).collect();
+    assert!(schema_names.contains(&"main"), "{schema_names:?}");
+
+    // Default schema is main.
+    assert_eq!(info.default_schema, "main");
+
+    // Default object is the smallest non-empty table (only one here).
+    let default = info.default_object.expect("rooms table should be picked");
+    assert_eq!(default.schema, "main");
+    assert_eq!(default.name, "rooms");
+    assert_eq!(default.kind, DbObjectKind::Table);
+
+    // Initial page sampled the rows.
+    assert_eq!(info.initial_page.rows.len(), 2);
+
+    // main schema's object list covers tables / views / indexes.
+    let main = info.schemas.iter().find(|s| s.name == "main").unwrap();
+    let names: Vec<&str> = main.objects.iter().map(|o| o.name.as_str()).collect();
+    assert!(names.contains(&"rooms"));
+    assert!(names.contains(&"room_names"));
+    assert!(names.contains(&"rooms_name_idx"));
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -29,43 +29,44 @@ pub struct BuiltProtocol {
 /// so rapid scrubbing coalesces into a single load.
 const PREVIEW_DEBOUNCE: Duration = Duration::from_millis(80);
 
-/// Pagination + table-selection state for the SQLite preview card.
+/// Pagination + object-selection state for the SQLite preview card.
 /// Lives `Some` for as long as the current `preview_content` is a
 /// `PreviewBody::Database`; rebuilt from `info.initial_page` whenever
 /// a new preview lands and the file changed (see
 /// `apply_worker_result`).
 ///
 /// **Cache invariant**: `col_widths` + `total_table_w` are derived
-/// from `(selected_table, current_rows)`. Any mutation of those two
+/// from `(selection, current_rows)`. Any mutation of those two
 /// fields must call [`Self::recompute_layout`] before the next
 /// render, or the cached widths will desync from the data and the
 /// table will visually misalign. Every mutation site in this file
 /// honors that — when adding new ones, follow suit.
 ///
 /// `current_rows` is the rows shown right now. On `[`/`]`/`PgUp`/`PgDn`
-/// we re-issue `Backend::db_load_page` synchronously and replace this
-/// vec on success. SQLite's open + LIMIT/OFFSET is sub-millisecond
-/// locally; over SSH it's an RPC round-trip (~10-50 ms typical) — a
-/// brief stall on flaky links is the accepted trade-off for keeping
-/// the navigation path simple.
+/// we re-issue `Backend::db_load_page_qualified` synchronously and
+/// replace this vec on success. SQLite's open + LIMIT/OFFSET is
+/// sub-millisecond locally; over SSH it's an RPC round-trip (~10-50 ms
+/// typical) — a brief stall on flaky links is the accepted trade-off
+/// for keeping the navigation path simple.
 #[derive(Debug, Clone)]
 pub struct DbPreviewState {
     /// Workdir-relative path of the SQLite file the state belongs to.
     /// Compared against `preview_content.file_path` on every render to
     /// catch the "file changed but state didn't get cleared" race.
     pub path: String,
-    /// Index into `info.tables`. Bounds-checked at every step.
-    pub selected_table: usize,
+    /// Currently selected object addressed by schema-qualified key.
+    pub selection: reef_sqlite_preview::DbObjectKey,
+    /// Schemas the sidebar currently shows expanded.
+    pub expanded: std::collections::BTreeSet<String>,
     /// Zero-based page index. `offset = page * rows_per_page`.
     pub page: u64,
     /// The rows currently visible. Each inner Vec is one row's cells
     /// in column order; length equals
-    /// `min(rows_per_page, table.row_count - offset)`.
+    /// `min(rows_per_page, object.row_count - offset)`.
     pub current_rows: Vec<Vec<reef_sqlite_preview::SqliteValue>>,
-    /// Page-size used to compute `offset` on the next request.
     pub rows_per_page: u32,
     /// Cached natural column widths for the current
-    /// `(selected_table, current_rows)` combo. Recomputed by
+    /// `(selection, current_rows)` combo. Recomputed by
     /// [`Self::recompute_layout`] on every mutation that changes
     /// either input. The render path consults the cache once per
     /// frame instead of re-walking 50 rows × N columns of UTF-8
@@ -74,61 +75,78 @@ pub struct DbPreviewState {
     /// Cached `Σcol_widths + (n−1)·sep_w` paired with `col_widths`.
     /// Used as the upper bound when clamping `preview_h_scroll`.
     pub total_table_w: usize,
+    /// Detail-pane payload for the currently-selected index / trigger,
+    /// or `None` when the current selection is a table / view (data
+    /// grid takes over) or when the detail RPC hasn't landed yet.
+    pub detail: Option<reef_sqlite_preview::DbObjectDetail>,
 }
 
-/// Navigation actions exposed by the SQLite preview keybindings. Kept
-/// as an enum (rather than separate methods) so the input dispatcher
-/// stays a single match arm per key — `db_navigate` does the bounds
-/// math + the RPC round-trip in one place.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DbNav {
     PrevPage,
     NextPage,
+    /// Previous row-bearing object in the current schema's flat list.
     PrevTable,
+    /// Next row-bearing object in the current schema's flat list.
     NextTable,
     FirstPage,
     LastPage,
 }
 
 impl DbPreviewState {
-    fn from_initial(path: &str, info: &reef_sqlite_preview::DatabaseInfo) -> Self {
+    pub fn from_initial(path: &str, info: &reef_sqlite_preview::DatabaseInfoV2) -> Self {
+        // `default_object` is None only when every schema is empty —
+        // fall back to a synthetic key on the default schema so the
+        // struct is well-formed; renderers branch on `info.lookup()`
+        // returning None to draw the empty state.
+        let selection =
+            info.default_object
+                .clone()
+                .unwrap_or_else(|| reef_sqlite_preview::DbObjectKey {
+                    schema: info.default_schema.clone(),
+                    name: String::new(),
+                    kind: reef_sqlite_preview::DbObjectKind::Table,
+                });
+        let mut expanded = std::collections::BTreeSet::new();
+        expanded.insert(info.default_schema.clone());
+        let columns: &[reef_sqlite_preview::ColumnInfo] = info
+            .lookup(&selection)
+            .map(|o| o.columns.as_slice())
+            .unwrap_or(&[]);
         let mut s = Self {
             path: path.to_string(),
-            selected_table: info.selected_table,
+            selection,
+            expanded,
             page: 0,
             current_rows: info.initial_page.rows.clone(),
             rows_per_page: crate::file_tree::INITIAL_DB_PAGE_ROWS,
             col_widths: Vec::new(),
             total_table_w: 0,
+            detail: None,
         };
-        s.recompute_layout(info);
+        s.recompute_layout(columns);
         s
     }
 
     /// Refresh `col_widths` + `total_table_w` from the current
-    /// `(selected_table, current_rows)` combo. Cheap-ish on its own
-    /// (O(rows × cols × avg_str_len)) but expensive when called per
-    /// frame — this method is the seam where we DO compute, so the
-    /// render path can stay zero-cost on h-scroll.
-    pub fn recompute_layout(&mut self, info: &reef_sqlite_preview::DatabaseInfo) {
-        let columns = info
-            .tables
-            .get(self.selected_table)
-            .map(|t| t.columns.as_slice())
-            .unwrap_or(&[]);
+    /// `(columns, current_rows)` combo. Cheap on its own; called by
+    /// nav helpers right after they swap in fresh rows. Render path
+    /// only reads the cached values, never recomputes.
+    pub fn recompute_layout(&mut self, columns: &[reef_sqlite_preview::ColumnInfo]) {
         self.col_widths = crate::ui::db_preview::natural_column_widths(columns, &self.current_rows);
         self.total_table_w = crate::ui::db_preview::total_table_width(&self.col_widths);
     }
 }
 
-/// Largest valid page index for a table at a given page size. Tables
-/// with zero rows still have one (empty) page, so we floor at 0
-/// rather than letting `(0/N)-1` wrap to `u64::MAX`.
-fn max_page_for(table: &reef_sqlite_preview::TableSummary, page_size: u32) -> u64 {
+/// Largest valid page index for an object at a given page size.
+/// Objects without a populated `row_count` (views, indexes, triggers)
+/// floor to 0 — pagination only meaningful when we know the total.
+fn max_page_for_object(object: &reef_sqlite_preview::DbObject, page_size: u32) -> u64 {
     if page_size == 0 {
         return 0;
     }
-    let pages = table.row_count.div_ceil(page_size as u64);
+    let rows = object.row_count.unwrap_or(0);
+    let pages = rows.div_ceil(page_size as u64);
     pages.saturating_sub(1)
 }
 
@@ -2513,143 +2531,192 @@ impl App {
     /// Navigate the SQLite preview card. Called from the input
     /// dispatcher when the focused panel is the preview pane and
     /// `preview_content.body` is `Database`. Computes the new
-    /// `(table, page)` window, issues a synchronous
-    /// `Backend::db_load_page` round-trip, and replaces
-    /// `db_preview_state.current_rows` on success. Errors land as a
-    /// warning toast.
-    ///
-    /// Runs synchronously on the main thread: locally sub-ms, over
-    /// SSH a single RPC round-trip (~10-50 ms). Brief UI stall on
-    /// flaky links is the accepted trade-off for keeping nav simple.
+    /// `(object, page)` window via the row-bearing flat list and
+    /// delegates to [`Self::db_apply_page`]. Runs synchronously on
+    /// the main thread — local sub-ms, SSH 10-50ms RPC.
     pub fn db_navigate(&mut self, action: DbNav) {
-        // Snapshot the database info we need from the current preview.
-        // We only mutate state when everything below resolves cleanly,
-        // so a stale preview / wrong body / missing state silently
-        // no-ops rather than panicking.
-        let info = match self.preview_content.as_ref().map(|p| &p.body) {
-            Some(PreviewBody::Database(info)) => info.clone(),
-            _ => return,
+        let Some((cur_key, cur_page, rows_per_page)) = self
+            .db_preview_state
+            .as_ref()
+            .map(|s| (s.selection.clone(), s.page, s.rows_per_page))
+        else {
+            return;
         };
-        if info.tables.is_empty() {
+        let Some(info) = self.preview_database_info() else {
+            return;
+        };
+        let visible: Vec<&reef_sqlite_preview::DbObject> = info.iter_row_bearing().collect();
+        if visible.is_empty() {
             return;
         }
-        let state = match self.db_preview_state.as_ref() {
-            Some(s) => s.clone(),
-            None => return,
-        };
-        let max_table = info.tables.len() - 1;
-        let cur_table = state.selected_table.min(max_table);
-
-        // Compute the target (table_idx, page) tuple without touching
-        // self.* yet. `max_page_for` clamps based on the cached
-        // row_count from the initial preview — page totals don't
-        // refresh until a fresh `load_preview` lands, which is fine
-        // because read-only previews can't change row counts under us.
-        let (new_table, new_page) = match action {
-            DbNav::PrevPage => (cur_table, state.page.saturating_sub(1)),
+        let cur_idx = visible
+            .iter()
+            .position(|o| o.name == cur_key.name && o.kind == cur_key.kind)
+            .unwrap_or(0)
+            .min(visible.len() - 1);
+        let max_idx = visible.len() - 1;
+        let (new_idx, new_page) = match action {
+            DbNav::PrevPage => (cur_idx, cur_page.saturating_sub(1)),
             DbNav::NextPage => (
-                cur_table,
-                (state.page + 1).min(max_page_for(&info.tables[cur_table], state.rows_per_page)),
+                cur_idx,
+                (cur_page + 1).min(max_page_for_object(visible[cur_idx], rows_per_page)),
             ),
-            DbNav::PrevTable => (cur_table.saturating_sub(1), 0),
-            DbNav::NextTable => ((cur_table + 1).min(max_table), 0),
-            DbNav::FirstPage => (cur_table, 0),
+            DbNav::PrevTable => (cur_idx.saturating_sub(1), 0),
+            DbNav::NextTable => ((cur_idx + 1).min(max_idx), 0),
+            DbNav::FirstPage => (cur_idx, 0),
             DbNav::LastPage => (
-                cur_table,
-                max_page_for(&info.tables[cur_table], state.rows_per_page),
+                cur_idx,
+                max_page_for_object(visible[cur_idx], rows_per_page),
             ),
         };
-
-        // No-op when the action would land on the same window — keeps
-        // PgUp on page 0 / NextTable at the last table from issuing a
-        // pointless RPC.
-        if new_table == cur_table && new_page == state.page {
+        if new_idx == cur_idx && new_page == cur_page {
             return;
         }
+        let new_key = visible[new_idx].key();
+        self.db_apply_page(
+            new_key,
+            new_page,
+            /* reset_h_scroll = */ new_idx != cur_idx,
+        );
+    }
 
-        let table_name = info.tables[new_table].name.clone();
-        let offset = new_page.saturating_mul(state.rows_per_page as u64);
-        let limit = state.rows_per_page;
-        let path = PathBuf::from(&state.path);
+    /// Toggle the expand / collapse state of one schema in the
+    /// sidebar. No row reload — the data grid keeps its selection.
+    pub fn db_toggle_schema(&mut self, name: &str) {
+        let Some(state) = self.db_preview_state.as_mut() else {
+            return;
+        };
+        if !state.expanded.remove(name) {
+            state.expanded.insert(name.to_string());
+        }
+    }
 
-        let table_changed = new_table != cur_table;
-        match self.backend.db_load_page(&path, &table_name, offset, limit) {
-            Ok(page) => {
-                if let Some(s) = self.db_preview_state.as_mut() {
-                    s.selected_table = new_table;
-                    s.page = new_page;
-                    s.current_rows = page.rows;
-                    s.recompute_layout(&info);
-                }
-                // New page / new table → reset within-page row offset
-                // so the user lands at row 1, not whatever scroll
-                // position they left the previous page at.
-                self.preview_scroll = 0;
-                // Table change → also reset horizontal scroll, since
-                // the new table's natural column widths almost
-                // certainly differ and a leftover h_scroll would land
-                // on a meaningless mid-column position. Page-only
-                // navigation keeps h_scroll so the user can keep
-                // reading the same column across pages.
-                if table_changed {
-                    self.preview_h_scroll = 0;
-                }
-            }
-            Err(e) => {
-                self.toasts
-                    .push(Toast::warn(format!("sqlite page load failed: {e}")));
-            }
+    /// Switch the SQLite preview's selection to a specific
+    /// schema-qualified object. Row-bearing kinds load page 0
+    /// synchronously; non-row kinds (Index / Trigger) stash the
+    /// structural detail in `state.detail` for the detail pane.
+    pub fn db_select_object(&mut self, key: reef_sqlite_preview::DbObjectKey) {
+        let current = self.db_preview_state.as_ref().map(|s| s.selection.clone());
+        if current.as_ref() == Some(&key) {
+            return;
+        }
+        if key.kind.has_rows() {
+            self.db_apply_page(key, 0, /* reset_h_scroll = */ true);
+        } else {
+            self.db_apply_detail(key);
         }
     }
 
     /// Jump to a specific 1-based page in the currently-selected
-    /// table. Used by the `g`-prefix page-jump input. Out-of-range
-    /// pages clamp to the last valid page rather than failing — the
-    /// input prompt enforces that user-typed numbers are well-formed
-    /// before calling this, but range clamping here keeps the contract
-    /// loose enough that a future caller can pass `u64::MAX` and get
-    /// "last page" without an error path.
+    /// object. Out-of-range pages clamp to the last valid page
+    /// rather than failing.
     pub fn db_navigate_to_page(&mut self, page_one_based: u64) {
-        let info = match self.preview_content.as_ref().map(|p| &p.body) {
-            Some(PreviewBody::Database(info)) => info.clone(),
-            _ => return,
+        let Some((selection, cur_page, rows_per_page)) = self
+            .db_preview_state
+            .as_ref()
+            .map(|s| (s.selection.clone(), s.page, s.rows_per_page))
+        else {
+            return;
         };
-        // Empty-tables guard — without it, `info.tables[table_idx]`
-        // below panics on a fresh DB with no user tables that the
-        // user somehow invokes `g`-prefix on.
-        if info.tables.is_empty() {
+        if !selection.kind.has_rows() {
             return;
         }
-        let state = match self.db_preview_state.as_ref() {
-            Some(s) => s.clone(),
-            None => return,
+        let Some(info) = self.preview_database_info() else {
+            return;
         };
-        let table_idx = state.selected_table.min(info.tables.len() - 1);
-        let max_page = max_page_for(&info.tables[table_idx], state.rows_per_page);
+        let Some(object) = info.lookup(&selection) else {
+            return;
+        };
+        let max_page = max_page_for_object(object, rows_per_page);
         let target_page = page_one_based.saturating_sub(1).min(max_page);
-        if target_page == state.page {
+        if target_page == cur_page {
             return;
         }
-        let table_name = info.tables[table_idx].name.clone();
-        let offset = target_page.saturating_mul(state.rows_per_page as u64);
-        let path = PathBuf::from(&state.path);
-        match self
+        self.db_apply_page(selection, target_page, /* reset_h_scroll = */ false);
+    }
+
+    /// Borrow the `DatabaseInfoV2` from the current preview body, or
+    /// `None` when the preview is missing / not a database.
+    fn preview_database_info(&self) -> Option<&reef_sqlite_preview::DatabaseInfoV2> {
+        match self.preview_content.as_ref()?.body {
+            crate::file_tree::PreviewBody::Database(ref info) => Some(info),
+            _ => None,
+        }
+    }
+
+    /// Shared row-load path for `db_navigate*` and `db_select_object`.
+    /// Issues the synchronous backend RPC, updates state on success,
+    /// resets scroll, surfaces errors as a warning toast.
+    fn db_apply_page(
+        &mut self,
+        key: reef_sqlite_preview::DbObjectKey,
+        page: u64,
+        reset_h_scroll: bool,
+    ) {
+        let Some((path, rows_per_page)) = self
+            .db_preview_state
+            .as_ref()
+            .map(|s| (PathBuf::from(&s.path), s.rows_per_page))
+        else {
+            return;
+        };
+        let offset = page.saturating_mul(rows_per_page as u64);
+        let page_data = match self
             .backend
-            .db_load_page(&path, &table_name, offset, state.rows_per_page)
+            .db_load_page(&path, &key, offset, rows_per_page)
         {
-            Ok(page) => {
-                if let Some(s) = self.db_preview_state.as_mut() {
-                    s.page = target_page;
-                    s.current_rows = page.rows;
-                    s.recompute_layout(&info);
-                }
-                self.preview_scroll = 0;
-            }
+            Ok(p) => p,
             Err(e) => {
                 self.toasts
                     .push(Toast::warn(format!("sqlite page load failed: {e}")));
+                return;
             }
+        };
+        // Snapshot column metadata before the &mut self.db_preview_state
+        // borrow so the recompute uses the canonical info-side columns.
+        let columns: Vec<reef_sqlite_preview::ColumnInfo> = self
+            .preview_database_info()
+            .and_then(|info| info.lookup(&key).map(|o| o.columns.clone()))
+            .unwrap_or_default();
+        if let Some(s) = self.db_preview_state.as_mut() {
+            s.selection = key;
+            s.page = page;
+            s.current_rows = page_data.rows;
+            s.detail = None;
+            s.recompute_layout(&columns);
         }
+        self.preview_scroll = 0;
+        if reset_h_scroll {
+            self.preview_h_scroll = 0;
+        }
+    }
+
+    /// Shared detail-load path for Index / Trigger selection clicks.
+    fn db_apply_detail(&mut self, key: reef_sqlite_preview::DbObjectKey) {
+        let Some(path) = self
+            .db_preview_state
+            .as_ref()
+            .map(|s| PathBuf::from(&s.path))
+        else {
+            return;
+        };
+        let detail = match self.backend.db_load_object_detail(&path, &key) {
+            Ok(d) => d,
+            Err(e) => {
+                self.toasts
+                    .push(Toast::warn(format!("sqlite detail load failed: {e}")));
+                return;
+            }
+        };
+        if let Some(s) = self.db_preview_state.as_mut() {
+            s.selection = key;
+            s.detail = Some(detail);
+            s.current_rows.clear();
+            s.col_widths.clear();
+            s.total_table_w = 0;
+        }
+        self.preview_scroll = 0;
+        self.preview_h_scroll = 0;
     }
 
     pub fn load_preview_for_path(&mut self, rel_path: PathBuf) {
@@ -4387,6 +4454,12 @@ impl App {
             }
             ClickAction::DbGotoPage(page) => {
                 self.db_navigate_to_page(page);
+            }
+            ClickAction::DbSelectObject { schema, name, kind } => {
+                self.db_select_object(reef_sqlite_preview::DbObjectKey { schema, name, kind });
+            }
+            ClickAction::DbToggleSchema(name) => {
+                self.db_toggle_schema(&name);
             }
             ClickAction::FindWidgetClose => {
                 crate::find_widget::close(self);

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -404,7 +404,7 @@ impl Backend for LocalBackend {
     fn db_load_page(
         &self,
         rel_path: &Path,
-        table: &str,
+        key: &reef_sqlite_preview::DbObjectKey,
         offset: u64,
         limit: u32,
     ) -> Result<reef_sqlite_preview::DbPage, BackendError> {
@@ -414,7 +414,24 @@ impl Backend for LocalBackend {
         // contents of a sensitive DB outside the workdir if we followed
         // a symlink without checking.
         let full = canonical_child_within(self.canonical_workdir()?, rel_path)?;
-        reef_sqlite_preview::load_page(&full, table, offset, limit)
+        reef_sqlite_preview::load_page_qualified(
+            &full,
+            &key.schema,
+            key.kind,
+            &key.name,
+            offset,
+            limit,
+        )
+        .map_err(|e| BackendError::Other(format!("sqlite: {e}")))
+    }
+
+    fn db_load_object_detail(
+        &self,
+        rel_path: &Path,
+        key: &reef_sqlite_preview::DbObjectKey,
+    ) -> Result<reef_sqlite_preview::DbObjectDetail, BackendError> {
+        let full = canonical_child_within(self.canonical_workdir()?, rel_path)?;
+        reef_sqlite_preview::read_object_detail_at(&full, &key.schema, key.kind, &key.name)
             .map_err(|e| BackendError::Other(format!("sqlite: {e}")))
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -292,23 +292,30 @@ pub trait Backend: Send + Sync {
     /// doesn't resolve to a regular file under the workdir.
     fn file_size(&self, rel_path: &Path) -> Result<u64, BackendError>;
 
-    /// Load one page of rows from a table inside a SQLite database at
-    /// `rel_path`. Used by the Files-tab preview pane's pagination
-    /// flow — `load_preview` builds the initial card with the first
-    /// page bundled in, then `[`/`]`/`PgUp`/`PgDn` route through here
-    /// to reissue with a fresh `(offset, limit)` window.
-    ///
-    /// `offset` and `limit` map directly to `LIMIT N OFFSET M`, with
-    /// the same caveat: cost grows with M for tables without a usable
-    /// index. The reef-sqlite-preview reader documents the keyset
-    /// pagination follow-up if this becomes a real hotspot.
+    /// Load one page of rows from a row-bearing object at `rel_path`.
+    /// `offset` and `limit` map directly to `LIMIT N OFFSET M`; cost
+    /// grows with `offset` on tables without a usable index — see the
+    /// keyset-pagination follow-up note in
+    /// `reef_sqlite_preview::load_page_qualified`. Returns
+    /// `BackendError::Other(...)` for `key.kind = Index | Trigger`;
+    /// callers should route those to [`Self::db_load_object_detail`].
     fn db_load_page(
         &self,
         rel_path: &Path,
-        table: &str,
+        key: &reef_sqlite_preview::DbObjectKey,
         offset: u64,
         limit: u32,
     ) -> Result<reef_sqlite_preview::DbPage, BackendError>;
+
+    /// Detail-pane payload for an index, trigger, table, or view.
+    /// Tables / views return their `CREATE` SQL; indexes return
+    /// uniqueness + column order + partial-WHERE; triggers return
+    /// parsed timing/event + the raw SQL body.
+    fn db_load_object_detail(
+        &self,
+        rel_path: &Path,
+        key: &reef_sqlite_preview::DbObjectKey,
+    ) -> Result<reef_sqlite_preview::DbObjectDetail, BackendError>;
 
     // ─── git: status / diff / stage ─────────────────────────────────────────
     fn git_status(&self) -> Result<StatusSnapshot, BackendError>;

--- a/src/backend/remote.rs
+++ b/src/backend/remote.rs
@@ -18,8 +18,8 @@ use std::thread;
 use std::time::Duration;
 
 use reef_proto::{
-    ContentSearchCompletedDto, ContentSearchRequestDto, DatabaseInfoDto, DirEntryDto, Envelope,
-    MatchHitDto, Notification, ReadFileResponse, Request, Response, TrashResponseDto, WalkOptsDto,
+    ContentSearchCompletedDto, ContentSearchRequestDto, DirEntryDto, Envelope, MatchHitDto,
+    Notification, ReadFileResponse, Request, Response, TrashResponseDto, WalkOptsDto,
     WalkResponseDto, decode_frame, encode_frame,
 };
 
@@ -494,16 +494,17 @@ impl Backend for RemoteBackend {
         // schema + first page of rows. On RPC failure or agent's
         // "not actually sqlite" reply, fall through to the standard
         // ReadFile path so the file still gets a binary card.
-        if reef_sqlite_preview::has_sqlite_extension(rel_path) {
-            if let Ok(Some(dto)) = self.request::<Option<DatabaseInfoDto>>(Request::LoadDbInitial {
-                rel_path: rel_str.clone(),
-                page_size: crate::file_tree::INITIAL_DB_PAGE_ROWS,
-            }) {
-                return Some(PreviewContent {
-                    file_path: rel_str,
-                    body: PreviewBody::Database(database_info_from_dto(dto)),
-                });
-            }
+        if reef_sqlite_preview::has_sqlite_extension(rel_path)
+            && let Ok(Some(dto)) =
+                self.request::<Option<reef_proto::DatabaseInfoV2Dto>>(Request::LoadDbInitialV2 {
+                    rel_path: rel_str.clone(),
+                    page_size: crate::file_tree::INITIAL_DB_PAGE_ROWS,
+                })
+        {
+            return Some(PreviewContent {
+                file_path: rel_str,
+                body: PreviewBody::Database(database_info_v2_from_dto(dto)),
+            });
         }
         let resp: ReadFileResponse = self
             .request(Request::ReadFile {
@@ -571,18 +572,35 @@ impl Backend for RemoteBackend {
     fn db_load_page(
         &self,
         rel_path: &Path,
-        table: &str,
+        key: &reef_sqlite_preview::DbObjectKey,
         offset: u64,
         limit: u32,
     ) -> Result<reef_sqlite_preview::DbPage, BackendError> {
         let rel_str = rel_path.to_string_lossy().to_string();
-        let dto: reef_proto::DbPageDto = self.request(Request::LoadDbPage {
+        let dto: reef_proto::DbPageDto = self.request(Request::LoadDbPageV2 {
             rel_path: rel_str,
-            table: table.to_string(),
+            schema: key.schema.clone(),
+            kind: db_object_kind_to_dto(key.kind),
+            name: key.name.clone(),
             offset,
             limit,
         })?;
         Ok(db_page_from_dto(dto))
+    }
+
+    fn db_load_object_detail(
+        &self,
+        rel_path: &Path,
+        key: &reef_sqlite_preview::DbObjectKey,
+    ) -> Result<reef_sqlite_preview::DbObjectDetail, BackendError> {
+        let rel_str = rel_path.to_string_lossy().to_string();
+        let dto: reef_proto::DbObjectDetailDto = self.request(Request::LoadDbObjectDetail {
+            rel_path: rel_str,
+            schema: key.schema.clone(),
+            kind: db_object_kind_to_dto(key.kind),
+            name: key.name.clone(),
+        })?;
+        Ok(db_object_detail_from_dto(dto))
     }
 
     fn git_status(&self) -> Result<StatusSnapshot, BackendError> {
@@ -1242,27 +1260,136 @@ impl From<reef_proto::RefLabelDto> for RefLabel {
 // here. Free functions instead — slightly noisier at the call site but
 // keeps reef-sqlite-preview wire-agnostic (no reef-proto dep).
 
-fn database_info_from_dto(v: reef_proto::DatabaseInfoDto) -> reef_sqlite_preview::DatabaseInfo {
-    reef_sqlite_preview::DatabaseInfo {
-        tables: v.tables.into_iter().map(table_summary_from_dto).collect(),
-        selected_table: v.selected_table as usize,
+fn column_info_from_dto(v: reef_proto::ColumnInfoDto) -> reef_sqlite_preview::ColumnInfo {
+    reef_sqlite_preview::ColumnInfo {
+        name: v.name,
+        decl_type: v.decl_type,
+        notnull: v.notnull,
+        pk: v.pk,
+    }
+}
+
+// ── v9: multi-schema DTO → domain converters ──────────────────────────────
+
+fn database_info_v2_from_dto(
+    v: reef_proto::DatabaseInfoV2Dto,
+) -> reef_sqlite_preview::DatabaseInfoV2 {
+    reef_sqlite_preview::DatabaseInfoV2 {
+        schemas: v.schemas.into_iter().map(schema_summary_from_dto).collect(),
+        default_schema: v.default_schema,
+        default_object: v.default_object.map(db_object_key_from_dto),
         initial_page: db_page_from_dto(v.initial_page),
         bytes_on_disk: v.bytes_on_disk,
     }
 }
 
-fn table_summary_from_dto(v: reef_proto::TableSummaryDto) -> reef_sqlite_preview::TableSummary {
-    reef_sqlite_preview::TableSummary {
+fn schema_summary_from_dto(v: reef_proto::SchemaSummaryDto) -> reef_sqlite_preview::SchemaSummary {
+    reef_sqlite_preview::SchemaSummary {
         name: v.name,
-        columns: v.columns.into_iter().map(column_info_from_dto).collect(),
-        row_count: v.row_count,
+        kind: schema_kind_from_dto(v.kind),
+        file: v.file,
+        objects: v.objects.into_iter().map(db_object_from_dto).collect(),
+        truncated: v.truncated,
     }
 }
 
-fn column_info_from_dto(v: reef_proto::ColumnInfoDto) -> reef_sqlite_preview::ColumnInfo {
-    reef_sqlite_preview::ColumnInfo {
+fn db_object_from_dto(v: reef_proto::DbObjectDto) -> reef_sqlite_preview::DbObject {
+    reef_sqlite_preview::DbObject {
+        schema: v.schema,
         name: v.name,
-        decl_type: v.decl_type,
+        kind: db_object_kind_from_dto(v.kind),
+        tbl_name: v.tbl_name,
+        row_count: v.row_count,
+        columns: v.columns.into_iter().map(column_info_from_dto).collect(),
+        is_virtual: v.is_virtual,
+        is_without_rowid: v.is_without_rowid,
+        is_strict: v.is_strict,
+    }
+}
+
+fn db_object_key_from_dto(v: reef_proto::DbObjectKeyDto) -> reef_sqlite_preview::DbObjectKey {
+    reef_sqlite_preview::DbObjectKey {
+        schema: v.schema,
+        name: v.name,
+        kind: db_object_kind_from_dto(v.kind),
+    }
+}
+
+fn db_object_kind_to_dto(k: reef_sqlite_preview::DbObjectKind) -> reef_proto::DbObjectKindDto {
+    match k {
+        reef_sqlite_preview::DbObjectKind::Table => reef_proto::DbObjectKindDto::Table,
+        reef_sqlite_preview::DbObjectKind::View => reef_proto::DbObjectKindDto::View,
+        reef_sqlite_preview::DbObjectKind::Index => reef_proto::DbObjectKindDto::Index,
+        reef_sqlite_preview::DbObjectKind::Trigger => reef_proto::DbObjectKindDto::Trigger,
+    }
+}
+
+fn db_object_kind_from_dto(v: reef_proto::DbObjectKindDto) -> reef_sqlite_preview::DbObjectKind {
+    match v {
+        reef_proto::DbObjectKindDto::Table => reef_sqlite_preview::DbObjectKind::Table,
+        reef_proto::DbObjectKindDto::View => reef_sqlite_preview::DbObjectKind::View,
+        reef_proto::DbObjectKindDto::Index => reef_sqlite_preview::DbObjectKind::Index,
+        reef_proto::DbObjectKindDto::Trigger => reef_sqlite_preview::DbObjectKind::Trigger,
+    }
+}
+
+fn schema_kind_from_dto(v: reef_proto::SchemaKindDto) -> reef_sqlite_preview::SchemaKind {
+    match v {
+        reef_proto::SchemaKindDto::Main => reef_sqlite_preview::SchemaKind::Main,
+        reef_proto::SchemaKindDto::Temp => reef_sqlite_preview::SchemaKind::Temp,
+        reef_proto::SchemaKindDto::Attached => reef_sqlite_preview::SchemaKind::Attached,
+    }
+}
+
+fn db_object_detail_from_dto(
+    v: reef_proto::DbObjectDetailDto,
+) -> reef_sqlite_preview::DbObjectDetail {
+    use reef_proto::DbObjectDetailDto as D;
+    match v {
+        D::Table { create_sql } => reef_sqlite_preview::DbObjectDetail::Table { create_sql },
+        D::View { create_sql } => reef_sqlite_preview::DbObjectDetail::View { create_sql },
+        D::Index {
+            unique,
+            columns,
+            partial_where,
+            tbl_name,
+            create_sql,
+        } => reef_sqlite_preview::DbObjectDetail::Index {
+            unique,
+            columns,
+            partial_where,
+            tbl_name,
+            create_sql,
+        },
+        D::Trigger {
+            timing,
+            event,
+            tbl_name,
+            sql,
+        } => reef_sqlite_preview::DbObjectDetail::Trigger {
+            timing: trigger_timing_from_dto(timing),
+            event: trigger_event_from_dto(event),
+            tbl_name,
+            sql,
+        },
+    }
+}
+
+fn trigger_timing_from_dto(v: reef_proto::TriggerTimingDto) -> reef_sqlite_preview::TriggerTiming {
+    match v {
+        reef_proto::TriggerTimingDto::Before => reef_sqlite_preview::TriggerTiming::Before,
+        reef_proto::TriggerTimingDto::After => reef_sqlite_preview::TriggerTiming::After,
+        reef_proto::TriggerTimingDto::InsteadOf => reef_sqlite_preview::TriggerTiming::InsteadOf,
+        reef_proto::TriggerTimingDto::Unknown => reef_sqlite_preview::TriggerTiming::Unknown,
+    }
+}
+
+fn trigger_event_from_dto(v: reef_proto::TriggerEventDto) -> reef_sqlite_preview::TriggerEvent {
+    match v {
+        reef_proto::TriggerEventDto::Insert => reef_sqlite_preview::TriggerEvent::Insert,
+        reef_proto::TriggerEventDto::Update => reef_sqlite_preview::TriggerEvent::Update,
+        reef_proto::TriggerEventDto::Delete => reef_sqlite_preview::TriggerEvent::Delete,
+        reef_proto::TriggerEventDto::Unknown => reef_sqlite_preview::TriggerEvent::Unknown,
     }
 }
 

--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -34,11 +34,13 @@ pub enum PreviewBody {
     },
     Image(ImagePreview),
     Binary(BinaryInfo),
-    /// SQLite read-only preview — a list of tables with row counts plus
-    /// the first page of rows for the smallest non-empty table. Built
-    /// by `reef-sqlite-preview` either locally (LocalBackend) or
-    /// agent-side (RemoteBackend's `LoadDbInitial` RPC).
-    Database(reef_sqlite_preview::DatabaseInfo),
+    /// SQLite read-only preview — the full schema graph (every schema
+    /// from `PRAGMA database_list` with its tables / views / indexes /
+    /// triggers) plus the first page of rows for the default
+    /// selection. Built by `reef-sqlite-preview` either locally
+    /// (LocalBackend) or agent-side (RemoteBackend's `LoadDbInitialV2`
+    /// RPC).
+    Database(reef_sqlite_preview::DatabaseInfoV2),
 }
 
 impl PreviewContent {
@@ -676,7 +678,7 @@ pub fn load_preview(
         && reef_sqlite_preview::has_sqlite_magic(&probe)
     {
         use reef_sqlite_preview::PreviewError as SqlitePreviewError;
-        match reef_sqlite_preview::read_initial(&full, INITIAL_DB_PAGE_ROWS) {
+        match reef_sqlite_preview::read_initial_v2(&full, INITIAL_DB_PAGE_ROWS) {
             Ok(info) => {
                 return Some(PreviewContent {
                     file_path: rel_str,

--- a/src/ui/db_preview.rs
+++ b/src/ui/db_preview.rs
@@ -23,34 +23,51 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use reef_sqlite_preview::{ColumnInfo, DatabaseInfo, SqliteValue, TableSummary};
+use reef_sqlite_preview::{ColumnInfo, DatabaseInfoV2, DbObject, DbObjectKind, SqliteValue};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-/// Width reserved for the left-side tables list when the panel is
-/// wide enough to show both panes. Below `MIN_TWO_PANE_WIDTH` we drop
-/// the list entirely and just show the data — the `[`/`]` keybinding
-/// still cycles tables, the user just doesn't see the list.
-const TABLES_PANEL_WIDTH: u16 = 22;
-/// Below this panel width we skip rendering the tables list and let
-/// the data area consume the full width.
+/// Minimum + maximum width clamp for the dynamically-sized sidebar.
+/// Picked so a one-letter schema with `▾ a` fits, and a deeply-nested
+/// `temp.complicated_long_table_name (10k)` doesn't eat the whole
+/// panel. The renderer computes the natural width per frame from the
+/// currently expanded objects and clamps into this range.
+const SIDEBAR_MIN_WIDTH: u16 = 18;
+const SIDEBAR_MAX_WIDTH: u16 = 32;
+/// Below this panel width we drop the sidebar entirely and let the
+/// data area consume the full width. The user can still cycle objects
+/// via `[`/`]` — they just don't see the sidebar.
 const MIN_TWO_PANE_WIDTH: u16 = 50;
-/// Cell separator between data columns. 3 chars wide; matches the
-/// vertical-rule glyph used elsewhere in Reef's diff layout.
-const COL_SEP: &str = " │ ";
+/// Cell separator between data columns. Two spaces — the modern
+/// "borderless table" look. Plenty of breathing room without a
+/// vertical-rule glyph that visually approximates a frame line.
+const COL_SEP: &str = "  ";
+/// Width to pad the row-count column to in the sidebar so counts
+/// across all object rows in a schema right-align. 5 covers `99999`
+/// and the `1.2k` / `10.5k` shortened forms.
+const SIDEBAR_COUNT_WIDTH: usize = 5;
 
 /// SQLite preview body. Layout (panel width permitting):
 ///
 /// ```text
-/// filename                                       ← card header
-/// ────────────────────────────────────────       ← separator
-/// sqlite · 12 tables · 4.1 MB                    ← meta line
-///                                                ← spacer
-///  tables           id   │ name      │ email     ← tables list + column header
-/// ▶users (3)        1    │ alice     │ a@x.io
-///  posts (42)       2    │ bob       │ NULL
-///  sessions (1)     3    │ carol     │ c@x.io
-/// page 1 / 1 · row 1-3 / 3                       ← footer
+/// fixture.db                                             ← card header
+/// ─────────────────────────────────────────────────      ← separator
+/// sqlite · 5 tables · 20.0 KB                            ← meta line
+///                                                        ← spacer
+/// ▾ main · fixture.db   id    email          name        ← sidebar + data header
+///   Tables (2)          INT   TEXT           TEXT         ← (type chips)
+/// ▎▸ users              1     alice@…        Alice        ← selected row (accent bar)
+///  ▸ posts              2     bob@…          Bob
+///   Views (1)           3     carol@…        Carol
+///  ▸ active_users
+///   Indexes (2)
+///  ▸ users_email_idx
+/// ▸ temp
+/// page  ‹ [1] › · row 1-3 / 3 · users (1/2)              ← footer
 /// ```
+///
+/// The data area replaces itself with a "detail card" when the
+/// current selection is an Index or Trigger — see
+/// [`render_detail_pane`] for that shape.
 ///
 /// `preview_scroll` doubles as the in-page row offset — Up/Down/
 /// Ctrl+P/N mutate it, the data pane slices `current_rows` from
@@ -63,7 +80,7 @@ pub(in crate::ui) fn render(
     app: &mut App,
     area: Rect,
     path: &str,
-    info: &DatabaseInfo,
+    info: &DatabaseInfoV2,
     focused: bool,
 ) {
     if area.height < 1 {
@@ -74,12 +91,15 @@ pub(in crate::ui) fn render(
     let mut y =
         crate::ui::file_preview_panel::render_card_header(f, area, path, &th, focused, None);
 
+    let total_objects: usize = info.schemas.iter().map(|s| s.objects.len()).sum();
+    let row_bearing_total: usize = info.iter_row_bearing().count();
+
     // Meta line — same shape as the binary card's `application/x · N B`
     // so the eye picks it up in the same place across formats.
     if y < max_y {
         let meta = format!(
             "sqlite · {} {} · {}",
-            info.tables.len(),
+            row_bearing_total,
             t(Msg::DbTablesHeader),
             crate::file_tree::human_bytes(info.bytes_on_disk),
         );
@@ -95,7 +115,7 @@ pub(in crate::ui) fn render(
     }
 
     // Empty database — single centred line, skip the panes entirely.
-    if info.tables.is_empty() {
+    if total_objects == 0 {
         if y < max_y {
             let msg = t(Msg::DbEmpty);
             let w = UnicodeWidthStr::width(msg) as u16;
@@ -109,21 +129,29 @@ pub(in crate::ui) fn render(
         return;
     }
 
-    // Read pagination state when present and pointing at the same
-    // file. State is rebuilt by `apply_worker_result` on every preview
-    // land, so a missing or stale state means we just sat down on a
-    // fresh `.db` — fall back to `info.initial_page` defaults.
-    let state = app.db_preview_state.as_ref().filter(|s| s.path == path);
-    let selected_idx = state
-        .map(|s| s.selected_table)
-        .unwrap_or(info.selected_table)
-        .min(info.tables.len() - 1);
-    let selected_table = &info.tables[selected_idx];
-    let rows: &[Vec<SqliteValue>] = state
+    // Navigation state for this `.db`. Cloned up front so the borrow
+    // releases before the pane renderers take `&mut app`. The clone is
+    // now small (no schema graph copy — that lives in `info`); the only
+    // heap fields left are the current page's rows + cached col_widths
+    // + the `expanded` set, all <1 KB in practice.
+    let state: Option<crate::app::DbPreviewState> = app
+        .db_preview_state
+        .as_ref()
+        .filter(|s| s.path == path)
+        .cloned();
+    let state_ref = state.as_ref();
+
+    // Locate the currently-selected object across every schema. Falls
+    // back to the first row-bearing object in any schema when state
+    // is missing or the selection is stale.
+    let selected_object: Option<&DbObject> = state_ref
+        .and_then(|s| info.lookup(&s.selection))
+        .or_else(|| info.iter_row_bearing().next());
+    let rows: &[Vec<SqliteValue>] = state_ref
         .map(|s| s.current_rows.as_slice())
         .unwrap_or(info.initial_page.rows.as_slice());
-    let page_index: u64 = state.map(|s| s.page).unwrap_or(0);
-    let rows_per_page: u64 = state
+    let page_index: u64 = state_ref.map(|s| s.page).unwrap_or(0);
+    let rows_per_page: u64 = state_ref
         .map(|s| s.rows_per_page as u64)
         .unwrap_or(rows.len().max(1) as u64);
 
@@ -142,104 +170,381 @@ pub(in crate::ui) fn render(
     // row left avoids a half-rendered card on a 6-row-tall panel.
     let body_max_y = max_y.saturating_sub(1);
 
-    // Layout: tables list on the left when the panel is wide enough,
-    // data area takes everything else.
     let two_pane = area.width >= MIN_TWO_PANE_WIDTH;
-    let tables_w = if two_pane { TABLES_PANEL_WIDTH } else { 0 };
-    let tables_x = area.x;
-    let data_x = area.x + tables_w + if two_pane { 1 } else { 0 };
+    let sidebar_rows = if two_pane {
+        build_sidebar_rows(info, state_ref)
+    } else {
+        Vec::new()
+    };
+    let sidebar_w = if two_pane {
+        sidebar_width_for_rows(&sidebar_rows)
+    } else {
+        0
+    };
+    let sidebar_x = area.x;
+    let data_x = area.x + sidebar_w + if two_pane { 1 } else { 0 };
     let data_w = area
         .width
-        .saturating_sub(tables_w + if two_pane { 1 } else { 0 });
+        .saturating_sub(sidebar_w + if two_pane { 1 } else { 0 });
 
     if two_pane {
-        render_tables_list(
+        render_objects_pane(
             f,
+            app,
             &th,
-            Rect::new(tables_x, y, tables_w, body_max_y - y),
-            &info.tables,
-            selected_idx,
+            Rect::new(sidebar_x, y, sidebar_w, body_max_y - y),
+            &sidebar_rows,
+            state_ref,
         );
     }
 
-    // Column widths come from the cache on `db_preview_state` —
-    // recomputed only when current_rows / selected_table change, not
-    // on every render. This makes h-scroll cheap: a single keypress
-    // is O(1) work in the render path (clip_spans on visible rows
-    // only), no O(rows × cols × avg_str_len) re-walk per frame. When
-    // state is missing (the rare race window between preview-land
-    // and the apply_worker_result hook) we fall back to computing on
-    // the fly so the table still draws.
-    let owned_widths: Vec<usize>;
-    let owned_total_w: usize;
-    let (col_widths, total_table_w) = match state {
-        Some(s) if !s.col_widths.is_empty() => (s.col_widths.as_slice(), s.total_table_w),
-        _ => {
-            owned_widths = natural_column_widths(&selected_table.columns, rows);
-            owned_total_w = total_table_width(&owned_widths);
-            (owned_widths.as_slice(), owned_total_w)
+    let data_rect = Rect::new(data_x, y, data_w, body_max_y - y);
+
+    match selected_object {
+        Some(o) if o.kind.has_rows() => {
+            // Column widths come from the cache on `db_preview_state` —
+            // recomputed only when current_rows / selected change, not
+            // on every render. This makes h-scroll cheap: a single
+            // keypress is O(1) work in the render path (clip_spans on
+            // visible rows only), no O(rows × cols × avg_str_len)
+            // re-walk per frame. When state is missing (the rare race
+            // window between preview-land and the apply_worker_result
+            // hook) we fall back to computing on the fly so the table
+            // still draws.
+            let owned_widths: Vec<usize>;
+            let owned_total_w: usize;
+            let (col_widths, total_table_w) = match state_ref {
+                Some(s) if !s.col_widths.is_empty() => (s.col_widths.as_slice(), s.total_table_w),
+                _ => {
+                    owned_widths = natural_column_widths(&o.columns, rows);
+                    owned_total_w = total_table_width(&owned_widths);
+                    (owned_widths.as_slice(), owned_total_w)
+                }
+            };
+            let max_h_scroll = total_table_w.saturating_sub(data_w as usize);
+            if app.preview_h_scroll > max_h_scroll {
+                app.preview_h_scroll = max_h_scroll;
+            }
+            let h_scroll = app.preview_h_scroll;
+
+            render_data_pane(
+                f,
+                &th,
+                data_rect,
+                &o.columns,
+                col_widths,
+                &rows[row_offset.min(rows.len())..],
+                h_scroll,
+            );
+
+            // Pagination footer.
+            if body_max_y < max_y {
+                if let Some(buf) = app.db_goto_input.as_ref() {
+                    let prompt_line = Line::from(vec![
+                        Span::styled(
+                            format!("{}: ", t(Msg::DbGotoPagePrompt)),
+                            Style::default()
+                                .fg(th.fg_primary)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled(buf.clone(), Style::default().fg(th.fg_primary)),
+                        Span::styled(
+                            "▏",
+                            Style::default()
+                                .fg(th.fg_primary)
+                                .add_modifier(Modifier::DIM),
+                        ),
+                        Span::styled(
+                            format!("  {}", t(Msg::DbGotoPageHint)),
+                            Style::default().fg(th.fg_secondary),
+                        ),
+                    ]);
+                    f.render_widget(prompt_line, Rect::new(area.x, body_max_y, area.width, 1));
+                } else {
+                    let footer_idx = position_in_row_bearing(info, o).unwrap_or(0);
+                    render_pagination_footer(
+                        f,
+                        app,
+                        Rect::new(area.x, body_max_y, area.width, 1),
+                        &th,
+                        FooterContext {
+                            object: o,
+                            selected_idx: footer_idx,
+                            table_count: row_bearing_total,
+                            page_index,
+                            rows_per_page,
+                        },
+                    );
+                }
+            }
         }
-    };
-    let max_h_scroll = total_table_w.saturating_sub(data_w as usize);
-    if app.preview_h_scroll > max_h_scroll {
-        app.preview_h_scroll = max_h_scroll;
+        Some(o) => {
+            // Non-row object (Index / Trigger): render structural
+            // detail in the data area; footer just shows the object's
+            // identity since there's nothing to paginate.
+            let detail = state_ref.and_then(|s| s.detail.as_ref());
+            render_detail_pane(f, &th, data_rect, o, detail);
+            if body_max_y < max_y {
+                let label = format!("{} · {}.{}", o.kind.as_master_type(), o.schema, o.name);
+                f.render_widget(
+                    Line::from(Span::styled(label, Style::default().fg(th.fg_secondary))),
+                    Rect::new(area.x, body_max_y, area.width, 1),
+                );
+            }
+        }
+        None => {
+            // No row-bearing object anywhere — render an explanatory
+            // line in the data area. The sidebar still lets the user
+            // pick an Index / Trigger to see its detail.
+            let msg = t(Msg::DbNoRows);
+            if data_rect.height >= 1 {
+                let w = UnicodeWidthStr::width(msg) as u16;
+                let cy = data_rect.y + data_rect.height / 2;
+                let cx = data_rect.x + data_rect.width.saturating_sub(w) / 2;
+                f.render_widget(
+                    Line::from(Span::styled(msg, Style::default().fg(th.fg_secondary))),
+                    Rect::new(cx, cy, data_rect.width.saturating_sub(cx - data_rect.x), 1),
+                );
+            }
+        }
     }
-    let h_scroll = app.preview_h_scroll;
+}
 
-    render_data_pane(
-        f,
-        &th,
-        Rect::new(data_x, y, data_w, body_max_y - y),
-        &selected_table.columns,
-        col_widths,
-        &rows[row_offset.min(rows.len())..],
-        h_scroll,
-    );
+/// Index of `target` within the flat list of row-bearing objects
+/// (used by the pagination footer to render `(i/N)`).
+fn position_in_row_bearing(
+    info: &reef_sqlite_preview::DatabaseInfoV2,
+    target: &DbObject,
+) -> Option<usize> {
+    info.iter_row_bearing()
+        .position(|o| o.schema == target.schema && o.name == target.name && o.kind == target.kind)
+}
 
-    // Footer — page chips + row range + selected-table indicator,
-    // or the goto-input prompt when the user has invoked `g`.
-    if body_max_y < max_y {
-        if let Some(buf) = app.db_goto_input.as_ref() {
-            // Prompt style — bold prompt label, regular digits, plus
-            // a block-cursor glyph at the end so the typing focus is
-            // visually obvious without us having to drive a real
-            // terminal cursor (which would conflict with the rest of
-            // the TUI's draw cycle).
-            let prompt_line = Line::from(vec![
+/// Render the detail pane for an Index or Trigger (and, for symmetry,
+/// Table / View — though the latter two normally show their data grid
+/// instead). Falls back to a "Loading…" placeholder when
+/// `state.detail` hasn't been populated yet.
+fn render_detail_pane(
+    f: &mut Frame,
+    theme: &crate::ui::theme::Theme,
+    area: Rect,
+    object: &DbObject,
+    detail: Option<&reef_sqlite_preview::DbObjectDetail>,
+) {
+    if area.height < 1 || area.width < 4 {
+        return;
+    }
+    let mut y = area.y;
+    let max_y = area.y + area.height;
+    let bold = Style::default()
+        .fg(theme.fg_primary)
+        .add_modifier(Modifier::BOLD);
+    let dim = Style::default().fg(theme.fg_secondary);
+
+    // Title row — object name with its kind as a tail tag.
+    if y < max_y {
+        let title = format!("{}  ", object.name);
+        let kind_tag = format!("[{}]", object.kind.as_master_type());
+        f.render_widget(
+            Line::from(vec![
+                Span::styled(title, bold),
                 Span::styled(
-                    format!("{}: ", t(Msg::DbGotoPagePrompt)),
+                    kind_tag,
                     Style::default()
-                        .fg(th.fg_primary)
+                        .fg(theme.accent)
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(buf.clone(), Style::default().fg(th.fg_primary)),
-                Span::styled(
-                    "▏",
+            ]),
+            Rect::new(area.x, y, area.width, 1),
+        );
+        y += 1;
+    }
+    if y < max_y {
+        // A single underline for visual closure of the title row.
+        let dash = "─".repeat(area.width as usize);
+        f.render_widget(
+            Line::from(Span::styled(dash, dim)),
+            Rect::new(area.x, y, area.width, 1),
+        );
+        y += 1;
+    }
+
+    // Loading placeholder when the detail RPC hasn't landed yet.
+    let Some(detail) = detail else {
+        if y < max_y {
+            f.render_widget(
+                Line::from(Span::styled(
+                    "Loading…",
                     Style::default()
-                        .fg(th.fg_primary)
-                        .add_modifier(Modifier::DIM),
-                ),
-                Span::styled(
-                    format!("  {}", t(Msg::DbGotoPageHint)),
-                    Style::default().fg(th.fg_secondary),
-                ),
-            ]);
-            f.render_widget(prompt_line, Rect::new(area.x, body_max_y, area.width, 1));
-        } else {
-            render_pagination_footer(
-                f,
-                app,
-                Rect::new(area.x, body_max_y, area.width, 1),
-                &th,
-                FooterContext {
-                    table: selected_table,
-                    selected_idx,
-                    table_count: info.tables.len(),
-                    page_index,
-                    rows_per_page,
-                },
+                        .fg(theme.fg_secondary)
+                        .add_modifier(Modifier::ITALIC),
+                )),
+                Rect::new(area.x, y, area.width, 1),
             );
         }
+        return;
+    };
+
+    use reef_sqlite_preview::DbObjectDetail as D;
+    match detail {
+        D::Index {
+            unique,
+            columns,
+            partial_where,
+            tbl_name,
+            ..
+        } => {
+            // Chip row: UNIQUE / PARTIAL when applicable.
+            if y < max_y {
+                let mut chips: Vec<Span> = Vec::new();
+                if *unique {
+                    chips.push(Span::styled(
+                        " UNIQUE ",
+                        Style::default()
+                            .fg(theme.badge_fg)
+                            .bg(theme.badge_bg)
+                            .add_modifier(Modifier::BOLD),
+                    ));
+                    chips.push(Span::raw("  "));
+                }
+                if partial_where.is_some() {
+                    chips.push(Span::styled(
+                        " PARTIAL ",
+                        Style::default()
+                            .fg(theme.badge_fg)
+                            .bg(theme.warn_bg)
+                            .add_modifier(Modifier::BOLD),
+                    ));
+                    chips.push(Span::raw("  "));
+                }
+                if !chips.is_empty() {
+                    f.render_widget(Line::from(chips), Rect::new(area.x, y, area.width, 1));
+                    y += 1;
+                }
+            }
+            if y < max_y {
+                f.render_widget(
+                    Line::from(vec![
+                        Span::styled("Table: ", dim),
+                        Span::styled(tbl_name.clone(), bold),
+                    ]),
+                    Rect::new(area.x, y, area.width, 1),
+                );
+                y += 1;
+            }
+            if y < max_y && !columns.is_empty() {
+                f.render_widget(
+                    Line::from(vec![
+                        Span::styled("Columns: ", dim),
+                        Span::styled(columns.join(", "), bold),
+                    ]),
+                    Rect::new(area.x, y, area.width, 1),
+                );
+                y += 1;
+            }
+            if let Some(w) = partial_where
+                && y < max_y
+            {
+                f.render_widget(
+                    Line::from(vec![
+                        Span::styled("WHERE: ", dim),
+                        Span::styled(w.clone(), Style::default().fg(theme.fg_primary)),
+                    ]),
+                    Rect::new(area.x, y, area.width, 1),
+                );
+            }
+        }
+        D::Trigger {
+            timing,
+            event,
+            tbl_name,
+            sql,
+        } => {
+            // Header: AFTER INSERT ON users
+            if y < max_y {
+                let header = format!(
+                    "{} {} ON {}",
+                    trigger_timing_label(*timing),
+                    trigger_event_label(*event),
+                    tbl_name,
+                );
+                f.render_widget(
+                    Line::from(Span::styled(header, bold)),
+                    Rect::new(area.x, y, area.width, 1),
+                );
+                y += 1;
+            }
+            if y < max_y {
+                y += 1; // spacer before body
+            }
+            // SQL body, capped at 20 lines.
+            const MAX_BODY_LINES: usize = 20;
+            let total: Vec<&str> = sql.lines().collect();
+            let to_render = total.iter().take(MAX_BODY_LINES);
+            for line in to_render {
+                if y >= max_y {
+                    break;
+                }
+                let body_str = clip_or_pad(line, area.width as usize);
+                f.render_widget(
+                    Line::from(Span::styled(
+                        body_str,
+                        Style::default().fg(theme.fg_primary),
+                    )),
+                    Rect::new(area.x, y, area.width, 1),
+                );
+                y += 1;
+            }
+            if total.len() > MAX_BODY_LINES && y < max_y {
+                let more = format!("… +{} lines", total.len() - MAX_BODY_LINES);
+                f.render_widget(
+                    Line::from(Span::styled(more, dim)),
+                    Rect::new(area.x, y, area.width, 1),
+                );
+            }
+        }
+        D::Table { create_sql } | D::View { create_sql } => {
+            if let Some(sql) = create_sql {
+                let total: Vec<&str> = sql.lines().collect();
+                for line in total.iter().take(20) {
+                    if y >= max_y {
+                        break;
+                    }
+                    let body_str = clip_or_pad(line, area.width as usize);
+                    f.render_widget(
+                        Line::from(Span::styled(
+                            body_str,
+                            Style::default().fg(theme.fg_primary),
+                        )),
+                        Rect::new(area.x, y, area.width, 1),
+                    );
+                    y += 1;
+                }
+            } else if y < max_y {
+                f.render_widget(
+                    Line::from(Span::styled("No CREATE SQL", dim)),
+                    Rect::new(area.x, y, area.width, 1),
+                );
+            }
+        }
+    }
+}
+
+fn trigger_timing_label(t: reef_sqlite_preview::TriggerTiming) -> &'static str {
+    match t {
+        reef_sqlite_preview::TriggerTiming::Before => "BEFORE",
+        reef_sqlite_preview::TriggerTiming::After => "AFTER",
+        reef_sqlite_preview::TriggerTiming::InsteadOf => "INSTEAD OF",
+        reef_sqlite_preview::TriggerTiming::Unknown => "?",
+    }
+}
+
+fn trigger_event_label(e: reef_sqlite_preview::TriggerEvent) -> &'static str {
+    match e {
+        reef_sqlite_preview::TriggerEvent::Insert => "INSERT",
+        reef_sqlite_preview::TriggerEvent::Update => "UPDATE",
+        reef_sqlite_preview::TriggerEvent::Delete => "DELETE",
+        reef_sqlite_preview::TriggerEvent::Unknown => "?",
     }
 }
 
@@ -250,7 +555,7 @@ pub(in crate::ui) fn render(
 /// `too_many_arguments` threshold and the call site reads as a
 /// labeled struct literal rather than a positional argument list.
 struct FooterContext<'a> {
-    table: &'a TableSummary,
+    object: &'a DbObject,
     selected_idx: usize,
     table_count: usize,
     page_index: u64,
@@ -279,10 +584,14 @@ fn render_pagination_footer(
     if area.width == 0 || area.height == 0 {
         return;
     }
+    // Row count missing (views, indexes, triggers) → degrade footer to
+    // "page 1 / 1" with no row range, since we can't paginate something
+    // we haven't counted.
+    let row_count = ctx.object.row_count.unwrap_or(0);
     let total_pages = if ctx.rows_per_page == 0 {
         1
     } else {
-        ctx.table.row_count.div_ceil(ctx.rows_per_page).max(1)
+        row_count.div_ceil(ctx.rows_per_page).max(1)
     };
     let current = ctx.page_index + 1;
     let chips = build_page_chips(current, total_pages);
@@ -346,19 +655,19 @@ fn render_pagination_footer(
     if x >= max_x {
         return;
     }
-    let row_start = if ctx.table.row_count > 0 {
+    let row_start = if row_count > 0 {
         ctx.page_index * ctx.rows_per_page + 1
     } else {
         0
     };
-    let row_end = (ctx.page_index * ctx.rows_per_page + ctx.rows_per_page).min(ctx.table.row_count);
+    let row_end = (ctx.page_index * ctx.rows_per_page + ctx.rows_per_page).min(row_count);
     let suffix = format!(
         " ·  {} {}-{} / {}  ·  {} ({}/{})",
         t(Msg::DbRowsLabel),
         row_start,
         row_end,
-        ctx.table.row_count,
-        ctx.table.name,
+        row_count,
+        ctx.object.name,
         ctx.selected_idx + 1,
         ctx.table_count,
     );
@@ -501,64 +810,300 @@ fn build_page_chips(current: u64, total: u64) -> Vec<PageChip> {
     out
 }
 
-/// Render the left-side tables list. The selected row is prefixed
-/// with `▶`, others with a leading space; both name and row count are
-/// right-truncated to fit the panel width (22 chars by default — see
-/// [`TABLES_PANEL_WIDTH`]).
-fn render_tables_list(
+/// One row in the objects sidebar's flat-list-with-scroll model.
+/// Grouped sidebars are easier to render as a single flat list (so
+/// scroll math stays trivial) than to keep section nesting at runtime.
+#[derive(Debug, Clone, Copy)]
+enum SidebarRow<'a> {
+    /// `▾ main` / `▸ temp` / `▸ aux  · file.db` header. Clickable —
+    /// toggles the schema's expanded/collapsed state.
+    SchemaHeader {
+        name: &'a str,
+        expanded: bool,
+        file: Option<&'a str>,
+    },
+    /// `Tables (12)` / `Indexes (3)` etc. subsection label. Not
+    /// clickable; purely a visual divider inside an expanded schema.
+    Subsection { label: &'static str, count: usize },
+    /// One object row. Clickable — switches the data grid / detail
+    /// pane to this object.
+    Object(&'a DbObject),
+}
+
+/// Build the flat row list for the objects sidebar. Iteration order
+/// is the same as `info.schemas` (which mirrors `PRAGMA database_list`
+/// — main first, then temp, then attached). Inside an expanded schema
+/// we group by kind in the canonical order; empty subsections are
+/// elided.
+fn build_sidebar_rows<'a>(
+    info: &'a reef_sqlite_preview::DatabaseInfoV2,
+    state: Option<&'a crate::app::DbPreviewState>,
+) -> Vec<SidebarRow<'a>> {
+    let mut rows = Vec::new();
+    for schema in &info.schemas {
+        let expanded = state
+            .map(|s| s.expanded.contains(&schema.name))
+            .unwrap_or(schema.kind == reef_sqlite_preview::SchemaKind::Main);
+        rows.push(SidebarRow::SchemaHeader {
+            name: &schema.name,
+            expanded,
+            file: schema.file.as_deref(),
+        });
+        if !expanded {
+            continue;
+        }
+        for kind in [
+            DbObjectKind::Table,
+            DbObjectKind::View,
+            DbObjectKind::Index,
+            DbObjectKind::Trigger,
+        ] {
+            let objs: Vec<&DbObject> = schema.objects.iter().filter(|o| o.kind == kind).collect();
+            if objs.is_empty() {
+                continue;
+            }
+            rows.push(SidebarRow::Subsection {
+                label: kind.section_label(),
+                count: objs.len(),
+            });
+            for o in objs {
+                rows.push(SidebarRow::Object(o));
+            }
+        }
+    }
+    rows
+}
+
+/// Natural sidebar width from a pre-built row list. Clamped into
+/// `[SIDEBAR_MIN_WIDTH, SIDEBAR_MAX_WIDTH]` so the min keeps `▸ main`
+/// readable and the max stops a long attached-db name from eating the
+/// data pane.
+fn sidebar_width_for_rows(rows: &[SidebarRow<'_>]) -> u16 {
+    let mut max_w: usize = SIDEBAR_MIN_WIDTH as usize;
+    for row in rows {
+        let w = match row {
+            SidebarRow::SchemaHeader { name, file, .. } => {
+                let mut w = 2 + UnicodeWidthStr::width(*name);
+                if let Some(f) = file
+                    && !f.is_empty()
+                {
+                    let file_short = short_file_label(f);
+                    w += 3 + UnicodeWidthStr::width(file_short.as_str());
+                }
+                w
+            }
+            SidebarRow::Subsection { label, count } => {
+                2 + UnicodeWidthStr::width(*label) + 1 + 2 + count.to_string().len()
+            }
+            SidebarRow::Object(o) => {
+                let name_w = UnicodeWidthStr::width(o.name.as_str());
+                let virt_w = if o.is_virtual { 2 } else { 0 };
+                4 + name_w + virt_w + 1 + SIDEBAR_COUNT_WIDTH
+            }
+        };
+        if w > max_w {
+            max_w = w;
+        }
+    }
+    max_w.min(SIDEBAR_MAX_WIDTH as usize) as u16
+}
+
+/// Shorten a `PRAGMA database_list.file` path to the bare filename,
+/// because the full absolute path almost never fits in a sidebar
+/// column. Falls back to the trailing path component.
+fn short_file_label(file: &str) -> String {
+    std::path::Path::new(file)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| file.to_string())
+}
+
+/// Format a row count for sidebar display, trimming to 4 chars max.
+/// 1234 → "1234", 12345 → "12.3k", 123456 → " 123k". `None` → "—".
+fn format_row_count(count: Option<u64>) -> String {
+    match count {
+        None => "—".to_string(),
+        Some(n) if n < 10_000 => n.to_string(),
+        Some(n) if n < 1_000_000 => format!("{:.1}k", n as f64 / 1000.0),
+        Some(n) => format!("{}k", n / 1000),
+    }
+}
+
+/// Render the grouped objects sidebar — schemas + their tables /
+/// views / indexes / triggers. Registers `DbToggleSchema` on schema
+/// headers and `DbSelectObject` on object rows; subsection labels
+/// are inert.
+fn render_objects_pane(
     f: &mut Frame,
+    app: &mut App,
     theme: &crate::ui::theme::Theme,
     area: Rect,
-    tables: &[TableSummary],
-    selected_idx: usize,
+    rows: &[SidebarRow<'_>],
+    state: Option<&crate::app::DbPreviewState>,
 ) {
-    if area.width < 4 || area.height < 1 {
+    if area.width < 4 || area.height < 1 || rows.is_empty() {
         return;
     }
-    // Header row.
-    let header = clip_or_pad(t(Msg::DbTablesHeader), area.width as usize - 1);
-    f.render_widget(
-        Line::from(vec![
-            Span::raw(" "),
-            Span::styled(
-                header,
-                Style::default()
+
+    // Anchor scroll on the row that contains the current selection so
+    // an off-screen object scrolls into view rather than getting lost.
+    let selected_row_idx = state
+        .and_then(|s| {
+            rows.iter().position(|r| match r {
+                SidebarRow::Object(o) => o.name == s.selection.name && o.kind == s.selection.kind,
+                _ => false,
+            })
+        })
+        .unwrap_or(0);
+    let body_h = area.height as usize;
+    let scroll = scroll_offset_for(selected_row_idx, rows.len(), body_h);
+
+    for (i, row) in rows.iter().skip(scroll).take(body_h).enumerate() {
+        let y = area.y + i as u16;
+        match row {
+            SidebarRow::SchemaHeader {
+                name,
+                expanded,
+                file,
+            } => {
+                let icon = if *expanded { "▾ " } else { "▸ " };
+                let mut text = format!("{icon}{name}");
+                if let Some(f) = file
+                    && !f.is_empty()
+                {
+                    let short = short_file_label(f);
+                    text.push_str(" · ");
+                    text.push_str(&short);
+                }
+                let body = clip_or_pad(&text, area.width as usize);
+                let style = Style::default()
                     .fg(theme.fg_primary)
-                    .add_modifier(Modifier::BOLD),
-            ),
-        ]),
-        Rect::new(area.x, area.y, area.width, 1),
-    );
-    // Body — one row per table, scroll-clamped at the bottom.
-    let body_h = area.height.saturating_sub(1);
-    let visible = (body_h as usize).min(tables.len().saturating_sub(scroll_offset_for(
-        selected_idx,
-        tables.len(),
-        body_h as usize,
-    )));
-    let scroll = scroll_offset_for(selected_idx, tables.len(), body_h as usize);
-    for i in 0..visible {
-        let idx = scroll + i;
-        let t_summary = &tables[idx];
-        let is_sel = idx == selected_idx;
-        let prefix = if is_sel { "▶" } else { " " };
-        let label = format!("{} ({})", t_summary.name, t_summary.row_count);
-        let body = clip_or_pad(&label, area.width as usize - 1);
-        let style = if is_sel {
-            Style::default()
-                .fg(theme.fg_primary)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(theme.fg_secondary)
-        };
-        f.render_widget(
-            Line::from(vec![
-                Span::styled(prefix.to_string(), style),
-                Span::styled(body, style),
-            ]),
-            Rect::new(area.x, area.y + 1 + i as u16, area.width, 1),
-        );
+                    .add_modifier(Modifier::BOLD);
+                f.render_widget(
+                    Line::from(Span::styled(body, style)),
+                    Rect::new(area.x, y, area.width, 1),
+                );
+                app.hit_registry.register_row(
+                    area.x,
+                    y,
+                    area.width,
+                    crate::ui::mouse::ClickAction::DbToggleSchema((*name).to_string()),
+                );
+            }
+            SidebarRow::Subsection { label, count } => {
+                // Subsection labels get a subtle accent so the eye can
+                // chunk the sidebar at a glance — the label is the
+                // section marker (Tables / Views / Indexes / Triggers).
+                // Bold + accent fg with the count in dimmer secondary
+                // fg so the magnitude information stays visible without
+                // competing for attention.
+                let indent = "  ";
+                let count_str = format!(" ({count})");
+                let max = area.width as usize;
+                let count_w = UnicodeWidthStr::width(count_str.as_str());
+                let label_avail = max.saturating_sub(indent.len() + count_w);
+                let label_w = UnicodeWidthStr::width(*label).min(label_avail);
+                // Clip (but don't pad) the label so the count stays
+                // adjacent.
+                let label_render: String = if UnicodeWidthStr::width(*label) <= label_avail {
+                    (*label).to_string()
+                } else {
+                    clip_or_pad(label, label_avail).trim_end().to_string()
+                };
+                let trailing = max.saturating_sub(indent.len() + label_w + count_w);
+                f.render_widget(
+                    Line::from(vec![
+                        Span::raw(indent.to_string()),
+                        Span::styled(
+                            label_render,
+                            Style::default()
+                                .fg(theme.accent)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled(count_str, Style::default().fg(theme.fg_secondary)),
+                        Span::raw(" ".repeat(trailing)),
+                    ]),
+                    Rect::new(area.x, y, area.width, 1),
+                );
+            }
+            SidebarRow::Object(o) => {
+                let is_selected =
+                    state.is_some_and(|s| o.name == s.selection.name && o.kind == s.selection.kind);
+                render_object_row(f, app, theme, area, y, o, is_selected);
+            }
+        }
     }
+}
+
+/// Render one object row in the sidebar. Layout:
+///
+/// ```text
+///   ▸ users           1.2k      ← unselected
+/// ▎ ▸ active_users    —         ← selected (accent bar on the left)
+///   ▸ notes ⓥ          0
+/// ```
+fn render_object_row(
+    f: &mut Frame,
+    app: &mut App,
+    theme: &crate::ui::theme::Theme,
+    area: Rect,
+    y: u16,
+    object: &DbObject,
+    is_selected: bool,
+) {
+    if area.width == 0 {
+        return;
+    }
+    let row_style = if is_selected {
+        Style::default()
+            .fg(theme.fg_primary)
+            .bg(theme.selection_bg)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.fg_secondary)
+    };
+    // Accent column only gets a non-default background on the selected
+    // row — otherwise we leave it transparent so it inherits the panel
+    // bg instead of painting a dark gutter against the main area
+    // (chrome_bg was visibly darker than the panel and showed as a
+    // black strip on every row).
+    let accent_style = if is_selected {
+        Style::default().fg(theme.accent).bg(theme.selection_bg)
+    } else {
+        Style::default()
+    };
+
+    // Object rows don't get an expand caret — they're terminal nodes,
+    // and the `▸ → ▾` toggle pattern is reserved for schema headers
+    // where it actually does something.
+    let accent_glyph = if is_selected { "▎" } else { " " };
+    let virt_suffix = if object.is_virtual { " ⓥ" } else { "" };
+    let name_with_virt = format!("{}{}", object.name, virt_suffix);
+    let count_str = format_row_count(object.row_count);
+    let count_w = SIDEBAR_COUNT_WIDTH;
+    let avail_for_name =
+        (area.width as usize).saturating_sub(1 /*accent*/ + 3 /*indent*/ + 1 /*gap*/ + count_w);
+    let name_disp = clip_or_pad(&name_with_virt, avail_for_name);
+    let count_disp = format!("{count_str:>count_w$}");
+
+    let spans = vec![
+        Span::styled(accent_glyph.to_string(), accent_style),
+        Span::styled("   ".to_string(), row_style),
+        Span::styled(name_disp, row_style),
+        Span::styled(" ".to_string(), row_style),
+        Span::styled(count_disp, row_style),
+    ];
+    f.render_widget(Line::from(spans), Rect::new(area.x, y, area.width, 1));
+    app.hit_registry.register_row(
+        area.x,
+        y,
+        area.width,
+        crate::ui::mouse::ClickAction::DbSelectObject {
+            schema: object.schema.clone(),
+            name: object.name.clone(),
+            kind: object.kind,
+        },
+    );
 }
 
 /// First-visible-row index for a scrolling list of `total` items in
@@ -577,17 +1122,22 @@ fn scroll_offset_for(selected: usize, total: usize, viewport: usize) -> usize {
     }
 }
 
-/// Render the right-side data area: a two-row header (column names
-/// plus affinity-colored type tags) followed by `rows` of cells.
-/// Columns are pre-sized in `col_widths` (natural widths from the
-/// max of name / type tag / all current-page row cells); within each
-/// row we pad cells to those widths and join with ` │ `. The whole
-/// row is then handed to [`clip_spans`] with `h_scroll` so any
-/// overflow past `area.width` becomes a horizontal scroll instead
-/// of a per-cell `…` truncation. NULL is shown italic dimmed, BLOB
-/// as `<blob N B>` italic dimmed, TEXT preserves the reader-side `…`
-/// suffix when the value was reader-truncated at
-/// `MAX_TEXT_CELL_CHARS`.
+/// Render the right-side data area in the modern "borderless table"
+/// style: a two-row header (column names + affinity-colored type
+/// chips) followed by `rows` of cells with zebra striping. Columns
+/// are pre-sized in `col_widths` and joined with two spaces — no
+/// vertical-rule glyphs anywhere, so the table relies on alignment
+/// and color rather than a visible frame.
+///
+/// - Headers: bold + bright; type row tinted by affinity (INT blue,
+///   TEXT green, REAL amber, etc.).
+/// - Data rows: alternating `theme.hover_bg` on odd rows for a subtle
+///   zebra stripe.
+/// - Integers / Reals: right-aligned within their column so digits
+///   stack cleanly.
+/// - NULL: italic dim, left-aligned. BLOB: italic dim `<blob N B>`.
+/// - Reader-truncated TEXT preserves its trailing `…` from the wire
+///   payload.
 fn render_data_pane(
     f: &mut Frame,
     theme: &crate::ui::theme::Theme,
@@ -601,19 +1151,24 @@ fn render_data_pane(
         return;
     }
 
-    let header_style = Style::default()
-        .fg(theme.fg_primary)
-        .add_modifier(Modifier::BOLD);
-    let sep_style = Style::default().fg(theme.fg_secondary);
+    let sep_bg_default = Style::default(); // separator inherits row bg below
 
-    // Row 0 — column names (bold, primary fg).
+    // Row 0 — column names. Tinted by affinity so each name pairs
+    // visually with the type chip directly below it (green for TEXT,
+    // blue for INT, etc.). Bold to keep the name as the primary
+    // emphasis; the chip below uses the same hue but unbolded so the
+    // hierarchy reads as "name (bold) / type (lighter)".
     let mut name_tokens: Vec<(Style, String)> = Vec::with_capacity(columns.len() * 2);
     for (i, col) in columns.iter().enumerate() {
         if i > 0 {
-            name_tokens.push((sep_style, COL_SEP.to_string()));
+            name_tokens.push((sep_bg_default, COL_SEP.to_string()));
         }
         let w = col_widths.get(i).copied().unwrap_or(0);
-        name_tokens.push((header_style, pad_to_width(&col.name, w)));
+        let aff = affinity_of(&col.decl_type);
+        let style = Style::default()
+            .fg(affinity_header_color(aff, theme))
+            .add_modifier(Modifier::BOLD);
+        name_tokens.push((style, pad_to_width(&col.name, w)));
     }
     let name_spans = clip_spans(&name_tokens, h_scroll, area.width as usize);
     f.render_widget(
@@ -621,14 +1176,15 @@ fn render_data_pane(
         Rect::new(area.x, area.y, area.width, 1),
     );
 
-    // Row 1 — affinity-colored type tags. Skipped when the panel is
-    // only one row tall (rare, but degrade gracefully rather than
-    // overflowing into a body row that doesn't exist).
+    // Row 1 — type label, same hue as the name above, no bold so the
+    // name carries the visual weight and the type sits as a quieter
+    // annotation. Empty for Affinity::None columns (rendered as
+    // spaces) since there's no useful tag to show.
     if area.height >= 2 {
         let mut type_tokens: Vec<(Style, String)> = Vec::with_capacity(columns.len() * 2);
         for (i, col) in columns.iter().enumerate() {
             if i > 0 {
-                type_tokens.push((sep_style, COL_SEP.to_string()));
+                type_tokens.push((sep_bg_default, COL_SEP.to_string()));
             }
             let w = col_widths.get(i).copied().unwrap_or(0);
             let aff = affinity_of(&col.decl_type);
@@ -642,8 +1198,7 @@ fn render_data_pane(
         );
     }
 
-    // Data rows start under both header rows when the panel is tall
-    // enough; on a 1-row-only panel the data simply doesn't render.
+    // Data rows start under both header rows.
     let body_y = if area.height >= 2 {
         area.y + 2
     } else {
@@ -653,7 +1208,6 @@ fn render_data_pane(
     let body_h = body_end.saturating_sub(body_y) as usize;
 
     if rows.is_empty() {
-        // "(no rows)" centred in the body slot.
         if body_h >= 1 {
             let msg = t(Msg::DbNoRows);
             let w = UnicodeWidthStr::width(msg) as u16;
@@ -668,16 +1222,49 @@ fn render_data_pane(
     }
 
     for (i, row) in rows.iter().take(body_h).enumerate() {
+        // Zebra stripe: odd rows get `theme.hover_bg`. Renders the
+        // whole row's worth of cells (including padding / separators)
+        // with that background so the stripe is unbroken across the
+        // grid.
+        let row_bg = if i % 2 == 1 {
+            Some(theme.hover_bg)
+        } else {
+            None
+        };
+        let bg_style = if let Some(bg) = row_bg {
+            Style::default().bg(bg)
+        } else {
+            Style::default()
+        };
+        // Fill the row's background first by rendering a span of
+        // spaces — clip_spans on the cell tokens below paints over
+        // it, but any gaps (e.g. when h_scroll positions us past the
+        // last column) keep the stripe visible.
+        if row_bg.is_some() {
+            f.render_widget(
+                Line::from(Span::styled(" ".repeat(area.width as usize), bg_style)),
+                Rect::new(area.x, body_y + i as u16, area.width, 1),
+            );
+        }
+
         let mut tokens: Vec<(Style, String)> = Vec::with_capacity(row.len() * 2);
         for (c_idx, value) in row.iter().enumerate() {
             if c_idx > 0 {
-                tokens.push((sep_style, COL_SEP.to_string()));
+                tokens.push((bg_style, COL_SEP.to_string()));
             }
             let w = col_widths.get(c_idx).copied().unwrap_or(0);
-            tokens.push((
-                cell_style(value, theme),
-                pad_to_width(&value.to_string(), w),
-            ));
+            let mut cell_style_v = cell_style(value, theme);
+            if let Some(bg) = row_bg {
+                cell_style_v = cell_style_v.bg(bg);
+            }
+            // Right-align numerics so digits stack cleanly down the
+            // column; left-align text / null / blob.
+            let padded = if value_is_numeric(value) {
+                pad_left_to_width(&value.to_string(), w)
+            } else {
+                pad_to_width(&value.to_string(), w)
+            };
+            tokens.push((cell_style_v, padded));
         }
         let spans = clip_spans(&tokens, h_scroll, area.width as usize);
         f.render_widget(
@@ -685,6 +1272,12 @@ fn render_data_pane(
             Rect::new(area.x, body_y + i as u16, area.width, 1),
         );
     }
+}
+
+/// `true` for Integer / Real — the right-align targets in the data
+/// grid. Text / Null / Blob stay left-aligned.
+fn value_is_numeric(v: &SqliteValue) -> bool {
+    matches!(v, SqliteValue::Integer(_) | SqliteValue::Real(_))
 }
 
 /// Style for a `SqliteValue` — what color/weight to render with.
@@ -820,6 +1413,16 @@ fn affinity_color(a: Affinity, theme: &crate::ui::theme::Theme) -> ratatui::styl
     }
 }
 
+/// Same as [`affinity_color`] but maps Blob / None to `fg_primary`
+/// instead of the secondary gray — used for the bold column-name
+/// row, where an untyped column shouldn't read as washed-out.
+fn affinity_header_color(a: Affinity, theme: &crate::ui::theme::Theme) -> ratatui::style::Color {
+    match a {
+        Affinity::Blob | Affinity::None => theme.fg_primary,
+        other => affinity_color(other, theme),
+    }
+}
+
 /// Total display width of the data table — sum of column widths plus
 /// `COL_SEP` between adjacent columns. Used to clamp `preview_h_scroll`
 /// so the user can't scroll past the right edge.
@@ -831,22 +1434,42 @@ pub(crate) fn total_table_width(col_widths: &[usize]) -> usize {
     col_widths.iter().sum::<usize>() + sep_w * (col_widths.len() - 1)
 }
 
-/// Right-pad `s` with spaces until it occupies exactly `target_w`
-/// display columns. If `s` is already wider it's returned as-is —
-/// callers pass natural widths so this branch shouldn't fire.
+/// Pad `s` with spaces to occupy exactly `target_w` display columns.
+/// If `s` is already wider it's returned as-is — callers pass natural
+/// widths so the wider branch shouldn't fire. Right-aligned variant
+/// (left-padding) used for numeric cells in the data grid.
 fn pad_to_width(s: &str, target_w: usize) -> String {
+    pad_aligned(s, target_w, Align::Left)
+}
+
+fn pad_left_to_width(s: &str, target_w: usize) -> String {
+    pad_aligned(s, target_w, Align::Right)
+}
+
+#[derive(Copy, Clone)]
+enum Align {
+    Left,
+    Right,
+}
+
+fn pad_aligned(s: &str, target_w: usize, align: Align) -> String {
     let cur = UnicodeWidthStr::width(s);
     if cur >= target_w {
-        s.to_string()
-    } else {
-        let pad = target_w - cur;
-        let mut out = String::with_capacity(s.len() + pad);
-        out.push_str(s);
-        for _ in 0..pad {
-            out.push(' ');
-        }
-        out
+        return s.to_string();
     }
+    let pad = target_w - cur;
+    let mut out = String::with_capacity(s.len() + pad);
+    match align {
+        Align::Left => {
+            out.push_str(s);
+            out.extend(std::iter::repeat_n(' ', pad));
+        }
+        Align::Right => {
+            out.extend(std::iter::repeat_n(' ', pad));
+            out.push_str(s);
+        }
+    }
+    out
 }
 
 /// Trim or right-pad a string to exactly `width` display columns. The
@@ -1074,6 +1697,8 @@ mod tests {
         let columns = vec![ColumnInfo {
             name: "n".to_string(),
             decl_type: "INTEGER".to_string(),
+            notnull: false,
+            pk: false,
         }];
         let rows: Vec<Vec<SqliteValue>> = vec![vec![SqliteValue::Integer(1)]];
         let widths = natural_column_widths(&columns, &rows);

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -97,6 +97,18 @@ pub enum ClickAction {
     /// Jump directly to a 1-based page index. Clicking the `[5]` chip
     /// dispatches `DbGotoPage(5)`.
     DbGotoPage(u64),
+    /// Click on an object row in the SQLite preview sidebar (e.g. a
+    /// table, view, index, or trigger name). Switches the current
+    /// selection to the named object, schema-qualified.
+    DbSelectObject {
+        schema: String,
+        name: String,
+        kind: reef_sqlite_preview::DbObjectKind,
+    },
+    /// Click on a schema header in the SQLite preview sidebar
+    /// (`▾ main` / `▸ temp` / …). Toggles the expanded / collapsed
+    /// state for that schema's object list.
+    DbToggleSchema(String),
 
     // ── Find widget (VSCode-style floating find, src/find_widget.rs) ──
     /// Click the `×` close button on the find widget.

--- a/tests/backend_preview_loopback.rs
+++ b/tests/backend_preview_loopback.rs
@@ -134,6 +134,14 @@ fn seed_sqlite_db(path: &std::path::Path) {
     drop(conn);
 }
 
+fn users_key() -> reef_sqlite_preview::DbObjectKey {
+    reef_sqlite_preview::DbObjectKey {
+        schema: "main".to_string(),
+        name: "users".to_string(),
+        kind: reef_sqlite_preview::DbObjectKind::Table,
+    }
+}
+
 #[test]
 fn load_preview_parity_for_sqlite_database() {
     use reef::file_tree::PreviewBody;
@@ -159,24 +167,33 @@ fn load_preview_parity_for_sqlite_database() {
         unreachable!("shape_of asserted Database above");
     };
 
-    // Table list parity — names + row counts must match. Without
-    // this guard a divergence in the agent's `list_tables` filter
-    // (e.g. accidentally including `sqlite_sequence`) would slip
-    // through silently.
-    let l_names: Vec<_> = li
-        .tables
-        .iter()
-        .map(|t| (t.name.clone(), t.row_count))
-        .collect();
-    let r_names: Vec<_> = ri
-        .tables
-        .iter()
-        .map(|t| (t.name.clone(), t.row_count))
-        .collect();
-    assert_eq!(l_names, r_names, "table list / counts");
+    // Object list parity for the default (main) schema — names +
+    // kinds + row counts must match. Without this guard a divergence
+    // in the agent's `list_objects` filter (e.g. accidentally including
+    // `sqlite_sequence`) would slip through silently.
+    fn main_objects(
+        info: &reef_sqlite_preview::DatabaseInfoV2,
+    ) -> Vec<(String, reef_sqlite_preview::DbObjectKind, Option<u64>)> {
+        info.schemas
+            .iter()
+            .find(|s| s.name == "main")
+            .map(|s| {
+                s.objects
+                    .iter()
+                    .map(|o| (o.name.clone(), o.kind, o.row_count))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+    assert_eq!(
+        main_objects(li),
+        main_objects(ri),
+        "main schema object list / counts",
+    );
 
-    // Selected table + initial page row count parity.
-    assert_eq!(li.selected_table, ri.selected_table, "selected_table");
+    // Default schema + selected object + initial page row count parity.
+    assert_eq!(li.default_schema, ri.default_schema, "default_schema");
+    assert_eq!(li.default_object, ri.default_object, "default_object");
     assert_eq!(
         li.initial_page.rows.len(),
         ri.initial_page.rows.len(),
@@ -196,10 +213,10 @@ fn db_load_page_parity_across_backends() {
 
     // Page from offset 0, limit 2 — should give two rows.
     let lp = local
-        .db_load_page(Path::new("fixture.db"), "users", 0, 2)
+        .db_load_page(Path::new("fixture.db"), &users_key(), 0, 2)
         .expect("local db_load_page");
     let rp = remote
-        .db_load_page(Path::new("fixture.db"), "users", 0, 2)
+        .db_load_page(Path::new("fixture.db"), &users_key(), 0, 2)
         .expect("remote db_load_page");
 
     assert_eq!(lp.rows.len(), 2, "local row count");
@@ -227,10 +244,10 @@ fn db_load_page_offset_works_across_backends() {
 
     // users has 3 rows; OFFSET 2 LIMIT 2 must return exactly 1 row.
     let lp = local
-        .db_load_page(Path::new("fixture.db"), "users", 2, 2)
+        .db_load_page(Path::new("fixture.db"), &users_key(), 2, 2)
         .expect("local db_load_page");
     let rp = remote
-        .db_load_page(Path::new("fixture.db"), "users", 2, 2)
+        .db_load_page(Path::new("fixture.db"), &users_key(), 2, 2)
         .expect("remote db_load_page");
 
     assert_eq!(lp.rows.len(), 1);

--- a/tests/snapshots/ui_snapshots__db_preview_grouped_sidebar.snap
+++ b/tests/snapshots/ui_snapshots__db_preview_grouped_sidebar.snap
@@ -1,0 +1,29 @@
+---
+source: tests/ui_snapshots.rs
+assertion_line: 811
+expression: output
+---
+ reef  [TMPDIR]  ⎇ (detached)
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph                                      ⊟  1:Files 2:Search 3:Git 4:Graph
+ + New File   📁  New Folder   ↻ │ fixture.db
+   fixture.db U                 │ ───────────────────────────────────────────────────────────────────────────
+                                │ sqlite · 3 tables · 20.0 KB
+                                │
+                                │ ▾ main · fixture.db       id   body
+                                │   Tables (2)              INT  TEXT
+                                │ ▎   posts               2   1  hi
+                                │     users               4   2  world
+                                │   Views (1)
+                                │     active_users        —
+                                │   Indexes (2)
+                                │     users_email_idx     —
+                                │     users_named_idx     —
+                                │   Triggers (1)
+                                │     users_audit         —
+                                │
+                                │
+                                │
+                                │
+                                │
+                                │ page  ‹  [1]  › ·  row 1-2 / 2  ·  posts (1/3)
+ 🔗  SSH                                      ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/snapshots/ui_snapshots__db_preview_index_detail.snap
+++ b/tests/snapshots/ui_snapshots__db_preview_index_detail.snap
@@ -1,0 +1,29 @@
+---
+source: tests/ui_snapshots.rs
+assertion_line: 854
+expression: output
+---
+ reef  [TMPDIR]  ⎇ (detached)
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph                                      ⊟  1:Files 2:Search 3:Git 4:Graph
+ + New File   📁  New Folder   ↻ │ fixture.db
+   fixture.db U                 │ ───────────────────────────────────────────────────────────────────────────
+                                │ sqlite · 3 tables · 20.0 KB
+                                │
+                                │ ▾ main · fixture.db       users_named_idx  [index]
+                                │   Tables (2)              ─────────────────────────────────────────────────
+                                │     posts               2  PARTIAL
+                                │     users               4 Table: users
+                                │   Views (1)               Columns: display_name
+                                │     active_users        — WHERE: display_name IS NOT NULL
+                                │   Indexes (2)
+                                │     users_email_idx     —
+                                │ ▎   users_named_idx     —
+                                │   Triggers (1)
+                                │     users_audit         —
+                                │
+                                │
+                                │
+                                │
+                                │
+                                │ index · main.users_named_idx
+ 🔗  SSH                                      ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/ui_snapshots.rs
+++ b/tests/ui_snapshots.rs
@@ -733,3 +733,123 @@ fn snapshot_find_widget_on_preview() {
         insta::assert_snapshot!("find_widget_on_preview", output)
     });
 }
+
+/// Build a SQLite fixture with the four object kinds + a virtual table
+/// so the new grouped sidebar has something to render. Returns the
+/// path within `tmp` that the file tree will pick up.
+fn seed_sqlite_fixture_full(tmp_path: &std::path::Path) -> std::path::PathBuf {
+    let db_path = tmp_path.join("fixture.db");
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE users (
+            id INTEGER PRIMARY KEY,
+            email TEXT NOT NULL,
+            display_name TEXT
+        );
+        INSERT INTO users(id, email, display_name) VALUES
+            (1, 'alice@example.io', 'Alice'),
+            (2, 'bob@example.io',   'Bob'),
+            (3, 'carol@example.io', 'Carol'),
+            (4, 'dave@example.io',  NULL);
+
+        CREATE TABLE posts (id INTEGER PRIMARY KEY, body TEXT);
+        INSERT INTO posts(body) VALUES ('hi'), ('world');
+
+        CREATE VIEW active_users AS
+            SELECT id, email FROM users WHERE display_name IS NOT NULL;
+
+        CREATE UNIQUE INDEX users_email_idx ON users(email);
+        CREATE INDEX users_named_idx ON users(display_name)
+            WHERE display_name IS NOT NULL;
+
+        CREATE TRIGGER users_audit
+            AFTER INSERT ON users
+            BEGIN
+                SELECT 1;
+            END;
+        "#,
+    )
+    .unwrap();
+    drop(conn);
+    db_path
+}
+
+#[test]
+fn snapshot_db_preview_grouped_sidebar() {
+    // The redesigned SQLite preview: grouped objects sidebar
+    // (▾ main / Tables (2) / Views (1) / Indexes (2) / Triggers (1))
+    // + borderless data grid with zebra striping + affinity-colored
+    // type chips + the existing footer chip row. This snapshot is the
+    // single end-to-end regression guard for the rewrite — width
+    // 110×24 gives both the sidebar (~24 cells) and the data area
+    // enough room to land without the sidebar collapsing.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    force_en_lang();
+    let (tmp, _raw) = tempdir_repo();
+    seed_sqlite_fixture_full(tmp.path());
+    let home = tempfile::TempDir::new().expect("home tempdir");
+    let _h = HomeGuard::enter(home.path());
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.refresh_file_tree();
+    wait_for_file_tree(&mut app);
+
+    let idx = app
+        .file_tree
+        .entries
+        .iter()
+        .position(|e| e.name == "fixture.db")
+        .expect("fixture.db in tree");
+    app.file_tree.selected = idx;
+    app.load_preview();
+    wait_for_preview(&mut app);
+
+    let output = render_app(&mut app, 110, 24);
+    with_filters(&[], || {
+        insta::assert_snapshot!("db_preview_grouped_sidebar", output)
+    });
+}
+
+#[test]
+fn snapshot_db_preview_index_detail() {
+    // Selecting an Index in the sidebar swaps the data grid for a
+    // detail card: object name + [index] tag + UNIQUE / PARTIAL chips
+    // + Table line + Columns line + optional WHERE.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    force_en_lang();
+    let (tmp, _raw) = tempdir_repo();
+    seed_sqlite_fixture_full(tmp.path());
+    let home = tempfile::TempDir::new().expect("home tempdir");
+    let _h = HomeGuard::enter(home.path());
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.refresh_file_tree();
+    wait_for_file_tree(&mut app);
+
+    let idx = app
+        .file_tree
+        .entries
+        .iter()
+        .position(|e| e.name == "fixture.db")
+        .expect("fixture.db in tree");
+    app.file_tree.selected = idx;
+    app.load_preview();
+    wait_for_preview(&mut app);
+
+    // Switch selection to the partial index — exercises both the
+    // UNIQUE branch off (this index isn't unique) and the PARTIAL
+    // chip + WHERE line on.
+    app.db_select_object(reef_sqlite_preview::DbObjectKey {
+        schema: "main".to_string(),
+        name: "users_named_idx".to_string(),
+        kind: reef_sqlite_preview::DbObjectKind::Index,
+    });
+
+    let output = render_app(&mut app, 110, 24);
+    with_filters(&[], || {
+        insta::assert_snapshot!("db_preview_index_detail", output)
+    });
+}


### PR DESCRIPTION
## Summary

- Reworks the SQLite preview from a single-table list into a full schema browser. Sidebar groups every schema from `PRAGMA database_list` (main / temp / attached) with Tables / Views / Indexes / Triggers subsections. Selecting an Index or Trigger swaps the data grid for a structural detail card (UNIQUE / PARTIAL chips, columns, partial WHERE, parsed trigger timing / event + SQL body).
- Data grid drops vertical-rule glyphs in favour of a borderless modern look: two-space column separator, alternating row background, type chips tinted by SQLite affinity (INT blue / TEXT green / REAL amber / …), numeric cells right-aligned, NULL italic dim. Column names share the same hue as their type chip so name + type read as one cell.
- Protocol bumps to **v9**. New `LoadDbInitialV2` / `LoadDbPageV2` / `LoadDbObjectDetail` carry schema-qualified `DbObjectKey`s. Old v8 variants stay declared in `reef-proto` but the client only sends v9; agent mismatches surface as the existing "re-run reef --ssh" hard-fail per the convention used for v7 / v8 bumps.

## Backend additions (`reef-sqlite-preview`)

- `list_databases`, `list_objects(schema, max_count)`, `read_columns_qualified(schema, table)`, `read_index_detail`, `read_trigger_detail`, `read_object_detail` / `read_object_detail_at`, `load_page_qualified`, `read_initial_v2`.
- New types: `DbObjectKind` (Table / View / Index / Trigger), `SchemaKind` (Main / Temp / Attached), `DbObjectKey`, `DbObject`, `SchemaSummary`, `DatabaseInfoV2`, `DbObjectDetail`. `ColumnInfo` gains `notnull` + `pk` from `PRAGMA table_info`.
- `quote_qualified(schema, name)` for safe `"schema"."object"` injection (PRAGMA can't bind identifiers; `quote_ident`'s double-quote doubling is the safe path).
- `MAX_OBJECTS_PER_SCHEMA = 5000` cap with `truncated: bool` flag so pathological schemas don't explode the wire payload.
- `DatabaseInfoV2::lookup(&key)` + `iter_row_bearing()` helpers consume the previously inline `info.schemas.iter().flat_map(...).find(...)` patterns at the call sites.
- FTS5 shadow tables (`<vt>_data` / `_idx` / `_content` / `_docsize` / `_config`) are detected via their parent virtual table and dropped from the sidebar.

## Backend trait + agent

- `Backend::db_load_page` and `db_load_object_detail` take `&DbObjectKey` instead of four positional args (`schema`, `kind`, `name` collapse into the key).
- `reef-agent` routes the three new V2 requests to the new helpers; existing `*_to_dto` / `*_from_dto` boilerplate extends to cover the new types.
- `RemoteBackend::load_preview` calls `LoadDbInitialV2`. Strict handshake stays — matches the established auto-redeploy philosophy from prior version bumps.

## UI / interaction

- New `ClickAction::DbSelectObject` and `DbToggleSchema`. Sidebar registers schema-header and object-row hit regions. Mouse click on a table / view loads its page; click on an index / trigger loads its detail; click on a schema header toggles expansion.
- Schema header uses `▾` / `▸` (real expand state). Object rows have no caret (they're terminal nodes — the chevron would mislead). Selected row gets a `▎` accent bar.
- Subsection labels (`Tables (3)` / `Indexes (2)` / ...) use accent fg + bold; counts stay in secondary fg.
- Sidebar width is computed per-frame from the visible (expanded) rows and clamped to 18..=32 columns. `build_sidebar_rows` + width calculation merged into a single pass so we don't walk the schemas twice per frame.

## Tests + tooling

- 13 new multi-schema integration tests in `crates/reef-sqlite-preview/tests/multi_schema.rs` covering ATTACH databases, the four object kinds + virtual tables, partial / unique indexes, trigger header parsing, FTS shadow filtering, and the `UnsupportedObjectKind` guard.
- Two new UI snapshots (`db_preview_grouped_sidebar`, `db_preview_index_detail`) lock in the visual rewrite.
- Two regression tests guard a multibyte UTF-8 panic that hit on a real-world `.db` containing CJK column comments — `sql_has_without_rowid_suffix` was byte-slicing past a char boundary and `extract_partial_where` was indexing a lowercased copy back into the original `&str`. Both fixed with byte-level ASCII case-folding.

## Code-review pass

After the initial implementation, three review agents (reuse / quality / efficiency) flagged ~30 issues. Cleanups in this PR:

- Dropped redundant `DbPreviewState.schemas: Vec<SchemaSummary>` (duplicated `info.schemas`; was the per-frame multi-MB clone the efficiency review called out). `DbPane` / `focused_pane` removed as dead code.
- Consolidated three nav functions (`db_navigate` / `db_navigate_to_page` / `db_select_object`) onto `db_apply_page` + `db_apply_detail` helpers, ~150 LoC of duplicated "snapshot state → RPC → mutate" boilerplate gone.
- `DbObjectKind::section_label()` + `as_master_type()` replace standalone `kind_section_label` / `detail_kind_label` helpers.
- Inline `info.schemas.iter().flat_map(...).find(...)` chains (4 sites) collapsed to `info.lookup` / `info.iter_row_bearing`.
- `pad_to_width` + `pad_left_to_width` merged behind `pad_aligned(Align)`.
- `is_create_virtual_table` switched to byte comparison so it doesn't allocate a String per `list_objects` row.
- Removed task-marker comments ("Phase A/B/C/D"), `narrating-WHAT` comments, and a stale duplicate `rusqlite` dev-dependency in `reef-sqlite-preview/Cargo.toml`.

## Out of scope (deliberate)

- **Async pagination** (heavy-task worker for `db_load_page`). The synchronous RPC still costs SSH 10-50 ms per nav; planned as a separate PR — it needs `WorkerResult::DbPageLoaded` + generation-token discipline and isn't visual.
- **SQL editor** / EXPLAIN entry — explicitly chosen against during planning; preview stays read-only browse.
- **ATTACH UI** — backend supports it (anything attached on the connection shows up), but no in-UI affordance to attach further files.

## Test plan

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace` (note: `fs_watcher_integration` has 3 pre-existing failures on macOS sandbox that are unrelated to this PR — they fail on `main` too)
- [ ] Manual: open a `.db` with multiple object kinds, click between table / view / index / trigger in the sidebar, verify the detail card / data grid swap and the alternating-row data grid renders correctly
- [ ] Manual: open a `.db` with CJK comments in DDL (regression for the byte-boundary panic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)