### PR TITLE
feat(ui): focused-preview mode with floating file picker

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -162,10 +162,16 @@ const PREFETCH_DELAY: Duration = Duration::from_millis(300);
 /// `Settings` is a full-screen takeover that hides the tab bar; the
 /// background work coordinator keeps running so the four-tab snapshots
 /// are fresh on return.
+///
+/// `FocusedPreview` is the "纯预览" mode — same full-screen takeover
+/// pattern as Settings, but the body is the active tab's preview/diff
+/// panel maximised. Entered via `Space+V` or `reef <file>` from CLI;
+/// Esc returns to `Main`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ViewMode {
     Main,
     Settings,
+    FocusedPreview,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -208,6 +214,23 @@ pub enum Panel {
     /// 右列,通常是 diff 或 preview。Graph tab 三列模式下指最右侧
     /// 的 diff 栏;二列模式下是 commit detail(含内联 diff)。
     Diff,
+}
+
+/// 一行 changed-file 数据,FocusedPreview 文件 picker 用来渲染 + 派发。
+/// 数据源由 [`FocusedPreviewFileSource`] 标注:同样的文件名在 Git tab
+/// 可能同时出现在 staged + unstaged,跟 reef 内部其它面板一致地视作两行。
+#[derive(Debug, Clone)]
+pub struct FocusedPreviewFileRow {
+    pub path: String,
+    pub status: char,
+    pub source: FocusedPreviewFileSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FocusedPreviewFileSource {
+    GitStaged,
+    GitUnstaged,
+    GraphCommit,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -500,6 +523,12 @@ pub struct App {
 
     pub view_mode: ViewMode,
     pub settings: crate::settings::SettingsState,
+
+    /// FocusedPreview 左上角 ☰ 按钮触发的悬浮文件 picker。`open` 控制
+    /// 弹窗显示;`selected` 是高亮行的索引,指向 `focused_preview_file_entries`
+    /// 返回的扁平 Vec。
+    pub focused_preview_files_open: bool,
+    pub focused_preview_files_selected: usize,
 
     // ── Git tab state ──
     pub staged_files: Vec<FileEntry>,
@@ -1026,6 +1055,8 @@ impl App {
             active_panel: Panel::Files,
             view_mode: ViewMode::Main,
             settings: crate::settings::SettingsState::default(),
+            focused_preview_files_open: false,
+            focused_preview_files_selected: 0,
             staged_files: Vec::new(),
             unstaged_files: Vec::new(),
             selected_file: None,
@@ -4204,6 +4235,269 @@ impl App {
         self.settings.editor_edit = None;
     }
 
+    /// Enter "pure preview" (纯预览) — the active tab's preview/diff
+    /// panel takes the whole screen. On entry we move `active_panel`
+    /// onto the content column so scroll keys route the right way;
+    /// `ui::render` decides what to show based on `active_tab`. Esc
+    /// flips `view_mode` back to `Main`.
+    ///
+    /// No-op when not in `Main`. Doesn't validate that there's
+    /// something to show — an empty/loading preview is a normal state
+    /// to render, just maximised.
+    pub fn enter_focused_preview(&mut self) {
+        if self.view_mode != ViewMode::Main {
+            return;
+        }
+        // Pick the panel that owns the content column for this tab. The
+        // Graph tab in 2-col mode draws its inline diff via the Commit
+        // panel; everywhere else the Diff panel is the content column.
+        self.active_panel = match self.active_tab {
+            Tab::Graph if !self.graph_uses_three_col() => Panel::Commit,
+            _ => Panel::Diff,
+        };
+        self.view_mode = ViewMode::FocusedPreview;
+    }
+
+    /// CLI entry point — `reef <file>` lands here after the workdir
+    /// has been opened at the file's parent (or the repo root, when
+    /// the file is inside a git repo — see `resolve_local_path`).
+    /// Drops straight into FocusedPreview against the given
+    /// workdir-relative path.
+    ///
+    /// Race-fix history: `App::new_with_backend` already fires an
+    /// async `refresh_file_tree` with an *empty* `selected_path`
+    /// snapshot. A naïve "reveal then dispatch_preview_load" would
+    /// lose the race — the worker comes back with `selected_idx = 0`,
+    /// `replace_entries` overwrites our selection, and the post-rebuild
+    /// `before != after` check fires a second `load_preview()` that
+    /// clobbers the in-flight foo.rs preview with whatever entries[0]
+    /// happens to be (often README.md).
+    ///
+    /// Fix: re-fire `refresh_file_tree_with_target(Some(rel))`
+    /// *after* setting the expanded ancestors via `reveal`. The new
+    /// task supersedes the prior one (generation bump), the worker
+    /// now captures the right `selected_path` snapshot, and
+    /// `apply_worker_result`'s eventual `load_preview()` for the
+    /// post-rebuild selection lands on the same `rel` path — same
+    /// path means dedupe at the dispatch layer (or a benign redundant
+    /// load against the file we actually want).
+    pub fn enter_focused_preview_with_file(&mut self, rel: PathBuf) {
+        self.set_active_tab(Tab::Files);
+        // Expand ancestor directories so the row is visible once the
+        // tree task lands. `reveal` no-ops the selection move on empty
+        // entries but always populates `self.expanded` — and the new
+        // refresh_file_tree_with_target call below reads from
+        // `file_tree.expanded_paths()` at dispatch time, so the
+        // expanded ancestors do reach the worker.
+        self.file_tree.reveal(&rel);
+        // Supersede the App::new tree task with one that knows the
+        // target path. The worker uses this to pin `selected_idx` and
+        // skips the wrong-file post-rebuild preview load.
+        self.refresh_file_tree_with_target(Some(rel.clone()));
+        // Start the preview immediately so the maximised panel isn't
+        // blank during the (~10ms) tree-rebuild window.
+        self.preview_schedule = None;
+        self.prefetch_schedule = None;
+        self.dispatch_preview_load(rel);
+        self.enter_focused_preview();
+    }
+
+    pub fn close_focused_preview(&mut self) {
+        if self.view_mode != ViewMode::FocusedPreview {
+            return;
+        }
+        self.view_mode = ViewMode::Main;
+        // Defensive: clear picker state so a future view_mode escape
+        // path (toast-driven, fatal-error overlay, etc.) that bypasses
+        // close_focused_preview_files can't leave the bool stuck `true`
+        // and re-paint the picker the next time the user enters
+        // FocusedPreview on a different tab. Today every reachable
+        // close path already runs close_focused_preview_files first,
+        // but the invariant is implicit — make it explicit here.
+        self.focused_preview_files_open = false;
+        self.focused_preview_files_selected = 0;
+    }
+
+    /// Space+V routing: enter from Main, exit from FocusedPreview.
+    /// No-op while Settings owns the screen so a stray chord can't
+    /// silently discard an in-progress settings edit.
+    pub fn toggle_focused_preview(&mut self) {
+        match self.view_mode {
+            ViewMode::Main => self.enter_focused_preview(),
+            ViewMode::FocusedPreview => self.close_focused_preview(),
+            ViewMode::Settings => {}
+        }
+    }
+
+    /// Shared gate for the ☰ chip + file picker: whether the chip
+    /// affordance is visually present right now. The renderer in
+    /// `focused_preview_panel::render` checks this, and the input
+    /// handler's `o` key shortcut checks the same predicate so the
+    /// two states never disagree (the original bug had keyboard
+    /// opening a picker the renderer refused to draw on Graph 2-col).
+    ///
+    /// Graph 2-col uses `commit_detail_panel`'s header (commit
+    /// metadata + inline files tree), which doesn't match the
+    /// `path_display + tag_str` layout the chip's wash math assumes —
+    /// so the chip is deliberately not rendered there, and the `o`
+    /// shortcut likewise no-ops.
+    pub fn focused_preview_chip_visible(&self) -> bool {
+        if !self.backend.has_repo() {
+            return false;
+        }
+        match self.active_tab {
+            Tab::Git => true,
+            Tab::Graph => self.graph_uses_three_col(),
+            _ => false,
+        }
+    }
+
+    // ── FocusedPreview floating file picker ──────────────────────────
+
+    /// Snapshot of the diff-changed file list to render in the popup.
+    /// Built fresh each call from `staged_files + unstaged_files` (Git)
+    /// or `commit_detail.detail.files` (Graph). Sorted by path so the
+    /// indented "tree-ish" layout in the popup is stable.
+    pub fn focused_preview_file_entries(&self) -> Vec<FocusedPreviewFileRow> {
+        match self.active_tab {
+            Tab::Git => {
+                let mut out: Vec<FocusedPreviewFileRow> = Vec::new();
+                for f in &self.staged_files {
+                    out.push(FocusedPreviewFileRow {
+                        path: f.path.clone(),
+                        status: f.status.label().chars().next().unwrap_or(' '),
+                        source: FocusedPreviewFileSource::GitStaged,
+                    });
+                }
+                for f in &self.unstaged_files {
+                    out.push(FocusedPreviewFileRow {
+                        path: f.path.clone(),
+                        status: f.status.label().chars().next().unwrap_or(' '),
+                        source: FocusedPreviewFileSource::GitUnstaged,
+                    });
+                }
+                out.sort_by(|a, b| a.path.cmp(&b.path));
+                out
+            }
+            Tab::Graph => {
+                let Some(detail) = self.commit_detail.detail.as_ref() else {
+                    return Vec::new();
+                };
+                let mut out: Vec<FocusedPreviewFileRow> = detail
+                    .files
+                    .iter()
+                    .map(|f| FocusedPreviewFileRow {
+                        path: f.path.clone(),
+                        status: f.status.label().chars().next().unwrap_or(' '),
+                        source: FocusedPreviewFileSource::GraphCommit,
+                    })
+                    .collect();
+                out.sort_by(|a, b| a.path.cmp(&b.path));
+                out
+            }
+            // Files / Search tabs have no concept of "changed files" —
+            // the chip isn't rendered there, so this returns empty.
+            _ => Vec::new(),
+        }
+    }
+
+    /// Open the floating picker. Snaps the highlighted row to whatever
+    /// file the diff is currently showing, so ↑/↓ navigation feels like
+    /// it picks up where the user already is. Falls back to row 0 if
+    /// the current target isn't in the list (e.g. no diff loaded yet).
+    ///
+    /// Git tab subtlety: a file can legitimately appear in both staged
+    /// and unstaged at the same time (committed + further edited). The
+    /// snap must compare `is_staged` too — otherwise opening the picker
+    /// while viewing the unstaged diff would snap to the staged row
+    /// (sort order puts staged first) and a no-op Enter would silently
+    /// switch the diff target from unstaged to staged.
+    pub fn open_focused_preview_files(&mut self) {
+        let entries = self.focused_preview_file_entries();
+        if entries.is_empty() {
+            return;
+        }
+        let idx = match self.active_tab {
+            Tab::Git => {
+                let sel = self.selected_file.as_ref();
+                sel.and_then(|s| {
+                    let target_src = if s.is_staged {
+                        FocusedPreviewFileSource::GitStaged
+                    } else {
+                        FocusedPreviewFileSource::GitUnstaged
+                    };
+                    entries
+                        .iter()
+                        .position(|e| e.path == s.path && e.source == target_src)
+                })
+                .unwrap_or(0)
+            }
+            Tab::Graph => self
+                .commit_detail
+                .file_diff
+                .as_ref()
+                .and_then(|d| entries.iter().position(|e| e.path == d.path))
+                .unwrap_or(0),
+            _ => 0,
+        };
+        self.focused_preview_files_selected = idx;
+        self.focused_preview_files_open = true;
+    }
+
+    pub fn close_focused_preview_files(&mut self) {
+        self.focused_preview_files_open = false;
+    }
+
+    pub fn toggle_focused_preview_files(&mut self) {
+        if self.focused_preview_files_open {
+            self.close_focused_preview_files();
+        } else {
+            self.open_focused_preview_files();
+        }
+    }
+
+    pub fn move_focused_preview_files_selection(&mut self, delta: i32) {
+        let len = self.focused_preview_file_entries().len();
+        if len == 0 {
+            return;
+        }
+        let cur = self.focused_preview_files_selected as i32;
+        let next = (cur + delta).rem_euclid(len as i32);
+        self.focused_preview_files_selected = next as usize;
+    }
+
+    /// Apply the highlighted row: load the corresponding file's diff
+    /// and close the picker. The diff render path then picks up the
+    /// new target on the next frame.
+    pub fn confirm_focused_preview_files_selection(&mut self) {
+        let entries = self.focused_preview_file_entries();
+        let Some(row) = entries.get(self.focused_preview_files_selected).cloned() else {
+            return;
+        };
+        self.apply_focused_preview_file_pick(&row);
+        self.close_focused_preview_files();
+    }
+
+    /// Mouse-click variant — picks by absolute index, used by the
+    /// `PickFocusedPreviewFile(usize)` action.
+    pub fn pick_focused_preview_file(&mut self, idx: usize) {
+        let entries = self.focused_preview_file_entries();
+        let Some(row) = entries.get(idx).cloned() else {
+            return;
+        };
+        self.focused_preview_files_selected = idx;
+        self.apply_focused_preview_file_pick(&row);
+        self.close_focused_preview_files();
+    }
+
+    fn apply_focused_preview_file_pick(&mut self, row: &FocusedPreviewFileRow) {
+        match row.source {
+            FocusedPreviewFileSource::GitStaged => self.select_file(&row.path, true),
+            FocusedPreviewFileSource::GitUnstaged => self.select_file(&row.path, false),
+            FocusedPreviewFileSource::GraphCommit => self.load_commit_file_diff(&row.path),
+        }
+    }
+
     pub fn set_active_tab(&mut self, tab: Tab) {
         if self.active_tab == tab {
             return;
@@ -4225,6 +4519,12 @@ impl App {
         // appears on return and the click-count resets cleanly.
         self.preview_selection = None;
         self.preview_click_state = None;
+        // FocusedPreview file picker is also tab-scoped (entries come
+        // from the active tab's diff list). Switching tabs while the
+        // picker is open would carry the popup state to a tab whose
+        // changed-file list is unrelated.
+        self.focused_preview_files_open = false;
+        self.focused_preview_files_selected = 0;
         // Same for diff-panel selection — the Git tab and the Graph tab
         // 3-col diff column share this state, and tab-switching between
         // them (or to Files/Search) should start fresh.
@@ -4527,6 +4827,15 @@ impl App {
             }
             ClickAction::ConfirmModalCancel => {
                 self.fire_confirm_cancel();
+            }
+            ClickAction::ToggleFocusedPreviewFiles => {
+                self.toggle_focused_preview_files();
+            }
+            ClickAction::PickFocusedPreviewFile(idx) => {
+                self.pick_focused_preview_file(idx);
+            }
+            ClickAction::CloseFocusedPreviewFiles => {
+                self.close_focused_preview_files();
             }
         }
     }

--- a/src/find_widget.rs
+++ b/src/find_widget.rs
@@ -185,13 +185,19 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
             return;
         }
         input::LeaderVerdict::Fire => {
+            // `leader_decision` Fires on any chord target (p/f/h/v). The
+            // widget's identity is Space+F — only that closes. For
+            // other chord letters we used to `return` here, which
+            // silently dropped the user's keystroke (`v` after Space
+            // typed into an empty query just vanished). Treat them as
+            // Consume instead so the literal char falls through to the
+            // input-dispatch arm and appends to the query buffer.
             app.find_widget.space_leader_at = None;
-            // Plain Space+F closes the widget; other chord targets are
-            // swallowed so the palette behaves like other overlays.
             if key.code == KeyCode::Char('f') && !ctrl && !alt {
                 close(app);
+                return;
             }
-            return;
+            // Fall through — non-F chord lands in the input handler.
         }
         input::LeaderVerdict::Consume => {
             app.find_widget.space_leader_at = None;

--- a/src/global_search.rs
+++ b/src/global_search.rs
@@ -458,16 +458,17 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
             return;
         }
         crate::input::LeaderVerdict::Fire => {
+            // `leader_decision` Fires on any chord target (p/f/h/v).
+            // Only Space+Shift+F is OUR own toggle — anything else is
+            // a stray Space + chord-letter inside an empty query, and
+            // the right thing is to let the literal char fall through
+            // to the input-append arm rather than silently swallow it.
             app.global_search.space_leader_at = None;
-            // Only close when the follow-up matches OUR chord target — the
-            // palette's open chord moved to `Space+Shift+F`, so `Char('F')`
-            // is now the only key that toggles us off. Lower-case `f`
-            // (Space+F) is in-panel find and doesn't belong to this
-            // overlay; other chord targets fall through quietly.
             if key.code == KeyCode::Char('F') && !ctrl && !alt {
                 app.global_search.active = false;
+                return;
             }
-            return;
+            // Fall through — non-Shift-F chord lands in the input handler.
         }
         crate::input::LeaderVerdict::Consume => {
             app.global_search.space_leader_at = None;

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -219,6 +219,16 @@ pub enum Msg {
     SidebarHiddenHint,
     HelpAnyKey,
 
+    // 纯预览 / FocusedPreview
+    /// Bottom-row hint shown while ViewMode::FocusedPreview is active.
+    FocusedPreviewHint,
+    /// Help-popup row describing the `Space v` chord.
+    HelpFocusedPreview,
+    /// Header row of the floating file picker — Git tab variant.
+    FocusedPreviewPickerHeaderGit,
+    /// Header row of the floating file picker — Graph (commit) variant.
+    FocusedPreviewPickerHeaderCommit,
+
     // Status bar panel-focus chip — short labels for the right-aligned
     // indicator showing which panel currently owns focus.
     PanelFiles,
@@ -400,6 +410,10 @@ fn t_zh(m: Msg) -> &'static str {
         HelpEscBackOut => "退出焦点 / 清除搜索",
         SidebarHiddenHint => "侧边栏已隐藏 — Ctrl+B 可恢复",
         HelpAnyKey => "关闭帮助",
+        FocusedPreviewHint => " 纯预览 · Esc 退出 · ↑↓ 滚动 ",
+        HelpFocusedPreview => "纯预览当前文件 / Diff（Esc 退出）",
+        FocusedPreviewPickerHeaderGit => " 改动文件 (Git) ",
+        FocusedPreviewPickerHeaderCommit => " 改动文件 (Commit) ",
         PanelFiles => "文件",
         PanelPreview => "预览",
         PanelCommit => "提交",
@@ -570,6 +584,10 @@ fn t_en(m: Msg) -> &'static str {
         HelpEscBackOut => "Exit focus / clear search",
         SidebarHiddenHint => "Sidebar hidden — Ctrl+B to restore",
         HelpAnyKey => "Close help",
+        FocusedPreviewHint => " Focused preview · Esc to exit · ↑↓ scroll ",
+        HelpFocusedPreview => "Focused preview of current file / diff (Esc exits)",
+        FocusedPreviewPickerHeaderGit => " Changed files (Git) ",
+        FocusedPreviewPickerHeaderCommit => " Changed files (Commit) ",
         PanelFiles => "Files",
         PanelPreview => "Preview",
         PanelCommit => "Commit",

--- a/src/input.rs
+++ b/src/input.rs
@@ -83,11 +83,17 @@ pub fn leader_decision(
     // uppercase char.
     let is_lower_chord = matches!(
         key.code,
-        KeyCode::Char('p') | KeyCode::Char('f') | KeyCode::Char('h')
+        KeyCode::Char('p')
+            | KeyCode::Char('f')
+            | KeyCode::Char('h')
+            | KeyCode::Char('v')
     ) && key.modifiers.is_empty();
     let is_upper_chord = matches!(
         key.code,
-        KeyCode::Char('P') | KeyCode::Char('F') | KeyCode::Char('H')
+        KeyCode::Char('P')
+            | KeyCode::Char('F')
+            | KeyCode::Char('H')
+            | KeyCode::Char('V')
     ) && (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT);
     let is_chord_target = is_lower_chord || is_upper_chord;
 
@@ -248,6 +254,22 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         return;
     }
 
+    // FocusedPreview ("纯预览") strips chrome and gives the whole frame
+    // to the active panel. Only a tiny key set is meaningful inside:
+    // Esc / q exit, Ctrl+C still quits, and a handful of nav keys fall
+    // through to the normal dispatcher so scroll/search continue to
+    // work on the visible diff/preview.
+    if app.view_mode == ViewMode::FocusedPreview {
+        if handle_key_focused_preview(key, app) {
+            return;
+        }
+        // Fallthrough lets navigation/scroll/search keys (↑/↓/PgUp/
+        // PgDn/Home/End/←/→/j/k/g/G/n/N/m/f/`/` etc.) keep their
+        // normal meaning against the visible panel. The Space-leader
+        // chord above already ran for any key reaching here, and
+        // overlays would have early-returned earlier in this fn.
+    }
+
     // Space-leader chord: bare Space primes, bare `p` opens the quick-open
     // palette, bare `f` opens the global-search palette. Bare Space has no
     // other global meaning, so the chord doesn't collide with any existing
@@ -316,6 +338,11 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
                     app.global_search.replace_open = true;
                     app.global_search.focus = crate::global_search::SearchPanelFocus::ReplaceInput;
                 }
+                // Space+V: 纯预览 toggle — maximise the active tab's
+                // content panel (file preview on Files/Search, diff on
+                // Git/Graph) from Main; exit back to Main if already
+                // focused. Esc inside the mode also exits.
+                KeyCode::Char('v') | KeyCode::Char('V') => app.toggle_focused_preview(),
                 _ => {}
             }
             return;
@@ -606,6 +633,171 @@ fn handle_key_db_goto(key: KeyEvent, app: &mut App) {
 ///   selection cursor; Enter cycles the selected enum / toggles the
 ///   selected bool, or opens the inline text editor for the
 ///   `editor.command` row; Esc closes the page.
+/// 纯预览模式的早期闸门 —— 拦截退出语义 + 文件 picker 相关按键。
+/// 返回 `true` 表示已消费,调用方应当 return;返回 `false` 表示让按键继续
+/// 走正常分发,这样↑↓/PgUp/PgDn/jk/`/`/n/N 等滚动 + 搜索键仍对全屏的
+/// preview/diff 面板有效。
+///
+/// picker open 时本闸门**完全接管**按键 —— ↑↓ 选行,Enter 确认,Esc/o
+/// 关闭。这样 picker 期间用户不会意外滚到 diff 上去。
+fn handle_key_focused_preview(key: KeyEvent, app: &mut App) -> bool {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+
+    // Picker fully owns the keyboard while open.
+    if app.focused_preview_files_open {
+        match key.code {
+            KeyCode::Esc => {
+                app.close_focused_preview_files();
+                return true;
+            }
+            KeyCode::Char('c') if ctrl => {
+                app.should_quit = true;
+                return true;
+            }
+            KeyCode::Up | KeyCode::Char('k') if !ctrl => {
+                app.move_focused_preview_files_selection(-1);
+                return true;
+            }
+            KeyCode::Down | KeyCode::Char('j') if !ctrl => {
+                app.move_focused_preview_files_selection(1);
+                return true;
+            }
+            KeyCode::PageUp | KeyCode::Home => {
+                app.focused_preview_files_selected = 0;
+                return true;
+            }
+            KeyCode::PageDown | KeyCode::End => {
+                let len = app.focused_preview_file_entries().len();
+                app.focused_preview_files_selected = len.saturating_sub(1);
+                return true;
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                app.confirm_focused_preview_files_selection();
+                return true;
+            }
+            KeyCode::Char('o') | KeyCode::Char('O') if !ctrl => {
+                app.close_focused_preview_files();
+                return true;
+            }
+            // While picker is up, swallow everything else so accidental
+            // keystrokes can't scroll the diff out from under the popup.
+            _ => return true,
+        }
+    }
+
+    // Explicit handling for FocusedPreview-specific actions.
+    match key.code {
+        KeyCode::Esc => {
+            app.close_focused_preview();
+            return true;
+        }
+        // Bare q quits reef (same convention as Settings / place mode
+        // takeovers). Ctrl+C is the universal quit and is intentionally
+        // handled here too so the user can bail without first Esc'ing.
+        KeyCode::Char('q') if !ctrl => {
+            app.should_quit = true;
+            return true;
+        }
+        KeyCode::Char('c') if ctrl => {
+            app.should_quit = true;
+            return true;
+        }
+        // `o` opens the floating file picker — scoped to focused preview
+        // only (not a global binding), and only where the picker is
+        // actually rendered (Git tab + Graph 3-col). Mirror the
+        // render-side `chip_layout_ok` gate so keyboard and visual
+        // states agree; otherwise pressing `o` on Graph 2-col would
+        // open a picker the renderer refuses to draw and the keyboard
+        // would freeze against an invisible selection.
+        KeyCode::Char('o') | KeyCode::Char('O')
+            if !ctrl
+                && app.space_leader_at.is_none()
+                && app.focused_preview_chip_visible() =>
+        {
+            app.toggle_focused_preview_files();
+            return true;
+        }
+        // Ctrl+, would otherwise reach the global keymap and call
+        // open_settings(), stomping view_mode from FocusedPreview to
+        // Settings — and close_settings always returns to Main, so the
+        // user would lose the 纯预览 context entirely. Swallow here.
+        KeyCode::Char(',') if ctrl => return true,
+        // Ctrl+O would open the hosts picker overlay — swallow for the
+        // same "don't lose 纯预览 context" reason. The user can Esc
+        // first if they really want to swap sessions.
+        KeyCode::Char('o') if ctrl => return true,
+        // Bare v / V — eat it so tab-specific bindings (Graph visual
+        // mode on V, etc.) don't fire against a hidden panel.
+        // Exception: when a Space leader is armed we must fall through
+        // so the chord can reach `leader_decision` →
+        // toggle_focused_preview() and exit.
+        KeyCode::Char('v') | KeyCode::Char('V')
+            if !ctrl && app.space_leader_at.is_none() =>
+        {
+            return true;
+        }
+        _ => {}
+    }
+
+    // Allowlist for falling through to per-tab handlers. The fallthrough
+    // path runs `handle_key_git` / `handle_key_files` etc. without any
+    // view_mode guard, and those handlers have *destructive* bindings on
+    // bare letters: `s/u` stage/unstage, `d` discard, `t/r` toggles,
+    // F2/Delete/Backspace rename/trash. None of those make sense while
+    // the user is "just looking" at a maximised preview — and the tree/
+    // status row they'd act on is invisible, so the action would land on
+    // a row the user can't even see.
+    //
+    // The whitelist below is intentionally narrow: scroll + h-scroll +
+    // search + diff layout/mode + SQLite navigation + readline nav. Any
+    // key not in here is swallowed (`return true`). Add to this list
+    // sparingly — every new entry has to be safe against firing from
+    // an invisible tree/status row.
+    let bare_allowed = !ctrl
+        && !key.modifiers.contains(KeyModifiers::ALT)
+        && matches!(
+            key.code,
+            KeyCode::Up
+                | KeyCode::Down
+                | KeyCode::Left
+                | KeyCode::Right
+                | KeyCode::PageUp
+                | KeyCode::PageDown
+                | KeyCode::Home
+                | KeyCode::End
+                | KeyCode::Char(
+                    'j' | 'k'      // vim vertical
+                    | 'h'          // help popup (FocusedPreview is in the
+                                   // takeover list now, so the next key
+                                   // reaches us, not "dismiss help")
+                    | '?' | '/'    // search prompt
+                    | 'n' | 'N'    // search step
+                    | 'm' | 'f'    // diff layout / diff mode toggles
+                    | '[' | ']'    // SQLite preview: prev/next table
+                    | 'g' | 'G',   // SQLite preview: goto-page; vim top/bottom
+                )
+        );
+    // Ctrl-prefixed nav aliases that the per-tab handlers honor and
+    // that are safe in FocusedPreview.
+    let ctrl_allowed = ctrl
+        && matches!(
+            key.code,
+            KeyCode::Char(
+                'p' | 'n'      // readline up/down
+                | 'j' | 'k'    // vim-style with ctrl
+                | 'f'          // VSCode-style find widget
+                | 'b'          // sidebar toggle (no-op visually in
+                               // FocusedPreview but harmless)
+            )
+        );
+
+    if bare_allowed || ctrl_allowed {
+        false // continue normal dispatch — scroll / search / diff toggles
+    } else {
+        true // swallow — destructive or modal-opening key
+    }
+}
+
 /// - **Editor-command edit mode** (`app.settings.editor_edit.is_some()`):
 ///   typing fills the buffer, Enter commits, Esc cancels and reverts.
 ///
@@ -2222,6 +2414,27 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
         return;
     }
 
+    // FocusedPreview chip / picker mouse intercept — sits in front of
+    // the preview/diff drag-select fast-paths because the chip is
+    // painted on top of the diff rect (col 0..3, row 0). Without this,
+    // a click on the chip falls into `handle_diff_selection`'s
+    // point_in_rect gate and starts a text-selection drag instead of
+    // toggling the file picker. Mirror of the find-widget intercept
+    // a few lines up.
+    if app.view_mode == crate::app::ViewMode::FocusedPreview
+        && let MouseEventKind::Down(MouseButton::Left) = mouse.kind
+        && let Some(action) = app.hit_registry.hit_test(mouse.column, mouse.row)
+        && matches!(
+            action,
+            ui::mouse::ClickAction::ToggleFocusedPreviewFiles
+                | ui::mouse::ClickAction::PickFocusedPreviewFile(_)
+                | ui::mouse::ClickAction::CloseFocusedPreviewFiles
+        )
+    {
+        app.handle_action(action);
+        return;
+    }
+
     // Preview drag-selection fast-path. Owns Down/Drag/Up(Left) when the
     // gesture starts inside the preview panel. Scroll wheel, right-click,
     // and Down outside the panel fall through to the normal match below.
@@ -3120,6 +3333,72 @@ impl ScrollPacer {
 /// h-scrolls (the results list) — other tabs' left panels are tree/list
 /// widgets with no long horizontal content.
 fn apply_horizontal_scroll(app: &mut App, column: u16, total_width: u16, delta: i32) {
+    // FocusedPreview collapses the layout to a single content column;
+    // SBS halves still split the diff width, but they start at x=0 now
+    // (no sidebar) so the cursor-side math has to use the full width.
+    if app.view_mode == crate::app::ViewMode::FocusedPreview {
+        match app.active_tab {
+            Tab::Files | Tab::Search => apply_scroll_delta(&mut app.preview_h_scroll, delta),
+            Tab::Git => match app.diff_layout {
+                crate::app::DiffLayout::Unified => {
+                    apply_scroll_delta(&mut app.diff_h_scroll, delta)
+                }
+                crate::app::DiffLayout::SideBySide => {
+                    if sbs_cursor_on_left(0, total_width, column) {
+                        apply_scroll_delta(&mut app.sbs_left_h_scroll, delta)
+                    } else {
+                        apply_scroll_delta(&mut app.sbs_right_h_scroll, delta)
+                    }
+                }
+            },
+            Tab::Graph => {
+                if app.graph_uses_three_col() {
+                    match app.commit_detail.diff_layout {
+                        crate::app::DiffLayout::Unified => {
+                            apply_scroll_delta(&mut app.commit_detail.file_diff_h_scroll, delta)
+                        }
+                        crate::app::DiffLayout::SideBySide => {
+                            if sbs_cursor_on_left(0, total_width, column) {
+                                apply_scroll_delta(
+                                    &mut app.commit_detail.file_diff_sbs_left_h_scroll,
+                                    delta,
+                                )
+                            } else {
+                                apply_scroll_delta(
+                                    &mut app.commit_detail.file_diff_sbs_right_h_scroll,
+                                    delta,
+                                )
+                            }
+                        }
+                    }
+                } else {
+                    // 2-col fallback — commit_detail panel renders inline diff
+                    // and tracks pan via `diff_h_scroll` (SBS uses the same
+                    // sbs_left/right_h_scroll fields the keyboard handler does).
+                    match app.commit_detail.diff_layout {
+                        crate::app::DiffLayout::Unified => {
+                            apply_scroll_delta(&mut app.commit_detail.diff_h_scroll, delta)
+                        }
+                        crate::app::DiffLayout::SideBySide => {
+                            if sbs_cursor_on_left(0, total_width, column) {
+                                apply_scroll_delta(
+                                    &mut app.commit_detail.sbs_left_h_scroll,
+                                    delta,
+                                )
+                            } else {
+                                apply_scroll_delta(
+                                    &mut app.commit_detail.sbs_right_h_scroll,
+                                    delta,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return;
+    }
+
     // Use the shared sidebar clamp so this matches `ui::render` even when
     // `split_percent` lives near its edges on narrow terminals.
     let split_x = app.graph_sidebar_width(total_width);
@@ -3212,6 +3491,27 @@ fn dispatch_vertical_scroll<B: Backend>(
     }
     app.vertical_scroll_lock.observe();
     let step_i = sign * (app.vertical_scroll_pacer.step() as i32);
+
+    // FocusedPreview collapses the layout to a single content column —
+    // the sidebar / commit middle column are hidden, so the usual
+    // `is_left = column < graph_sidebar_width` heuristic would mis-route
+    // wheel scrolls in the leftmost ~30 cols to the hidden tree/status.
+    // Route directly to the panel that 纯预览 actually renders.
+    if app.view_mode == crate::app::ViewMode::FocusedPreview {
+        match app.active_tab {
+            Tab::Files | Tab::Search => apply_scroll_delta(&mut app.preview_scroll, step_i),
+            Tab::Git => apply_scroll_delta(&mut app.diff_scroll, step_i),
+            Tab::Graph => {
+                if app.graph_uses_three_col() {
+                    apply_scroll_delta(&mut app.commit_detail.file_diff_scroll, step_i);
+                } else {
+                    ui::commit_detail_panel::scroll(app, step_i);
+                }
+            }
+        }
+        return;
+    }
+
     // Use the shared clamp + sidebar-hidden short-circuit so wheel
     // routing lines up with hit-testing. With sidebar hidden
     // `graph_sidebar_width` returns 0 and `is_left` never fires.

--- a/src/input.rs
+++ b/src/input.rs
@@ -83,17 +83,11 @@ pub fn leader_decision(
     // uppercase char.
     let is_lower_chord = matches!(
         key.code,
-        KeyCode::Char('p')
-            | KeyCode::Char('f')
-            | KeyCode::Char('h')
-            | KeyCode::Char('v')
+        KeyCode::Char('p') | KeyCode::Char('f') | KeyCode::Char('h') | KeyCode::Char('v')
     ) && key.modifiers.is_empty();
     let is_upper_chord = matches!(
         key.code,
-        KeyCode::Char('P')
-            | KeyCode::Char('F')
-            | KeyCode::Char('H')
-            | KeyCode::Char('V')
+        KeyCode::Char('P') | KeyCode::Char('F') | KeyCode::Char('H') | KeyCode::Char('V')
     ) && (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT);
     let is_chord_target = is_lower_chord || is_upper_chord;
 
@@ -627,19 +621,14 @@ fn handle_key_db_goto(key: KeyEvent, app: &mut App) {
     }
 }
 
-/// Settings page key dispatcher. Two modes:
-///
-/// - **List mode** (default): ↑↓/k/j/Home/End/PageUp/PageDown move the
-///   selection cursor; Enter cycles the selected enum / toggles the
-///   selected bool, or opens the inline text editor for the
-///   `editor.command` row; Esc closes the page.
 /// 纯预览模式的早期闸门 —— 拦截退出语义 + 文件 picker 相关按键。
-/// 返回 `true` 表示已消费,调用方应当 return;返回 `false` 表示让按键继续
-/// 走正常分发,这样↑↓/PgUp/PgDn/jk/`/`/n/N 等滚动 + 搜索键仍对全屏的
-/// preview/diff 面板有效。
 ///
-/// picker open 时本闸门**完全接管**按键 —— ↑↓ 选行,Enter 确认,Esc/o
-/// 关闭。这样 picker 期间用户不会意外滚到 diff 上去。
+/// 返回 `true` 表示已消费,调用方应当 return;返回 `false` 表示让按键继续
+/// 走正常分发,这样 ↑↓/PgUp/PgDn/jk 等滚动 + 搜索键仍对全屏的 preview/diff
+/// 面板有效。
+///
+/// picker open 时本闸门完全接管按键 —— ↑↓ 选行,Enter 确认,Esc/o 关闭。
+/// 这样 picker 期间用户不会意外滚到 diff 上去。
 fn handle_key_focused_preview(key: KeyEvent, app: &mut App) -> bool {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
 
@@ -710,9 +699,7 @@ fn handle_key_focused_preview(key: KeyEvent, app: &mut App) -> bool {
         // open a picker the renderer refuses to draw and the keyboard
         // would freeze against an invisible selection.
         KeyCode::Char('o') | KeyCode::Char('O')
-            if !ctrl
-                && app.space_leader_at.is_none()
-                && app.focused_preview_chip_visible() =>
+            if !ctrl && app.space_leader_at.is_none() && app.focused_preview_chip_visible() =>
         {
             app.toggle_focused_preview_files();
             return true;
@@ -731,9 +718,7 @@ fn handle_key_focused_preview(key: KeyEvent, app: &mut App) -> bool {
         // Exception: when a Space leader is armed we must fall through
         // so the chord can reach `leader_decision` →
         // toggle_focused_preview() and exit.
-        KeyCode::Char('v') | KeyCode::Char('V')
-            if !ctrl && app.space_leader_at.is_none() =>
-        {
+        KeyCode::Char('v') | KeyCode::Char('V') if !ctrl && app.space_leader_at.is_none() => {
             return true;
         }
         _ => {}
@@ -774,7 +759,7 @@ fn handle_key_focused_preview(key: KeyEvent, app: &mut App) -> bool {
                     | 'n' | 'N'    // search step
                     | 'm' | 'f'    // diff layout / diff mode toggles
                     | '[' | ']'    // SQLite preview: prev/next table
-                    | 'g' | 'G',   // SQLite preview: goto-page; vim top/bottom
+                    | 'g' | 'G', // SQLite preview: goto-page; vim top/bottom
                 )
         );
     // Ctrl-prefixed nav aliases that the per-tab handlers honor and
@@ -786,8 +771,8 @@ fn handle_key_focused_preview(key: KeyEvent, app: &mut App) -> bool {
                 'p' | 'n'      // readline up/down
                 | 'j' | 'k'    // vim-style with ctrl
                 | 'f'          // VSCode-style find widget
-                | 'b'          // sidebar toggle (no-op visually in
-                               // FocusedPreview but harmless)
+                | 'b' // sidebar toggle (no-op visually in
+                      // FocusedPreview but harmless)
             )
         );
 
@@ -798,6 +783,12 @@ fn handle_key_focused_preview(key: KeyEvent, app: &mut App) -> bool {
     }
 }
 
+/// Settings page key dispatcher. Two modes:
+///
+/// - **List mode** (default): ↑↓/k/j/Home/End/PageUp/PageDown move the
+///   selection cursor; Enter cycles the selected enum / toggles the
+///   selected bool, or opens the inline text editor for the
+///   `editor.command` row; Esc closes the page.
 /// - **Editor-command edit mode** (`app.settings.editor_edit.is_some()`):
 ///   typing fills the buffer, Enter commits, Esc cancels and reverts.
 ///
@@ -3381,15 +3372,9 @@ fn apply_horizontal_scroll(app: &mut App, column: u16, total_width: u16, delta: 
                         }
                         crate::app::DiffLayout::SideBySide => {
                             if sbs_cursor_on_left(0, total_width, column) {
-                                apply_scroll_delta(
-                                    &mut app.commit_detail.sbs_left_h_scroll,
-                                    delta,
-                                )
+                                apply_scroll_delta(&mut app.commit_detail.sbs_left_h_scroll, delta)
                             } else {
-                                apply_scroll_delta(
-                                    &mut app.commit_detail.sbs_right_h_scroll,
-                                    delta,
-                                )
+                                apply_scroll_delta(&mut app.commit_detail.sbs_right_h_scroll, delta)
                             }
                         }
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,7 +144,10 @@ enum ResolvedPath {
     /// File quick-look. `workdir` is set so the Files tab + Git
     /// tab see the enclosing repo (when present); `rel` is the
     /// path relative to `workdir`.
-    File { workdir: PathBuf, rel: PathBuf },
+    File {
+        workdir: PathBuf,
+        rel: PathBuf,
+    },
 }
 
 fn resolve_local_path(raw: &str) -> Result<ResolvedPath, String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,10 @@ fn print_usage() {
     eprintln!();
     eprintln!("USAGE:");
     eprintln!("    reef                            # open cwd with local backend");
-    eprintln!("    reef <PATH>                     # open PATH (supports ~/)");
+    eprintln!("    reef <DIR>                      # open DIR (supports ~/)");
+    eprintln!(
+        "    reef <FILE>                     # open FILE's parent dir, drop straight into 纯预览"
+    );
     eprintln!(
         "    reef --ssh user@host            # open remote HOME on host (agent auto-installed)"
     );
@@ -132,15 +135,62 @@ fn expand_tilde(raw: &str) -> Result<PathBuf, String> {
 }
 
 /// Resolve a user-supplied local path: expand `~/`, make absolute,
-/// verify it exists and is a directory.
-fn resolve_local_path(raw: &str) -> Result<PathBuf, String> {
+/// verify it exists. `Dir` opens normally; `File` opens the smallest
+/// containing context (repo root if any, file's parent otherwise) and
+/// remembers the workdir-relative path so the caller can drop straight
+/// into FocusedPreview against it (the `reef <file>` quick-look path).
+enum ResolvedPath {
+    Dir(PathBuf),
+    /// File quick-look. `workdir` is set so the Files tab + Git
+    /// tab see the enclosing repo (when present); `rel` is the
+    /// path relative to `workdir`.
+    File { workdir: PathBuf, rel: PathBuf },
+}
+
+fn resolve_local_path(raw: &str) -> Result<ResolvedPath, String> {
     let expanded = expand_tilde(raw)?;
     let canonical =
         std::fs::canonicalize(&expanded).map_err(|e| format!("cannot open `{raw}`: {e}"))?;
-    if !canonical.is_dir() {
-        return Err(format!("`{raw}` is not a directory"));
+    if canonical.is_dir() {
+        return Ok(ResolvedPath::Dir(canonical));
     }
-    Ok(canonical)
+    if canonical.is_file() {
+        let parent = canonical
+            .parent()
+            .map(|p| p.to_path_buf())
+            .ok_or_else(|| format!("`{raw}` has no parent directory"))?;
+        // Prefer the enclosing repo root as the workdir so the file
+        // tree + Git tab show the right scope. `Repository::discover`
+        // walks upward looking for `.git`; if none is found we fall
+        // back to the file's immediate parent (loose-file viewing).
+        let workdir = match git2::Repository::discover(&parent) {
+            Ok(repo) => repo
+                .workdir()
+                .map(|p| p.to_path_buf())
+                // Bare repos have no workdir — useless for file
+                // viewing, fall back to the file's parent.
+                .unwrap_or(parent.clone()),
+            Err(_) => parent.clone(),
+        };
+        // `canonical` is absolute; `workdir` is also absolute. Their
+        // shared prefix should always be `workdir` because workdir is
+        // either an ancestor (repo case) or the immediate parent
+        // (loose case). strip_prefix returning Err here means the
+        // discover walked past `canonical`'s ancestor chain, which
+        // canonicalize ensures can't happen for honest filesystems —
+        // fall back to just the file name in the defensive arm.
+        let rel = canonical
+            .strip_prefix(&workdir)
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|_| {
+                canonical
+                    .file_name()
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| PathBuf::from(raw))
+            });
+        return Ok(ResolvedPath::File { workdir, rel });
+    }
+    Err(format!("`{raw}` is neither a file nor a directory"))
 }
 
 /// Split a `[user@]host[:path]` target. Returns `(host_with_user, path)`;
@@ -193,6 +243,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Build the backend before terminal setup so any spawn failure surfaces
     // as a normal error (stderr) rather than painting half-initialised on
     // the alt-screen.
+    //
+    // `pending_preview_file` is the relative filename to drop straight into
+    // 纯预览 once the first `App` boots — only set on the `reef <file>`
+    // quick-look path. Carries across the outer 'session loop only on the
+    // very first iteration (subsequent SSH hops shouldn't replay it).
+    let mut pending_preview_file: Option<PathBuf> = None;
     let mut backend: Arc<dyn Backend> = if let Some(target) = parsed.ssh_target.as_deref() {
         Arc::new(build_ssh_backend(target)?)
     } else if let Some(spec) = parsed.agent_exec.as_deref() {
@@ -204,9 +260,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else if let Some(raw) = parsed.path.as_deref() {
         // Switch the process cwd so spawned subprocesses ($EDITOR, git hooks)
         // inherit the same workdir — matches reef-agent's --workdir path.
-        let workdir = resolve_local_path(raw)?;
-        std::env::set_current_dir(&workdir)?;
-        Arc::new(LocalBackend::open_at(workdir))
+        match resolve_local_path(raw)? {
+            ResolvedPath::Dir(workdir) => {
+                std::env::set_current_dir(&workdir)?;
+                Arc::new(LocalBackend::open_at(workdir))
+            }
+            ResolvedPath::File { workdir, rel } => {
+                // Quick-look path: anchor at the enclosing repo root
+                // (or the file's parent when no repo is found, per
+                // resolve_local_path's discover logic). `rel` is the
+                // path relative to that workdir — Files tab tree + Git
+                // tab status both anchor on workdir so the user sees
+                // the file in its repo context, not just a subdir.
+                std::env::set_current_dir(&workdir)?;
+                pending_preview_file = Some(rel);
+                Arc::new(LocalBackend::open_at(workdir))
+            }
+        }
     } else {
         Arc::new(LocalBackend::open_cwd()?)
     };
@@ -260,6 +330,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // — they came here trying to connect to *something*.
             app.open_hosts_picker();
         }
+        // `reef <file>` quick-look: reveal the file in the freshly-built
+        // tree and enter 纯预览 immediately. Consumed on first iteration
+        // so an SSH session swap doesn't try to replay it against a
+        // remote tree that doesn't have the path.
+        if let Some(file) = pending_preview_file.take() {
+            app.enter_focused_preview_with_file(file);
+        }
 
         // Main loop
         loop {
@@ -299,7 +376,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             || app.global_search.active
                             || app.hosts_picker.active
                             || app.view_mode == ViewMode::Settings
+                            || app.view_mode == ViewMode::FocusedPreview
                         {
+                            // Full-screen takeovers + overlays own every key,
+                            // including the would-be "dismiss help" path:
+                            // otherwise a stray j/k inside FocusedPreview
+                            // after `h` would close help instead of reaching
+                            // handle_key_focused_preview's nav fallthrough.
                             input::handle_key(key, &mut app);
                         } else if app.show_help {
                             app.show_help = false;

--- a/src/quick_open.rs
+++ b/src/quick_open.rs
@@ -209,9 +209,20 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
             return;
         }
         crate::input::LeaderVerdict::Fire => {
+            // `leader_decision` Fires on *any* chord target (p/f/h/v).
+            // But quick-open's chord identity is Space+P — only that
+            // pair should toggle the palette closed. For other chord
+            // letters (`v` from FocusedPreview, `h` from help, etc.)
+            // the user pressed Space-then-letter while the palette
+            // happened to be empty; we don't want to swallow it. Treat
+            // those as Consume so the literal char still appends to the
+            // query below.
             app.quick_open.space_leader_at = None;
-            app.quick_open.active = false;
-            return;
+            if matches!(key.code, KeyCode::Char('p') | KeyCode::Char('P')) {
+                app.quick_open.active = false;
+                return;
+            }
+            // Fall through — non-P chord lands in the char-append arm.
         }
         crate::input::LeaderVerdict::Consume => {
             app.quick_open.space_leader_at = None;

--- a/src/ui/focused_preview_panel.rs
+++ b/src/ui/focused_preview_panel.rs
@@ -1,0 +1,347 @@
+//! "纯预览" (FocusedPreview) — full-screen takeover that maximises the
+//! active tab's preview/diff content. Triggered via `Space+V` or the
+//! CLI quick-look path (`reef <file>`). The header row carries a
+//! floating ☰ chip + invisible click zone covering the file path,
+//! opening a no-border popup that lists changed files for one-click
+//! file switching.
+//!
+//! Layout summary
+//! - Whole frame minus 1 bottom hint row goes to the content panel.
+//! - On Git tab + Graph 3-col, a ☰ chip + path-wide click zone is
+//!   painted on top of the diff header. Graph 2-col uses a different
+//!   header layout (commit_detail_panel) so the chip is deliberately
+//!   skipped there — see [`render`] for the gate.
+//! - When the picker is open, a 36×N popup hangs under the chip with
+//!   the changed-files list; row clicks dispatch `PickFocusedPreviewFile`.
+
+use crate::app::{App, Tab};
+use crate::i18n::{Msg, t};
+use crate::ui::mouse::ClickAction;
+use crate::ui::text::truncate_to_width;
+use crate::ui::{diff_panel, file_preview_panel, hover};
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use unicode_width::UnicodeWidthStr;
+
+/// Width of the ☰ chip in the upper-left of the focused-preview body.
+const FOCUSED_PREVIEW_CHIP: &str = " ☰ ";
+
+/// Public entry point — mirrors per-tab routing in `ui::render`.
+/// Files/Search show the file preview, Git the working-tree diff,
+/// Graph the commit diff (3-col diff column or 2-col commit detail).
+pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
+    if area.height == 0 {
+        return;
+    }
+    app.last_total_width = area.width;
+
+    let body_h = area.height.saturating_sub(1);
+    let body = Rect::new(area.x, area.y, area.width, body_h);
+    let hint_row = Rect::new(area.x, area.y + body_h, area.width, 1);
+
+    match app.active_tab {
+        Tab::Files | Tab::Search => {
+            file_preview_panel::render(f, app, body, true);
+        }
+        Tab::Git => {
+            if app.backend.has_repo() {
+                diff_panel::render(f, app, body);
+            } else {
+                super::render_no_repo(f, app, body);
+            }
+        }
+        Tab::Graph => {
+            if app.graph_uses_three_col() {
+                super::render_graph_diff_column(f, app, body);
+            } else {
+                super::render_graph_editor(f, app, body);
+            }
+        }
+    }
+
+    // Float the file-picker affordance on top of the diff for tabs
+    // where switching files makes sense + the chip's width math
+    // actually applies. Single source of truth for that predicate
+    // lives on `App` so the `o` keyboard shortcut in
+    // `handle_key_focused_preview` can gate identically — the original
+    // bug was render saying "no" while input said "yes" on Graph 2-col.
+    //
+    // Order matters: popup renders its catch-all + per-row hit zones
+    // first, then the chip is registered *last* so a click on the
+    // chip wins over the popup's body-wide CloseFocusedPreviewFiles
+    // fallthrough (hit_test scans in reverse — later-registered =
+    // higher z-order).
+    if app.focused_preview_chip_visible() {
+        if app.focused_preview_files_open {
+            render_picker(f, app, body);
+        }
+        render_chip(f, app, body);
+    }
+
+    render_hint(f, app, hint_row);
+}
+
+fn render_chip(f: &mut Frame, app: &mut App, body: Rect) {
+    if body.height == 0 || body.width < 3 {
+        return;
+    }
+    let th = app.theme;
+    let chip_w = UnicodeWidthStr::width(FOCUSED_PREVIEW_CHIP) as u16;
+    let chip_rect = Rect::new(body.x, body.y, chip_w.min(body.width), 1);
+    // The diff header is laid out as `path_display + tag_str`, where
+    // `tag_str = "  [unified][compact]  m/f toggle"`. We want the hover
+    // wash + clickable zone to stop where the path ends — the right-
+    // hand metadata cluster is just visual chrome, not part of the
+    // "open file picker" affordance.
+    let interactive_w = interactive_width(app, body.width);
+    let row_rect = Rect::new(body.x, body.y, interactive_w, 1);
+
+    let is_hovered = hover::is_hover(app, row_rect, row_rect.y);
+
+    // Hover wash on the chip + file-path span only. diff_panel already
+    // wrote the path text into the buffer, so we patch its background
+    // via `buffer_mut().set_style` (keeps glyphs + foreground intact)
+    // rather than re-rendering a Line over it.
+    if is_hovered && !app.focused_preview_files_open {
+        let wash = Style::default().bg(th.hover_bg);
+        f.buffer_mut().set_style(row_rect, wash);
+    } else if app.focused_preview_files_open {
+        // Picker-open state: mirror the chip's inverted look across
+        // the file-path span so the "active" surface is visually
+        // continuous with the chip itself.
+        let wash = Style::default().bg(th.accent).fg(th.chrome_bg);
+        f.buffer_mut().set_style(row_rect, wash);
+    }
+
+    let style = if app.focused_preview_files_open {
+        Style::default()
+            .fg(th.chrome_bg)
+            .bg(th.accent)
+            .add_modifier(Modifier::BOLD)
+    } else if is_hovered {
+        Style::default()
+            .fg(th.accent)
+            .bg(th.hover_bg)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+            .fg(th.accent)
+            .bg(th.chrome_bg)
+            .add_modifier(Modifier::BOLD)
+    };
+    f.render_widget(
+        Line::from(Span::styled(FOCUSED_PREVIEW_CHIP, style)),
+        chip_rect,
+    );
+    // Register the interactive zone last (chip+path, not the tag tail)
+    // so hit_test's reverse scan picks it up across the whole washed
+    // region. Clicking on `[unified][compact] m/f toggle` does NOT
+    // toggle the picker — those reserve their visual role as chrome.
+    app.hit_registry
+        .register(row_rect, ClickAction::ToggleFocusedPreviewFiles);
+}
+
+/// Width of the "interactive" portion of the focused-preview header
+/// row — chip + file path, stopping before the `[unified][compact]
+/// m/f toggle` tag tail that diff_panel paints on the right. Falls
+/// back to chip-only when we can't read the current diff's path.
+///
+/// Both Git tab `diff_panel::render` and Graph 3-col `render_graph_diff_column`
+/// wrap their content in `Block::padding(1, 1, 0, 0)`, so the path
+/// text is rendered starting at column `body.x + 1`, not `body.x`.
+/// The wash starts at `body.x` (so the cell *under* the chip glyph
+/// also gets the wash background) but its right edge must align with
+/// the path's actual rightmost cell — hence the `+1` offset below.
+/// Without it the wash falls short by exactly one cell and the trailing
+/// character of the filename reads as un-highlighted.
+fn interactive_width(app: &App, body_w: u16) -> u16 {
+    let chip_w = UnicodeWidthStr::width(FOCUSED_PREVIEW_CHIP) as u16;
+    let path: Option<&str> = match app.active_tab {
+        Tab::Git => app.diff_content.as_ref().map(|d| d.diff.file_path.as_str()),
+        Tab::Graph => app
+            .commit_detail
+            .file_diff
+            .as_ref()
+            .map(|d| d.path.as_str()),
+        _ => None,
+    };
+    let Some(path) = path else {
+        return chip_w.min(body_w);
+    };
+    // Mirror diff_panel's header tag exactly: Git tab uses the top-level
+    // `app.diff_layout/diff_mode`, Graph tab uses `commit_detail`'s
+    // independent pair. Mismatched math leaves the wash a few cells
+    // short of (or past) the path's actual end.
+    let (layout, mode) = match app.active_tab {
+        Tab::Graph => (app.commit_detail.diff_layout, app.commit_detail.diff_mode),
+        _ => (app.diff_layout, app.diff_mode),
+    };
+    let layout_label = match layout {
+        crate::app::DiffLayout::Unified => t(Msg::LayoutUnified),
+        crate::app::DiffLayout::SideBySide => t(Msg::LayoutSideBySide),
+    };
+    let mode_label = match mode {
+        crate::app::DiffMode::Compact => t(Msg::ModeCompact),
+        crate::app::DiffMode::FullFile => t(Msg::ModeFullFile),
+    };
+    let tag = crate::i18n::diff_mode_hint(layout_label, mode_label);
+    let tag_w = UnicodeWidthStr::width(tag.as_str()) as u16;
+    // `path_max` matches diff_panel's truncation budget *inside* the
+    // padded inner rect — width is body_w-2 (left+right pad) - tag_w.
+    let inner_w = body_w.saturating_sub(2);
+    let path_max = inner_w.saturating_sub(tag_w) as usize;
+    let path_display = truncate_to_width(path, path_max);
+    let path_w = UnicodeWidthStr::width(path_display) as u16;
+    // +1 for the diff_panel's left padding column that sits between
+    // body.x=0 and the path's first character. The wash starts at
+    // body.x to cover the chip glyph too, so its width is
+    // (left_pad=1) + path_w, clamped so we never read past chip_w on
+    // empty paths or past body_w on narrow terminals.
+    chip_w.max(1 + path_w).min(body_w)
+}
+
+/// No-border popup listing diff-changed files. Anchored under the
+/// chip; solid `chrome_bg` background so it reads as a distinct
+/// surface even without a border. Rows below the visible window
+/// scroll-clip when the file count exceeds the popup height.
+fn render_picker(f: &mut Frame, app: &mut App, body: Rect) {
+    let entries = app.focused_preview_file_entries();
+    if entries.is_empty() {
+        return;
+    }
+    let th = app.theme;
+
+    let popup_w: u16 = 36;
+    let popup_max_h: u16 = body.height.saturating_sub(1).min(20);
+    let popup_h: u16 = (entries.len() as u16 + 1).min(popup_max_h);
+    if popup_h < 2 {
+        return;
+    }
+    let anchor_y = body.y + 1;
+    if anchor_y + popup_h > body.y + body.height {
+        return;
+    }
+    let popup = Rect::new(body.x, anchor_y, popup_w.min(body.width), popup_h);
+
+    // Catch-all hit zone for click-outside-to-close. Registered first
+    // so per-row PickFocusedPreviewFile zones below override it for
+    // hits that land on actual rows.
+    app.hit_registry
+        .register(body, ClickAction::CloseFocusedPreviewFiles);
+
+    let bg = th.chrome_bg;
+    let fg = th.fg_primary;
+    for dy in 0..popup.height {
+        f.render_widget(
+            Line::from(Span::styled(
+                " ".repeat(popup.width as usize),
+                Style::default().bg(bg),
+            )),
+            Rect::new(popup.x, popup.y + dy, popup.width, 1),
+        );
+    }
+
+    let header_msg = match app.active_tab {
+        Tab::Git => Msg::FocusedPreviewPickerHeaderGit,
+        _ => Msg::FocusedPreviewPickerHeaderCommit,
+    };
+    f.render_widget(
+        Line::from(Span::styled(
+            t(header_msg),
+            Style::default()
+                .fg(th.fg_secondary)
+                .bg(bg)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Rect::new(popup.x, popup.y, popup.width, 1),
+    );
+
+    let rows_avail = popup.height.saturating_sub(1) as usize;
+    let sel = app
+        .focused_preview_files_selected
+        .min(entries.len().saturating_sub(1));
+    let scroll = if sel >= rows_avail {
+        sel + 1 - rows_avail
+    } else {
+        0
+    };
+    for (visible_idx, abs_idx) in (scroll..entries.len()).take(rows_avail).enumerate() {
+        let row = &entries[abs_idx];
+        let y = popup.y + 1 + visible_idx as u16;
+        let is_sel = abs_idx == sel;
+        let row_rect = Rect::new(popup.x, y, popup.width, 1);
+        // Selection wins over hover so the cursor row stays distinct even
+        // when the mouse drifts across it; otherwise show a subtle hover
+        // wash so unselected rows still react to the pointer.
+        let is_hovered = !is_sel && hover::is_hover(app, row_rect, y);
+        let (fg_row, bg_row) = if is_sel {
+            (th.chrome_bg, th.accent)
+        } else if is_hovered {
+            (fg, th.hover_bg)
+        } else {
+            (fg, bg)
+        };
+        let depth = row.path.matches('/').count();
+        let indent = "  ".repeat(depth);
+        let name = std::path::Path::new(&row.path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(&row.path);
+        let line_text = format!("{}{} {}", indent, row.status, name);
+        let inner_w = popup.width.saturating_sub(2) as usize;
+        let clipped = truncate_to_width(&line_text, inner_w).to_string();
+        let used = UnicodeWidthStr::width(clipped.as_str());
+        // Use saturating_sub defensively — inner_w is intentionally
+        // <= popup.width-2 so today (popup.width-1) - used >= 1, but
+        // a future tweak that lets `used` reach popup.width-1 would
+        // underflow a plain `usize` subtraction and the subsequent
+        // `\" \".repeat(pad_w)` would OOM. Doesn't change the safe-case
+        // value.
+        let pad_w = (popup.width.saturating_sub(1) as usize).saturating_sub(used);
+        let style = Style::default()
+            .fg(fg_row)
+            .bg(bg_row)
+            .add_modifier(if is_sel {
+                Modifier::BOLD
+            } else {
+                Modifier::empty()
+            });
+        f.render_widget(
+            Line::from(vec![
+                Span::styled(" ", Style::default().fg(fg_row).bg(bg_row)),
+                Span::styled(clipped, style),
+                Span::styled(
+                    " ".repeat(pad_w),
+                    Style::default().fg(fg_row).bg(bg_row),
+                ),
+            ]),
+            row_rect,
+        );
+        app.hit_registry
+            .register(row_rect, ClickAction::PickFocusedPreviewFile(abs_idx));
+    }
+}
+
+fn render_hint(f: &mut Frame, app: &App, area: Rect) {
+    let th = app.theme;
+    let fill = Line::from(Span::styled(
+        " ".repeat(area.width as usize),
+        Style::default().bg(th.chrome_bg),
+    ));
+    f.render_widget(fill, area);
+    let hint = t(Msg::FocusedPreviewHint);
+    let hint_w = UnicodeWidthStr::width(hint) as u16;
+    if hint_w == 0 || hint_w > area.width {
+        return;
+    }
+    let x = area.x + (area.width.saturating_sub(hint_w)) / 2;
+    f.render_widget(
+        Line::from(Span::styled(
+            hint,
+            Style::default().fg(th.chrome_muted_fg).bg(th.chrome_bg),
+        )),
+        Rect::new(x, area.y, hint_w, 1),
+    );
+}

--- a/src/ui/focused_preview_panel.rs
+++ b/src/ui/focused_preview_panel.rs
@@ -312,10 +312,7 @@ fn render_picker(f: &mut Frame, app: &mut App, body: Rect) {
             Line::from(vec![
                 Span::styled(" ", Style::default().fg(fg_row).bg(bg_row)),
                 Span::styled(clipped, style),
-                Span::styled(
-                    " ".repeat(pad_w),
-                    Style::default().fg(fg_row).bg(bg_row),
-                ),
+                Span::styled(" ".repeat(pad_w), Style::default().fg(fg_row).bg(bg_row)),
             ]),
             row_rect,
         );

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,6 +7,7 @@ pub mod file_preview_panel;
 pub mod file_tree_panel;
 pub mod find_widget_panel;
 pub mod focus;
+pub mod focused_preview_panel;
 pub mod git_graph_panel;
 pub mod git_status_panel;
 pub mod global_search_panel;
@@ -65,6 +66,16 @@ pub fn render(f: &mut Frame, app: &mut App) {
     // draw it.
     if app.view_mode == ViewMode::Settings {
         settings_panel::render(f, app, size);
+        return;
+    }
+
+    // FocusedPreview ("纯预览") is also a full-screen takeover —
+    // strip the tab bar / sidebar / status chrome and give the entire
+    // frame to the active tab's content panel. Implementation lives in
+    // `focused_preview_panel`; we still draw a 1-row bottom hint so
+    // the Esc affordance is always visible.
+    if app.view_mode == ViewMode::FocusedPreview {
+        focused_preview_panel::render(f, app, size);
         return;
     }
 
@@ -842,6 +853,7 @@ fn render_help(f: &mut Frame, app: &App, screen: Rect) {
         ("Ctrl+,", t(Msg::HelpOpenSettings)),
         ("Space p", t(Msg::HelpQuickOpen)),
         ("Space f", t(Msg::HelpGlobalSearch)),
+        ("Space v", t(Msg::HelpFocusedPreview)),
         (t(Msg::HelpKeyDragDrop), t(Msg::HelpDragDrop)),
         ("F2", t(Msg::HelpRenameEntry)),
         ("d / Del / ⌫", t(Msg::HelpDeleteEntry)),

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -137,6 +137,19 @@ pub enum ClickAction {
     /// `ConfirmModal`. Fires `on_cancel` (usually a no-op) and clears
     /// the modal.
     ConfirmModalCancel,
+
+    // ── FocusedPreview floating file picker ──
+    /// Click the ☰ chip in the upper-left of the focused-preview body.
+    /// Toggles the changed-files popup open/closed.
+    ToggleFocusedPreviewFiles,
+    /// Click a row inside the focused-preview file picker. `usize`
+    /// indexes into the entries returned by `App::focused_preview_file_entries`.
+    /// Switches the active diff target and closes the popup.
+    PickFocusedPreviewFile(usize),
+    /// Catch-all click outside the open focused-preview file picker.
+    /// Registered panel-wide underneath the popup so a stray click
+    /// dismisses it without affecting the diff underneath.
+    CloseFocusedPreviewFiles,
 }
 
 #[derive(Debug, Clone)]

--- a/tests/focused_preview_scroll.rs
+++ b/tests/focused_preview_scroll.rs
@@ -138,7 +138,11 @@ fn git_focused_preview_wheel_in_left_columns_scrolls_diff_not_hidden_sidebar() {
 
     let before = app.diff_scroll;
     // Column 5 sits well inside what would have been the sidebar.
-    input::handle_mouse(wheel(5, 10, MouseEventKind::ScrollDown), &mut app, &terminal);
+    input::handle_mouse(
+        wheel(5, 10, MouseEventKind::ScrollDown),
+        &mut app,
+        &terminal,
+    );
     assert!(
         app.diff_scroll > before,
         "wheel in former-sidebar columns must scroll diff in 纯预览"
@@ -181,7 +185,11 @@ fn focused_preview_horizontal_wheel_routes_to_preview_or_diff() {
     let terminal = Terminal::new(backend).unwrap();
 
     let before = app.preview_h_scroll;
-    input::handle_mouse(wheel(2, 5, MouseEventKind::ScrollRight), &mut app, &terminal);
+    input::handle_mouse(
+        wheel(2, 5, MouseEventKind::ScrollRight),
+        &mut app,
+        &terminal,
+    );
     assert!(
         app.preview_h_scroll > before,
         "horizontal wheel must move preview_h_scroll even in former-sidebar columns"
@@ -193,7 +201,11 @@ fn focused_preview_horizontal_wheel_routes_to_preview_or_diff() {
     app.set_active_tab(Tab::Git);
     app.enter_focused_preview();
     let dh_before = app.diff_h_scroll;
-    input::handle_mouse(wheel(4, 6, MouseEventKind::ScrollRight), &mut app, &terminal);
+    input::handle_mouse(
+        wheel(4, 6, MouseEventKind::ScrollRight),
+        &mut app,
+        &terminal,
+    );
     assert!(app.diff_h_scroll > dh_before);
 }
 
@@ -527,7 +539,10 @@ fn graph_focused_preview_picks_commit_file_via_picker() {
     let entries = app.focused_preview_file_entries();
     assert_eq!(entries.len(), 2);
     assert_eq!(entries[0].path, "src/app.rs");
-    assert_eq!(entries[0].source, reef::app::FocusedPreviewFileSource::GraphCommit);
+    assert_eq!(
+        entries[0].source,
+        reef::app::FocusedPreviewFileSource::GraphCommit
+    );
 
     // Open picker + pick row 1 (src/input.rs).
     app.open_focused_preview_files();
@@ -573,7 +588,10 @@ fn picker_enter_confirm_switches_diff_target() {
     input::handle_key(key(KeyCode::Enter), &mut app);
 
     assert!(!app.focused_preview_files_open);
-    let sel = app.selected_file.as_ref().expect("Enter should set selected_file");
+    let sel = app
+        .selected_file
+        .as_ref()
+        .expect("Enter should set selected_file");
     assert_eq!(sel.path, "b.txt");
     assert!(!sel.is_staged, "row came from unstaged_files");
 }
@@ -610,9 +628,9 @@ fn picker_selection_wraps_at_boundaries() {
     assert_eq!(app.focused_preview_files_selected, 0);
 }
 
-/// Graph 2-col layout deliberately doesn't show the chip — the
+/// Graph 2-col layout deliberately doesn't show the chip: the
 /// commit_detail_panel renders a different header (commit metadata
-/// + inline file tree) where the chip's path-width math doesn't
+/// plus inline file tree) where the chip's path-width math doesn't
 /// apply. Regression guard so this stays intentional.
 #[test]
 fn graph_two_col_does_not_register_chip_hit_zone() {

--- a/tests/focused_preview_scroll.rs
+++ b/tests/focused_preview_scroll.rs
@@ -1,0 +1,834 @@
+//! Scroll routing in `ViewMode::FocusedPreview`.
+//!
+//! 纯预览态把 active_panel 强制设到内容列, 所有 ↑↓/PgUp/PgDn/←/→ 都应落
+//! 在对应的滚动字段上。这组测试逐 tab 验证, 防止以后改 `enter_focused_preview`
+//! 或 per-tab 键位路由时把这个路径打断。
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use reef::app::{App, Tab, ViewMode};
+use reef::input;
+use reef::ui::theme::Theme;
+use std::sync::Mutex;
+use tempfile::TempDir;
+use test_support::CwdGuard;
+
+static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+fn key_with(code: KeyCode, mods: KeyModifiers) -> KeyEvent {
+    KeyEvent::new(code, mods)
+}
+
+#[test]
+fn files_tab_focused_preview_scrolls_preview_vertically() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "x\n".repeat(200)).unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    assert_eq!(app.active_tab, Tab::Files);
+    app.enter_focused_preview();
+    assert_eq!(app.view_mode, ViewMode::FocusedPreview);
+
+    let before = app.preview_scroll;
+    input::handle_key(key(KeyCode::Down), &mut app);
+    assert_eq!(
+        app.preview_scroll,
+        before + 1,
+        "↓ in Files focused preview should pan preview_scroll"
+    );
+    input::handle_key(key(KeyCode::Down), &mut app);
+    input::handle_key(key(KeyCode::Down), &mut app);
+    assert_eq!(app.preview_scroll, before + 3);
+    input::handle_key(key(KeyCode::Up), &mut app);
+    assert_eq!(app.preview_scroll, before + 2);
+
+    // PageDown step is +20 in handle_key_files.
+    input::handle_key(key(KeyCode::PageDown), &mut app);
+    assert_eq!(app.preview_scroll, before + 22);
+}
+
+#[test]
+fn files_tab_focused_preview_scrolls_preview_horizontally() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "wide".repeat(200)).unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.enter_focused_preview();
+
+    let before = app.preview_h_scroll;
+    input::handle_key(key(KeyCode::Right), &mut app);
+    assert_eq!(
+        app.preview_h_scroll,
+        before + 1,
+        "→ should pan preview_h_scroll horizontally"
+    );
+    input::handle_key(key_with(KeyCode::Right, KeyModifiers::SHIFT), &mut app);
+    // Shift+→ steps by 10 in handle_key_files.
+    assert_eq!(app.preview_h_scroll, before + 11);
+    input::handle_key(key(KeyCode::Left), &mut app);
+    assert_eq!(app.preview_h_scroll, before + 10);
+}
+
+#[test]
+fn git_tab_focused_preview_scrolls_diff_vertically_and_horizontally() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+    app.enter_focused_preview();
+    assert_eq!(app.view_mode, ViewMode::FocusedPreview);
+
+    let vert_before = app.diff_scroll;
+    input::handle_key(key(KeyCode::Down), &mut app);
+    assert_eq!(app.diff_scroll, vert_before + 1);
+    input::handle_key(key(KeyCode::PageDown), &mut app);
+    // PageDown step in handle_key_git is +20.
+    assert_eq!(app.diff_scroll, vert_before + 21);
+    input::handle_key(key(KeyCode::Up), &mut app);
+    assert_eq!(app.diff_scroll, vert_before + 20);
+
+    let h_before = app.diff_h_scroll;
+    input::handle_key(key(KeyCode::Right), &mut app);
+    assert_eq!(app.diff_h_scroll, h_before + 1);
+    input::handle_key(key_with(KeyCode::Right, KeyModifiers::SHIFT), &mut app);
+    assert_eq!(app.diff_h_scroll, h_before + 11);
+    input::handle_key(key(KeyCode::Home), &mut app);
+    assert_eq!(app.diff_h_scroll, 0);
+}
+
+fn wheel(col: u16, row: u16, kind: MouseEventKind) -> MouseEvent {
+    MouseEvent {
+        kind,
+        column: col,
+        row,
+        modifiers: KeyModifiers::NONE,
+    }
+}
+
+#[test]
+fn git_focused_preview_wheel_in_left_columns_scrolls_diff_not_hidden_sidebar() {
+    // Regression: dispatch_vertical_scroll routes wheel events by
+    // `column < graph_sidebar_width`. In 纯预览 the sidebar isn't
+    // rendered, so a wheel in cols 0..30 (which would normally hit the
+    // git status panel) must still scroll the diff that fills the
+    // whole frame instead. The bug looked like "scrolling doesn't work"
+    // because the wheel was silently moving an invisible status row
+    // cursor.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+    app.enter_focused_preview();
+
+    let backend = TestBackend::new(100, 24);
+    let terminal = Terminal::new(backend).unwrap();
+
+    let before = app.diff_scroll;
+    // Column 5 sits well inside what would have been the sidebar.
+    input::handle_mouse(wheel(5, 10, MouseEventKind::ScrollDown), &mut app, &terminal);
+    assert!(
+        app.diff_scroll > before,
+        "wheel in former-sidebar columns must scroll diff in 纯预览"
+    );
+    let after_down = app.diff_scroll;
+    input::handle_mouse(wheel(5, 10, MouseEventKind::ScrollUp), &mut app, &terminal);
+    assert!(app.diff_scroll < after_down);
+}
+
+#[test]
+fn files_focused_preview_wheel_scrolls_preview_at_any_column() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "x\n".repeat(200)).unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.enter_focused_preview();
+
+    let backend = TestBackend::new(100, 24);
+    let terminal = Terminal::new(backend).unwrap();
+
+    // Same column the (now-hidden) file tree would have lived in.
+    let before = app.preview_scroll;
+    input::handle_mouse(wheel(3, 8, MouseEventKind::ScrollDown), &mut app, &terminal);
+    assert!(app.preview_scroll > before);
+}
+
+#[test]
+fn focused_preview_horizontal_wheel_routes_to_preview_or_diff() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("wide.txt"), "x".repeat(5000)).unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.enter_focused_preview();
+
+    let backend = TestBackend::new(100, 24);
+    let terminal = Terminal::new(backend).unwrap();
+
+    let before = app.preview_h_scroll;
+    input::handle_mouse(wheel(2, 5, MouseEventKind::ScrollRight), &mut app, &terminal);
+    assert!(
+        app.preview_h_scroll > before,
+        "horizontal wheel must move preview_h_scroll even in former-sidebar columns"
+    );
+
+    // Switch to Git tab + focused preview and confirm horizontal routes
+    // to diff_h_scroll instead.
+    app.close_focused_preview();
+    app.set_active_tab(Tab::Git);
+    app.enter_focused_preview();
+    let dh_before = app.diff_h_scroll;
+    input::handle_mouse(wheel(4, 6, MouseEventKind::ScrollRight), &mut app, &terminal);
+    assert!(app.diff_h_scroll > dh_before);
+}
+
+/// The wash must reach the path's *last* cell — diff_panel pads its
+/// inner area by 1 column on the left, so a naïve `width = path_w`
+/// stops one column short of where the filename actually ends.
+/// Regression for: "highlight covers `/ui/mod.r` but not the trailing
+/// `s`".
+#[test]
+fn hover_wash_reaches_last_char_of_filename() {
+    use reef::ui;
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = test_support::tempdir_repo();
+    // 10-char filename so we can pin the "last cell" cleanly.
+    let name = "abcdefghij";
+    std::fs::write(tmp.path().join(name), "hi\n").unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+    app.unstaged_files.push(reef::git::FileEntry {
+        path: name.to_string(),
+        status: reef::git::FileStatus::Modified,
+        additions: 0,
+        deletions: 0,
+    });
+    app.diff_content = Some(reef::app::HighlightedDiff {
+        diff: reef::git::DiffContent {
+            file_path: name.to_string(),
+            hunks: Vec::new(),
+        },
+        highlighted: None,
+    });
+    app.enter_focused_preview();
+    // Drive picker-open so the wash uses the accent (easier to spot than
+    // hover_bg) and we're sure the path is up.
+    app.focused_preview_files_open = true;
+
+    let backend = TestBackend::new(100, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(|f| ui::render(f, &mut app)).unwrap();
+
+    // diff_panel pads left by 1, so path is at cols 1..=10. The wash
+    // must cover col 10 (the trailing 'j') and stop at col 11 (the
+    // first space of the tag tail).
+    let accent = Theme::dark().accent;
+    let last_path_bg = terminal.backend().buffer()[(10, 0)].bg;
+    let first_tag_bg = terminal.backend().buffer()[(11, 0)].bg;
+    assert_eq!(
+        last_path_bg, accent,
+        "wash must reach the path's last cell (col 10 = trailing 'j')"
+    );
+    assert_ne!(
+        first_tag_bg, accent,
+        "wash must stop before the tag tail (col 11)"
+    );
+}
+
+/// Hover on the chip+file-path span should wash that span only. The
+/// right-hand tag (`[unified][compact] m/f toggle`) stays unwashed —
+/// it's chrome, not part of the picker affordance.
+#[test]
+fn hovering_file_path_washes_chip_and_path_only() {
+    use ratatui::style::Color;
+    use reef::ui;
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = test_support::tempdir_repo();
+    let long_name = "long_filename_for_hover_test.txt"; // 32 cols
+    std::fs::write(tmp.path().join(long_name), "hi\n").unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+    app.unstaged_files.push(reef::git::FileEntry {
+        path: long_name.to_string(),
+        status: reef::git::FileStatus::Modified,
+        additions: 0,
+        deletions: 0,
+    });
+    // Seed diff_content so `focused_preview_interactive_width` can read
+    // the path (matches what diff_panel draws in the header).
+    app.diff_content = Some(reef::app::HighlightedDiff {
+        diff: reef::git::DiffContent {
+            file_path: long_name.to_string(),
+            hunks: Vec::new(),
+        },
+        highlighted: None,
+    });
+    app.enter_focused_preview();
+
+    let backend = TestBackend::new(100, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    // Baseline: no hover position.
+    terminal.draw(|f| ui::render(f, &mut app)).unwrap();
+    let baseline_in_path = terminal.backend().buffer()[(15, 0)].bg;
+    let baseline_in_tag = terminal.backend().buffer()[(90, 0)].bg;
+
+    // Hover sitting on col=15 — well inside the long filename text.
+    app.hover_row = Some(0);
+    app.hover_col = Some(15);
+    terminal.draw(|f| ui::render(f, &mut app)).unwrap();
+
+    let path_bg = terminal.backend().buffer()[(15, 0)].bg;
+    let tag_bg = terminal.backend().buffer()[(90, 0)].bg;
+    let hover_bg = Theme::dark().hover_bg;
+
+    assert_eq!(
+        path_bg, hover_bg,
+        "hover should wash cells inside the path (col 15)"
+    );
+    assert_ne!(
+        baseline_in_path, hover_bg,
+        "baseline at col 15 must differ from hovered state"
+    );
+    assert_eq!(
+        tag_bg, baseline_in_tag,
+        "cells inside the tag tail (col 90) must NOT pick up the hover wash"
+    );
+
+    // Chip cells share the same span so they should also wash.
+    let chip_bg = terminal.backend().buffer()[(1, 0)].bg;
+    assert_ne!(chip_bg, Color::Reset);
+}
+
+/// Clicking inside the file-path span toggles the picker.
+#[test]
+fn clicking_inside_file_path_toggles_picker() {
+    use reef::ui;
+    use reef::ui::mouse::ClickAction;
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = test_support::tempdir_repo();
+    let long_name = "long_filename_for_click_test.txt";
+    std::fs::write(tmp.path().join(long_name), "hi\n").unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+    app.unstaged_files.push(reef::git::FileEntry {
+        path: long_name.to_string(),
+        status: reef::git::FileStatus::Modified,
+        additions: 0,
+        deletions: 0,
+    });
+    app.diff_content = Some(reef::app::HighlightedDiff {
+        diff: reef::git::DiffContent {
+            file_path: long_name.to_string(),
+            hunks: Vec::new(),
+        },
+        highlighted: None,
+    });
+    app.enter_focused_preview();
+
+    let backend = TestBackend::new(100, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(|f| ui::render(f, &mut app)).unwrap();
+
+    // Col 15 sits inside the filename text.
+    let action = app.hit_registry.hit_test(15, 0);
+    assert!(
+        matches!(action, Some(ClickAction::ToggleFocusedPreviewFiles)),
+        "file-path cell should toggle picker; got {action:?}"
+    );
+
+    let click = MouseEvent {
+        kind: MouseEventKind::Down(MouseButton::Left),
+        column: 15,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    };
+    input::handle_mouse(click, &mut app, &terminal);
+    assert!(app.focused_preview_files_open);
+}
+
+/// Clicking on the tag tail (`[unified][compact] m/f toggle`) does
+/// NOT toggle the picker — the highlight + click zone are deliberately
+/// scoped to chip + path. Regression test for the "framed area only"
+/// scoping requested after the initial full-row implementation.
+#[test]
+fn clicking_tag_tail_does_not_toggle_picker() {
+    use reef::ui;
+    use reef::ui::mouse::ClickAction;
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = test_support::tempdir_repo();
+    std::fs::write(tmp.path().join("a.txt"), "hi\n").unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+    app.unstaged_files.push(reef::git::FileEntry {
+        path: "a.txt".to_string(),
+        status: reef::git::FileStatus::Modified,
+        additions: 0,
+        deletions: 0,
+    });
+    app.diff_content = Some(reef::app::HighlightedDiff {
+        diff: reef::git::DiffContent {
+            file_path: "a.txt".to_string(),
+            hunks: Vec::new(),
+        },
+        highlighted: None,
+    });
+    app.enter_focused_preview();
+
+    let backend = TestBackend::new(100, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(|f| ui::render(f, &mut app)).unwrap();
+
+    // Col 80 is past "a.txt" (which is 5 chars), well inside the tag tail.
+    // hit_test must NOT return ToggleFocusedPreviewFiles there.
+    let action = app.hit_registry.hit_test(80, 0);
+    assert!(
+        !matches!(action, Some(ClickAction::ToggleFocusedPreviewFiles)),
+        "tag-tail cells must not be claimed by the picker chip; got {action:?}"
+    );
+}
+
+/// Click on the ☰ chip in the upper-left of a Git-tab focused preview
+/// must reach `ToggleFocusedPreviewFiles` — not get hijacked by the
+/// diff-panel drag-select fast path. Regression for the original
+/// implementation where `handle_diff_selection` saw the chip's column
+/// inside `last_diff_rect` and ate the click.
+#[test]
+fn chip_click_in_git_focused_preview_toggles_picker_not_diff_drag() {
+    use reef::ui;
+    use reef::ui::mouse::ClickAction;
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // Chip is only painted when `backend.has_repo()` is true, so we
+    // need a real git repo here — a bare tempdir won't trigger it.
+    let (tmp, _repo) = test_support::tempdir_repo();
+    std::fs::write(tmp.path().join("a.txt"), "hi\n").unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+    // Fake an unstaged entry so the picker can open.
+    app.unstaged_files.push(reef::git::FileEntry {
+        path: "a.txt".to_string(),
+        status: reef::git::FileStatus::Modified,
+        additions: 0,
+        deletions: 0,
+    });
+    app.enter_focused_preview();
+
+    // Render once so the chip's hit zone (and last_diff_rect) lands in
+    // the registry.
+    let backend = TestBackend::new(100, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(|f| ui::render(f, &mut app)).unwrap();
+
+    // Chip sits at body.y row 0, columns 0-2 (" ☰ "). Click the glyph
+    // cell — column 1 is the cell most likely to be inside last_diff_rect
+    // (diff_panel pads by 1 column, so col 0 is outside but col 1 is in).
+    let click = MouseEvent {
+        kind: MouseEventKind::Down(MouseButton::Left),
+        column: 1,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    };
+    // Sanity: the registered hit zone really is the chip action, so a
+    // failure of `handle_mouse` to fire it points at routing not rendering.
+    let action = app.hit_registry.hit_test(1, 0);
+    assert!(
+        matches!(action, Some(ClickAction::ToggleFocusedPreviewFiles)),
+        "chip hit zone missing at (1,0); got {action:?}"
+    );
+
+    assert!(!app.focused_preview_files_open);
+    let entries = app.focused_preview_file_entries();
+    assert!(
+        !entries.is_empty(),
+        "test fixture must provide at least one changed file or open_focused_preview_files no-ops"
+    );
+
+    input::handle_mouse(click, &mut app, &terminal);
+    assert!(
+        app.focused_preview_files_open,
+        "click on chip must open the picker — not start a diff drag"
+    );
+}
+
+/// Graph 3-col happy path: entering focused preview on Graph,
+/// opening the picker, and picking a row must load that file's diff
+/// via `load_commit_file_diff` — i.e. the `GraphCommit` source maps
+/// to the right backend call.
+#[test]
+fn graph_focused_preview_picks_commit_file_via_picker() {
+    use reef::ui;
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = test_support::tempdir_repo();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Graph);
+    // Stub commit_detail.detail with two changed files so
+    // `focused_preview_file_entries` returns a non-empty list.
+    app.commit_detail.detail = Some(reef::git::CommitDetail {
+        info: reef::git::CommitInfo {
+            oid: "deadbeef".to_string(),
+            short_oid: "dead".to_string(),
+            parents: Vec::new(),
+            author_name: "Tester".to_string(),
+            author_email: "t@example.com".to_string(),
+            time: 0,
+            subject: "test".to_string(),
+        },
+        message: "test".to_string(),
+        committer_name: "Tester".to_string(),
+        committer_time: 0,
+        files: vec![
+            reef::git::FileEntry {
+                path: "src/app.rs".to_string(),
+                status: reef::git::FileStatus::Modified,
+                additions: 0,
+                deletions: 0,
+            },
+            reef::git::FileEntry {
+                path: "src/input.rs".to_string(),
+                status: reef::git::FileStatus::Modified,
+                additions: 0,
+                deletions: 0,
+            },
+        ],
+    });
+    app.enter_focused_preview();
+
+    let backend = TestBackend::new(120, 30);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(|f| ui::render(f, &mut app)).unwrap();
+
+    let entries = app.focused_preview_file_entries();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].path, "src/app.rs");
+    assert_eq!(entries[0].source, reef::app::FocusedPreviewFileSource::GraphCommit);
+
+    // Open picker + pick row 1 (src/input.rs).
+    app.open_focused_preview_files();
+    app.pick_focused_preview_file(1);
+    // Without a real backend / git repo content, the load is fire-and-
+    // forget; what we *can* assert is that the picker closed and the
+    // selection cursor moved to the picked index.
+    assert!(!app.focused_preview_files_open);
+    assert_eq!(app.focused_preview_files_selected, 1);
+}
+
+/// Enter inside the picker confirms — for Git tab, this means
+/// `select_file` runs and `selected_file.path` matches the row.
+#[test]
+fn picker_enter_confirm_switches_diff_target() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = test_support::tempdir_repo();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+    app.unstaged_files = vec![
+        reef::git::FileEntry {
+            path: "a.txt".to_string(),
+            status: reef::git::FileStatus::Modified,
+            additions: 0,
+            deletions: 0,
+        },
+        reef::git::FileEntry {
+            path: "b.txt".to_string(),
+            status: reef::git::FileStatus::Modified,
+            additions: 0,
+            deletions: 0,
+        },
+    ];
+    app.enter_focused_preview();
+    app.open_focused_preview_files();
+
+    // Picker open, cursor at index 0 (a.txt — sort is lexical). Press
+    // ↓ then Enter — should select b.txt and close the picker.
+    input::handle_key(key(KeyCode::Down), &mut app);
+    assert_eq!(app.focused_preview_files_selected, 1);
+    input::handle_key(key(KeyCode::Enter), &mut app);
+
+    assert!(!app.focused_preview_files_open);
+    let sel = app.selected_file.as_ref().expect("Enter should set selected_file");
+    assert_eq!(sel.path, "b.txt");
+    assert!(!sel.is_staged, "row came from unstaged_files");
+}
+
+/// Selection wraps around at the boundary — pressing ↑ on row 0
+/// lands on the last row (and ↓ from last lands on 0). Vim-friendly
+/// + matches what `rem_euclid` was supposed to do.
+#[test]
+fn picker_selection_wraps_at_boundaries() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = test_support::tempdir_repo();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+    app.unstaged_files = (0..3)
+        .map(|i| reef::git::FileEntry {
+            path: format!("f{i}.txt"),
+            status: reef::git::FileStatus::Modified,
+            additions: 0,
+            deletions: 0,
+        })
+        .collect();
+    app.enter_focused_preview();
+    app.open_focused_preview_files();
+    assert_eq!(app.focused_preview_files_selected, 0);
+
+    // Up from 0 → wraps to last (2).
+    input::handle_key(key(KeyCode::Up), &mut app);
+    assert_eq!(app.focused_preview_files_selected, 2);
+
+    // Down from last → wraps to 0.
+    input::handle_key(key(KeyCode::Down), &mut app);
+    assert_eq!(app.focused_preview_files_selected, 0);
+}
+
+/// Graph 2-col layout deliberately doesn't show the chip — the
+/// commit_detail_panel renders a different header (commit metadata
+/// + inline file tree) where the chip's path-width math doesn't
+/// apply. Regression guard so this stays intentional.
+#[test]
+fn graph_two_col_does_not_register_chip_hit_zone() {
+    use reef::ui;
+    use reef::ui::mouse::ClickAction;
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = test_support::tempdir_repo();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Graph);
+    app.enter_focused_preview();
+
+    // GRAPH_THREE_COL_MIN_WIDTH is 120 in the source; render at 80 so
+    // graph_uses_three_col() returns false → 2-col layout, no chip.
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(|f| ui::render(f, &mut app)).unwrap();
+
+    let action = app.hit_registry.hit_test(1, 0);
+    assert!(
+        !matches!(action, Some(ClickAction::ToggleFocusedPreviewFiles)),
+        "Graph 2-col must not register chip hit zone; got {action:?}"
+    );
+}
+
+/// Regression for Fix #1: bare 'd' in Git tab FocusedPreview must NOT
+/// trigger discard-changes against the (invisible) selected file.
+/// Previously the gate `_ => false` let destructive keys fall through
+/// to handle_key_git's unguarded chord arms.
+#[test]
+fn focused_preview_swallows_destructive_keys_on_git_tab() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = test_support::tempdir_repo();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+    app.unstaged_files.push(reef::git::FileEntry {
+        path: "a.txt".to_string(),
+        status: reef::git::FileStatus::Modified,
+        additions: 0,
+        deletions: 0,
+    });
+    // Pretend the user has a.txt selected — the discard chord would
+    // target it if we let `d` fall through.
+    app.selected_file = Some(reef::app::SelectedFile {
+        path: "a.txt".to_string(),
+        is_staged: false,
+    });
+    app.enter_focused_preview();
+
+    // No confirm modal should be up to begin with.
+    assert!(app.confirm_modal.is_none());
+
+    // Bare 'd' on Git tab outside FocusedPreview opens the discard
+    // confirmation. Inside FocusedPreview it must be swallowed.
+    input::handle_key(key(KeyCode::Char('d')), &mut app);
+    assert!(
+        app.confirm_modal.is_none(),
+        "bare 'd' in FocusedPreview must not open the discard prompt"
+    );
+    assert!(
+        app.git_status.confirm_discard.is_none(),
+        "bare 'd' must not arm the discard-changes chord either"
+    );
+
+    // 's' (stage) and 'u' (unstage) likewise.
+    let unstaged_before = app.unstaged_files.len();
+    let staged_before = app.staged_files.len();
+    input::handle_key(key(KeyCode::Char('s')), &mut app);
+    input::handle_key(key(KeyCode::Char('u')), &mut app);
+    assert_eq!(app.unstaged_files.len(), unstaged_before);
+    assert_eq!(app.staged_files.len(), staged_before);
+}
+
+/// Regression for Fix #5: when the same path is in both staged and
+/// unstaged, opening the picker while viewing the UNSTAGED diff must
+/// snap to the unstaged row, not silently pick the staged duplicate.
+#[test]
+fn picker_snaps_to_unstaged_when_viewing_unstaged_diff_of_dup_path() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = test_support::tempdir_repo();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+    // Same path in both lists (committed + further edited).
+    app.staged_files.push(reef::git::FileEntry {
+        path: "a.txt".to_string(),
+        status: reef::git::FileStatus::Modified,
+        additions: 0,
+        deletions: 0,
+    });
+    app.unstaged_files.push(reef::git::FileEntry {
+        path: "a.txt".to_string(),
+        status: reef::git::FileStatus::Modified,
+        additions: 0,
+        deletions: 0,
+    });
+    // Currently viewing the UNSTAGED diff of a.txt.
+    app.selected_file = Some(reef::app::SelectedFile {
+        path: "a.txt".to_string(),
+        is_staged: false,
+    });
+    app.enter_focused_preview();
+    app.open_focused_preview_files();
+
+    let entries = app.focused_preview_file_entries();
+    assert_eq!(entries.len(), 2);
+    let selected = &entries[app.focused_preview_files_selected];
+    assert_eq!(selected.path, "a.txt");
+    assert_eq!(
+        selected.source,
+        reef::app::FocusedPreviewFileSource::GitUnstaged,
+        "picker must snap to the unstaged duplicate when viewing unstaged diff"
+    );
+}
+
+/// Regression for Fix #6: pressing Space then `v` while quick_open is
+/// open with an empty query must NOT close the palette. (Before the
+/// fix, leader_decision Fired on `v` and quick_open closed.)
+#[test]
+fn quick_open_keeps_v_keystroke_after_leader() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = test_support::tempdir_repo();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    reef::quick_open::begin(&mut app);
+    assert!(app.quick_open.active);
+    assert!(app.quick_open.query.is_empty());
+
+    // Space arms the leader (allowed because query is empty).
+    input::handle_key(key(KeyCode::Char(' ')), &mut app);
+    assert!(app.quick_open.space_leader_at.is_some());
+
+    // 'v' is now a chord target — must NOT close the palette. The
+    // leader is cleared and `v` falls through to the char-append arm.
+    input::handle_key(key(KeyCode::Char('v')), &mut app);
+    assert!(
+        app.quick_open.active,
+        "Space+V must not close quick_open — it's not the palette's own chord"
+    );
+    assert!(app.quick_open.space_leader_at.is_none());
+    assert_eq!(
+        app.quick_open.query, "v",
+        "the 'v' keystroke should land in the query buffer"
+    );
+
+    // Sanity: Space+P (the actual quick_open chord) DOES close.
+    input::handle_key(key(KeyCode::Char(' ')), &mut app);
+    input::handle_key(key(KeyCode::Char('p')), &mut app);
+    // After Space+P the palette closes — but only when query is empty
+    // again, which it isn't (we typed 'v'). With 'v' in query, the
+    // leader isn't armed by Space, so Space appends to query.
+    // Reset for a clean P-toggle check:
+    app.quick_open.query.clear();
+    app.quick_open.cursor = 0;
+    input::handle_key(key(KeyCode::Char(' ')), &mut app);
+    input::handle_key(key(KeyCode::Char('p')), &mut app);
+    assert!(
+        !app.quick_open.active,
+        "Space+P with empty query should close quick_open"
+    );
+}
+
+/// Regression for Fix #3: pressing `o` on Graph 2-col (terminal width
+/// below GRAPH_THREE_COL_MIN_WIDTH) must not open a picker that the
+/// renderer refuses to draw.
+#[test]
+fn graph_two_col_o_keypress_does_not_open_invisible_picker() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = test_support::tempdir_repo();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Graph);
+    // Set last_total_width below the 3-col threshold so
+    // graph_uses_three_col() returns false.
+    app.last_total_width = 80;
+    app.enter_focused_preview();
+
+    assert!(!app.focused_preview_chip_visible());
+    assert!(!app.focused_preview_files_open);
+    input::handle_key(key(KeyCode::Char('o')), &mut app);
+    assert!(
+        !app.focused_preview_files_open,
+        "'o' on Graph 2-col must not open the picker (which wouldn't render)"
+    );
+}
+
+#[test]
+fn picker_open_swallows_scroll_keys_so_diff_stays_put() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+    app.enter_focused_preview();
+
+    // Picker open with at least one row so it gets armed; the row list
+    // comes from staged+unstaged, which is empty in this fixture, so
+    // simulate it being open via the explicit setter.
+    app.focused_preview_files_open = true;
+
+    let before = app.diff_scroll;
+    input::handle_key(key(KeyCode::Down), &mut app);
+    assert_eq!(
+        app.diff_scroll, before,
+        "diff should not scroll while picker has the keyboard"
+    );
+
+    // Esc closes picker without exiting focused preview.
+    input::handle_key(key(KeyCode::Esc), &mut app);
+    assert!(!app.focused_preview_files_open);
+    assert_eq!(app.view_mode, ViewMode::FocusedPreview);
+}


### PR DESCRIPTION
## Summary

- **新的 "纯预览" / FocusedPreview 模式**：`Space+V` toggle 把当前 tab 的 diff/preview 面板拉到全屏；`reef <file>` CLI 直接以文件父级 repo 根为 workdir 进入此模式。
- **左上角 ☰ chip + 文件 picker 弹窗**（Git tab + Graph 3-col）：hover wash 与点击区域覆盖整行 chip + 文件路径；popup 无边框纯色，按 path/staged 双键定位光标，键盘 ↑↓ / Enter / Esc 完整可用，`o` 在预览态内开关 picker。
- **作用域正确性修复一并合入**：scroll 路由重写（单列布局下鼠标滚轮不再落到被隐藏的 sidebar）、按键允许列表（破坏性键不会因 fallthrough 在不可见的 tree row 上触发）、`Ctrl+,` / `Ctrl+O` / `h` 等与 takeover 的协同、`reef <file>` 用 `git2::Repository::discover` 找 repo 根、`refresh_file_tree_with_target` 修 CLI quick-look 与异步 tree 任务的竞态、overlay leader chord 不再吞 `v`/`h` 字符。

## Test plan

- [ ] `cargo build --bin reef` 干净
- [ ] `cargo test --tests`（除已知 fs_watcher_integration flake）全过；focused_preview_scroll 套件 20/20
- [ ] 手动：在 git 仓库内 `reef src/main.rs` 应进入文件预览，Esc 后 tree 显示整个 repo（不是 src/ 子集）
- [ ] 手动：Git tab `Space+V` → diff 全屏，左上角 ☰；点击 chip / 文件路径整行打开 picker；同名 staged + unstaged 时光标自动停在当前 diff 对应的那行
- [ ] 手动：Graph tab 2-col 下按 `o` 不应弹任何东西（避免隐形 picker）
- [ ] 手动：quick-open 内按 Space 然后 `v` 字符应进入 query，而不是关闭面板

## Scope

详见 commit message。主要触及：

- 新文件：`src/ui/focused_preview_panel.rs`、`tests/focused_preview_scroll.rs`
- 修改：`src/app.rs`（ViewMode + 状态 + 方法）、`src/input.rs`（FocusedPreview key gate + scroll 路由 + mouse intercept）、`src/main.rs`（CLI `<file>` 分支 + ResolvedPath enum + 帮助豁免）、`src/i18n.rs`（5 条新文案）、`src/ui/mod.rs`（dispatch + help 行）、`src/ui/mouse.rs`（3 个 ClickAction 变体）、`src/quick_open.rs` / `src/find_widget.rs` / `src/global_search.rs`（leader Fire 只在自己 chord 时 close）