### PR TITLE
feat(ui): vim gg/G + visible search prompt in focused preview; drop Ctrl+F

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -856,6 +856,12 @@ pub struct App {
     /// can't interfere across mode transitions.
     pub space_leader_at: Option<std::time::Instant>,
 
+    /// Timestamp of the last bare `g` keystroke. `Some(t)` means a vim-style
+    /// `gg` chord is primed and waiting for the second `g` within 500ms; on
+    /// the second hit we scroll the active preview to the top. Suppressed in
+    /// search / overlay / SQLite-preview contexts — see `handle_key`.
+    pub g_pending_at: Option<std::time::Instant>,
+
     /// Last-rendered content height (in rows) for each right-side panel.
     /// Search jumps read these to center the match in view. Written by the
     /// panel's render fn every frame; defaults to 0 until the first render.
@@ -1158,6 +1164,7 @@ impl App {
             tree_drag: crate::tree_drag::TreeDragState::default(),
             paste_conflict: None,
             space_leader_at: None,
+            g_pending_at: None,
             last_preview_view_h: 0,
             last_diff_view_h: 0,
             last_commit_detail_view_h: 0,
@@ -2778,6 +2785,14 @@ impl App {
     fn dispatch_preview_load(&mut self, rel_path: PathBuf) {
         let generation = self.preview_load.begin();
         self.preview_in_flight_path = Some(rel_path.clone());
+        // A new preview is incoming — drop any in-flight `gg` chord so a
+        // bare `g` that lands while `preview_content` still holds the
+        // *previous* body can't be misinterpreted. Specifically: when
+        // the new body is a .db, `is_sqlite_preview()` (which reads the
+        // old preview_content) returns false during the load window, so
+        // the chord arms instead of opening db_goto. Clearing here makes
+        // the very next `g` after a navigation always re-arm cleanly.
+        self.g_pending_at = None;
         // Skip the image decode when we can't render pixels anyway —
         // the worker will return a metadata-only `ImagePreview` with
         // dims + format + size, and the render path shows the
@@ -4256,6 +4271,12 @@ impl App {
             _ => Panel::Diff,
         };
         self.view_mode = ViewMode::FocusedPreview;
+        // Chord state is scoped to a view mode in users' mental model —
+        // entering 纯预览 with `gg` half-pressed and resuming it on a
+        // different panel would feel like a glitch. Clear on the
+        // boundary.
+        self.g_pending_at = None;
+        self.space_leader_at = None;
     }
 
     /// CLI entry point — `reef <file>` lands here after the workdir
@@ -4307,6 +4328,11 @@ impl App {
             return;
         }
         self.view_mode = ViewMode::Main;
+        // Mirror `enter_focused_preview`: clear chord state on the
+        // view-mode boundary so a `gg` half-press doesn't carry from
+        // Main into FocusedPreview or vice versa.
+        self.g_pending_at = None;
+        self.space_leader_at = None;
         // Defensive: clear picker state so a future view_mode escape
         // path (toast-driven, fatal-error overlay, etc.) that bypasses
         // close_focused_preview_files can't leave the bool stuck `true`
@@ -4504,6 +4530,15 @@ impl App {
         }
         let was_files = self.active_tab == Tab::Files;
         self.active_tab = tab;
+        // Drop any in-flight chord state. Without this, "press `g` →
+        // mouse-click another tab within 500 ms → press `g`" would fire
+        // `scroll_active_preview_to_top` against the *new* tab, which
+        // can resync diff scroll / commit selection unexpectedly.
+        // Symmetric `space_leader_at` reset for the same reason: a
+        // primed leader that crosses a tab boundary no longer maps to
+        // the chord targets the user intended.
+        self.g_pending_at = None;
+        self.space_leader_at = None;
         // Leaving the Files tab cancels any Files-tab-scoped modal —
         // tree edit row, context menu, delete confirm. Those modals
         // are invisible on other tabs, so leaving them armed would
@@ -4919,6 +4954,135 @@ impl App {
         self.diff_h_scroll = 0;
         self.sbs_left_h_scroll = 0;
         self.sbs_right_h_scroll = 0;
+    }
+
+    /// Vim `gg` — jump the active content panel to its top. List panels
+    /// (file tree, git status, commit graph) move their selection to the
+    /// first row; content panels (Diff/Commit) reset the vertical scroll.
+    /// SQLite preview is a no-op so the bare `g` keystroke can still open
+    /// the goto-page input.
+    ///
+    /// **Side effects on list panels** — list-mode `gg` is not a pure
+    /// cursor move:
+    /// - Git Files: `navigate_files` also resets `diff_scroll` /
+    ///   `diff_h_scroll` / `sbs_left/right_h_scroll` and triggers a
+    ///   deferred `load_diff()` for the new selection, so the right
+    ///   pane reloads to file #1's diff.
+    /// - Graph Files: `move_graph_selection` clears any visual range
+    ///   (when no anchor is set; when an anchor exists we delegate to
+    ///   `extend_graph_selection` and preserve the range — matching
+    ///   vim's behaviour) and triggers `load_commit_detail()` for the
+    ///   new selection.
+    pub fn scroll_active_preview_to_top(&mut self) {
+        if self.is_sqlite_preview() {
+            return;
+        }
+        // Symmetric sentinel for the two directions. `i32::MIN` would
+        // overflow in the `(-delta) as usize` paths inside
+        // `file_tree::navigate` / `navigate_files` / `move_graph_selection`
+        // (debug-build panic); pick a value that's far larger than any
+        // realistic entry count but safe to negate.
+        const NAV_FAR: i32 = 1_000_000;
+        match (self.active_tab, self.active_panel) {
+            (Tab::Files, Panel::Files) => {
+                if !self.file_tree.entries.is_empty() {
+                    self.file_tree.navigate(-NAV_FAR);
+                }
+            }
+            (Tab::Files, Panel::Diff) | (Tab::Search, Panel::Diff) => {
+                self.preview_scroll = 0;
+            }
+            (Tab::Search, Panel::Files) => {
+                // Search-tab left column owns its own list cursor via the
+                // global_search overlay — leave it alone here.
+            }
+            (Tab::Git, Panel::Files) => {
+                self.navigate_files(-NAV_FAR);
+            }
+            (Tab::Git, Panel::Diff) => {
+                self.diff_scroll = 0;
+            }
+            (Tab::Graph, Panel::Files) => {
+                // Preserve any Shift-extended visual range: vim's `gg`
+                // in visual mode extends the selection to the top, so
+                // delegate to `extend_graph_selection` (which keeps
+                // `selection_anchor` intact). Without this, the chord
+                // would call `move_graph_selection` and silently
+                // collapse the range to a single commit.
+                if self.git_graph.selection_anchor.is_some() {
+                    self.extend_graph_selection(-NAV_FAR);
+                } else {
+                    self.move_graph_selection(-NAV_FAR);
+                }
+            }
+            (Tab::Graph, Panel::Commit) => {
+                self.commit_detail.scroll = 0;
+            }
+            (Tab::Graph, Panel::Diff) => {
+                self.commit_detail.file_diff_scroll = 0;
+            }
+            _ => {}
+        }
+    }
+
+    /// Vim `G` — jump the active content panel to its bottom. List panels
+    /// move selection to the last row; content panels set the scroll to
+    /// `usize::MAX` and rely on the render-layer clamp
+    /// (file_preview_panel / diff_panel / commit_detail_panel all clamp
+    /// against `lines.len() - viewport`).
+    pub fn scroll_active_preview_to_bottom(&mut self) {
+        if self.is_sqlite_preview() {
+            return;
+        }
+        const NAV_FAR: i32 = 1_000_000;
+        match (self.active_tab, self.active_panel) {
+            (Tab::Files, Panel::Files) => {
+                if !self.file_tree.entries.is_empty() {
+                    self.file_tree.navigate(NAV_FAR);
+                }
+            }
+            (Tab::Files, Panel::Diff) | (Tab::Search, Panel::Diff) => {
+                self.preview_scroll = usize::MAX;
+            }
+            (Tab::Search, Panel::Files) => {}
+            (Tab::Git, Panel::Files) => {
+                self.navigate_files(NAV_FAR);
+            }
+            (Tab::Git, Panel::Diff) => {
+                self.diff_scroll = usize::MAX;
+            }
+            (Tab::Graph, Panel::Files) => {
+                // Mirror scroll_active_preview_to_top: keep visual-range
+                // anchors so `G` extends rather than collapses.
+                if self.git_graph.selection_anchor.is_some() {
+                    self.extend_graph_selection(NAV_FAR);
+                } else {
+                    self.move_graph_selection(NAV_FAR);
+                }
+            }
+            (Tab::Graph, Panel::Commit) => {
+                self.commit_detail.scroll = usize::MAX;
+            }
+            (Tab::Graph, Panel::Diff) => {
+                self.commit_detail.file_diff_scroll = usize::MAX;
+            }
+            _ => {}
+        }
+    }
+
+    /// True when the active content panel is rendering a SQLite database
+    /// preview *in a tab whose handler actually wires bare `g` to the
+    /// goto-page input*. Only `Tab::Files` qualifies — `handle_key_search`
+    /// has no `g` → `db_goto_input` branch, so suppressing `gg` there
+    /// would silence both the chord and the per-tab fallback, leaving
+    /// bare `g` as a no-op against a .db preview opened from Search.
+    pub fn is_sqlite_preview(&self) -> bool {
+        self.active_panel == Panel::Diff
+            && self.active_tab == Tab::Files
+            && self
+                .preview_content
+                .as_ref()
+                .is_some_and(|p| p.is_database())
     }
 
     /// Called every frame: drain fs-watcher events and the push worker's

--- a/src/find_widget.rs
+++ b/src/find_widget.rs
@@ -103,6 +103,24 @@ impl FindWidgetState {
 /// No-op when the active panel has no in-panel find target (e.g. focus
 /// is on the Search tab's left list).
 pub fn begin_with_selection(app: &mut App) {
+    use crate::app::{Panel, Tab};
+    // VSCode-style "find in this file" — if focus is currently on a
+    // list panel (file tree, git status, commit graph) that has no
+    // searchable preview target, force-focus onto the content column
+    // so Space+F lands on the diff/preview the user sees, mirroring
+    // the behaviour the removed Ctrl+F binding used to give.
+    // Without this, pressing Space+F at app startup (default focus is
+    // `Panel::Files`) silently no-ops because resolve_target returns
+    // None for `(Files, Files)` / `(Git, Files)` etc.
+    //
+    // Exception: `(Tab::Search, Panel::Files)` is the search input
+    // row, not a list — pulling focus away from it would lose the
+    // user's half-typed query. Leave it alone; the user can Tab into
+    // the preview panel themselves if they want find-in-file there.
+    let on_search_input = app.active_tab == Tab::Search && app.active_panel == Panel::Files;
+    if !on_search_input && resolve_target(app).is_none() && app.active_panel != Panel::Diff {
+        app.active_panel = Panel::Diff;
+    }
     let Some(target) = resolve_target(app) else {
         return;
     };

--- a/src/input.rs
+++ b/src/input.rs
@@ -106,6 +106,12 @@ pub fn leader_decision(
         if allow_arm && is_bare_space {
             return LeaderVerdict::Arm;
         }
+        // Stale or non-target → Consume clears the leader at the call
+        // site, so a single keystroke after timeout resets state cleanly.
+        // The destructive-key risk this used to carry in FocusedPreview
+        // (Space + idle + stray `d` → discard) is now bounded by the
+        // bypass's own timeout check at `handle_key_focused_preview`'s
+        // entry — see comment there.
         return LeaderVerdict::Consume;
     }
 
@@ -348,6 +354,63 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         LeaderVerdict::None => {}
     }
 
+    // vim `gg` / `G` — jump the active preview to top / bottom. Sits
+    // between the Space-leader chord and the global keymap so the chord
+    // works in both Main and FocusedPreview without each per-tab handler
+    // having to reimplement it. Suppressed in:
+    //
+    // - input modes (search query / commit message / db-goto-page input);
+    // - any modal overlay (find widget / global / quick / hosts pickers,
+    //   tree edit, search-tab replace mode);
+    // - SQLite preview, so bare `g` keeps its goto-page meaning down in
+    //   `handle_key_files`.
+    //
+    // `g` arms the chord; a second `g` within 500 ms fires `to_top` and
+    // anything else cancels. `G` is a single-shot `to_bottom` that also
+    // clears any pending `g` so an unrelated stutter doesn't strand state.
+    let gg_suppressed = in_input_mode
+        || app.search.active
+        || app.find_widget.active
+        || app.global_search.active
+        || app.quick_open.active
+        || app.hosts_picker.active
+        || app.tree_edit.active
+        || app.db_goto_input.is_some()
+        || app.is_sqlite_preview();
+    if !gg_suppressed {
+        // Use `contains` + a Ctrl/Alt veto rather than strict equality on
+        // `modifiers`, so terminals that surface extra modifier bits
+        // alongside Shift (kitty enhanced keyboard, some IME paths) still
+        // deliver `G` correctly. Matches the convention in the rest of
+        // this file (`if !ctrl` guards on per-tab handlers).
+        let no_ctrl_alt = !key.modifiers.contains(KeyModifiers::CONTROL)
+            && !key.modifiers.contains(KeyModifiers::ALT);
+        let is_bare_g = key.code == KeyCode::Char('g')
+            && no_ctrl_alt
+            && !key.modifiers.contains(KeyModifiers::SHIFT);
+        let is_shift_g = key.code == KeyCode::Char('G') && no_ctrl_alt;
+        if is_shift_g {
+            app.g_pending_at = None;
+            app.scroll_active_preview_to_bottom();
+            return;
+        }
+        if is_bare_g {
+            let now = Instant::now();
+            if let Some(t0) = app.g_pending_at.take() {
+                if now.duration_since(t0) < Duration::from_millis(500) {
+                    app.scroll_active_preview_to_top();
+                    return;
+                }
+            }
+            app.g_pending_at = Some(now);
+            return;
+        }
+        if app.g_pending_at.is_some() {
+            // Any other keystroke breaks the chord — back to normal dispatch.
+            app.g_pending_at = None;
+        }
+    }
+
     // Always-available global keys — even when the user is typing in a
     // search input, these need to remain usable as the escape hatch.
     // `Ctrl+C` quits, `Tab` / `BackTab` move between tabs and panels so the
@@ -383,22 +446,6 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         // message / search query isn't stolen by the chord.
         KeyCode::Char(',') if key.modifiers.contains(KeyModifiers::CONTROL) && !in_input_mode => {
             app.open_settings();
-            return;
-        }
-        // Ctrl+F: VSCode-style find-in-file. Forces focus onto the
-        // preview so `search::begin`'s `resolve_target` picks
-        // `SearchTarget::FilePreview` regardless of where focus was.
-        // Suppressed in text-input modes so it doesn't yank the user
-        // out of a half-typed commit message or global-search query.
-        KeyCode::Char('f')
-            if key.modifiers.contains(KeyModifiers::CONTROL)
-                && !in_input_mode
-                && matches!(app.active_tab, Tab::Files | Tab::Search) =>
-        {
-            if app.active_panel != Panel::Diff {
-                app.active_panel = Panel::Diff;
-            }
-            search::begin(app, false);
             return;
         }
         // Ctrl+Tab: best-effort "next tab" alias. Many legacy terminals
@@ -674,6 +721,27 @@ fn handle_key_focused_preview(key: KeyEvent, app: &mut App) -> bool {
         }
     }
 
+    // When a Space leader is armed AND still within the chord window,
+    // the *next* key must reach `leader_decision` so chord targets
+    // (Space+F = FindWidget, Space+V = exit FocusedPreview, etc.) can
+    // fire. The whitelist below would otherwise swallow most chord
+    // targets — `p`/`P` for QuickOpen aren't in it at all — and a
+    // typo'd chord would silently stay armed past the timeout.
+    //
+    // The timeout check is load-bearing: without it, a stray Space
+    // (e.g. the user tapped Space and walked away) would leave
+    // `space_leader_at = Some(stale_t)` indefinitely, and every
+    // subsequent key — including destructive `s`/`u`/`d` on Git —
+    // would bypass the whitelist and reach per-tab dispatch against
+    // the invisible status row. With the check, the bypass is bounded
+    // to LEADER_TIMEOUT (800 ms) starting from the Space press.
+    if app
+        .space_leader_at
+        .is_some_and(|t| Instant::now().duration_since(t) < LEADER_TIMEOUT)
+    {
+        return false;
+    }
+
     // Explicit handling for FocusedPreview-specific actions.
     match key.code {
         KeyCode::Esc => {
@@ -751,7 +819,9 @@ fn handle_key_focused_preview(key: KeyEvent, app: &mut App) -> bool {
                 | KeyCode::Home
                 | KeyCode::End
                 | KeyCode::Char(
-                    'j' | 'k'      // vim vertical
+                    ' '            // Space-leader arm — chord targets fire
+                                   // via the leader-armed bypass above.
+                    | 'j' | 'k'    // vim vertical
                     | 'h'          // help popup (FocusedPreview is in the
                                    // takeover list now, so the next key
                                    // reaches us, not "dismiss help")
@@ -759,7 +829,9 @@ fn handle_key_focused_preview(key: KeyEvent, app: &mut App) -> bool {
                     | 'n' | 'N'    // search step
                     | 'm' | 'f'    // diff layout / diff mode toggles
                     | '[' | ']'    // SQLite preview: prev/next table
-                    | 'g' | 'G', // SQLite preview: goto-page; vim top/bottom
+                    | 'g' | 'G', // vim top/bottom + SQLite goto-page; the
+                                 // chord runs in `handle_key`'s main body,
+                                 // SQLite goto is per-tab in handle_key_files.
                 )
         );
     // Ctrl-prefixed nav aliases that the per-tab handlers honor and
@@ -770,7 +842,6 @@ fn handle_key_focused_preview(key: KeyEvent, app: &mut App) -> bool {
             KeyCode::Char(
                 'p' | 'n'      // readline up/down
                 | 'j' | 'k'    // vim-style with ctrl
-                | 'f'          // VSCode-style find widget
                 | 'b' // sidebar toggle (no-op visually in
                       // FocusedPreview but harmless)
             )
@@ -1354,13 +1425,16 @@ fn handle_key_graph(key: KeyEvent, app: &mut App) {
             app.refresh_graph();
         }
         // m/f/t target the commit-detail panel regardless of focus.
-        KeyCode::Char('m') => {
+        // `!ctrl` guards so Ctrl+F/M/T (e.g. VSCode muscle-memory Ctrl+F
+        // for find) don't silently flip diff layout/mode — the global
+        // Ctrl+F binding was removed in favour of Space+F.
+        KeyCode::Char('m') if !ctrl => {
             commit_detail_panel::handle_key(app, "m");
         }
-        KeyCode::Char('f') => {
+        KeyCode::Char('f') if !ctrl => {
             commit_detail_panel::handle_key(app, "f");
         }
-        KeyCode::Char('t') => {
+        KeyCode::Char('t') if !ctrl => {
             commit_detail_panel::handle_key(app, "t");
         }
         _ => {}
@@ -1606,10 +1680,13 @@ fn handle_key_git(key: KeyEvent, app: &mut App) {
         KeyCode::Char('t') => {
             ui::git_status_panel::handle_key(app, "t");
         }
-        KeyCode::Char('m') => {
+        // `!ctrl` guard on `m`/`f` so Ctrl+F (VSCode muscle memory)
+        // doesn't silently flip diff layout/mode now that the global
+        // Ctrl+F binding has been removed in favour of Space+F.
+        KeyCode::Char('m') if !ctrl => {
             app.toggle_diff_layout();
         }
-        KeyCode::Char('f') => {
+        KeyCode::Char('f') if !ctrl => {
             app.toggle_diff_mode();
         }
         KeyCode::Char('e') | KeyCode::Enter => {
@@ -4230,9 +4307,14 @@ mod leader_tests {
     }
 
     #[test]
-    fn ctrl_f_does_not_fire_even_when_armed() {
-        // Keep Ctrl+F free for future panel-level search bindings; only bare
-        // `f` is the chord target.
+    fn ctrl_f_is_not_a_chord_target() {
+        // Only bare `f` / `F` is the FindWidget chord target — Ctrl+F has no
+        // global binding (Find is reached exclusively via Space+F), so when
+        // the leader is armed pressing Ctrl+F just consumes the leader.
+        // NOTE: this test only covers `leader_decision`'s view. The
+        // integration-level guarantee that "Ctrl+F doesn't toggle diff
+        // mode / layout in Git/Graph tabs" is asserted by the
+        // `ctrl_f_in_main_mode_*` tests in tests/focused_preview_scroll.rs.
         let now = Instant::now();
         let ctrl_f = ke(KeyCode::Char('f'), KeyModifiers::CONTROL);
         let v = leader_decision(&ctrl_f, true, Some(now), now, LEADER_TIMEOUT);

--- a/src/ui/focused_preview_panel.rs
+++ b/src/ui/focused_preview_panel.rs
@@ -18,7 +18,7 @@ use crate::app::{App, Tab};
 use crate::i18n::{Msg, t};
 use crate::ui::mouse::ClickAction;
 use crate::ui::text::truncate_to_width;
-use crate::ui::{diff_panel, file_preview_panel, hover};
+use crate::ui::{diff_panel, file_preview_panel, find_widget_panel, hover};
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
@@ -80,7 +80,26 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
         render_chip(f, app, body);
     }
 
-    render_hint(f, app, hint_row);
+    // FocusedPreview takes over `ui::render` and returns early before the
+    // normal `find_widget_panel::render` call, so the Space+F overlay
+    // would never appear here without this hop. Draw after the body
+    // renderers (which write `last_preview_rect` / `last_diff_rect`)
+    // so the widget can anchor itself to the visible content column.
+    // Skips itself when `find_widget.active == false`.
+    find_widget_panel::render(f, app);
+
+    // FocusedPreview replaces the normal status bar entirely, so the search
+    // prompt would never render here without this branch — `/` would silently
+    // capture keystrokes against an invisible input. Mirror the same
+    // priority order `render_status_bar` uses (active prompt → dormant
+    // counter → hint) so the bottom row stays meaningful in every state.
+    if app.search.active {
+        super::render_search_prompt(f, app, hint_row);
+    } else if !app.search.matches.is_empty() {
+        super::render_search_dormant(f, app, hint_row);
+    } else {
+        render_hint(f, app, hint_row);
+    }
 }
 
 fn render_chip(f: &mut Frame, app: &mut App, body: Rect) {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -736,7 +736,7 @@ fn panel_chip_text(tab: crate::app::Tab, panel: crate::app::Panel) -> &'static s
     }
 }
 
-fn render_search_prompt(f: &mut Frame, app: &App, area: Rect) {
+pub(crate) fn render_search_prompt(f: &mut Frame, app: &App, area: Rect) {
     let th = app.theme;
     let prefix = if app.search.backwards { '?' } else { '/' };
     let query = app.search.query.as_str();
@@ -794,7 +794,7 @@ fn render_search_prompt(f: &mut Frame, app: &App, area: Rect) {
     f.set_cursor_position((cursor_x, area.y));
 }
 
-fn render_search_dormant(f: &mut Frame, app: &App, area: Rect) {
+pub(crate) fn render_search_dormant(f: &mut Frame, app: &App, area: Rect) {
     let th = app.theme;
     let prefix = if app.search.backwards { '?' } else { '/' };
     let counter = match app.search.current {

--- a/tests/focused_preview_scroll.rs
+++ b/tests/focused_preview_scroll.rs
@@ -850,3 +850,361 @@ fn picker_open_swallows_scroll_keys_so_diff_stays_put() {
     assert!(!app.focused_preview_files_open);
     assert_eq!(app.view_mode, ViewMode::FocusedPreview);
 }
+
+// ─── `/` 底部输入框 / Ctrl+F noop / Space+F / vim gg-G ──────────────────
+
+#[test]
+fn focused_preview_slash_renders_prompt_at_bottom() {
+    // Regression target: pressing `/` in FocusedPreview used to flip
+    // `search.active=true` but the prompt row was never painted because
+    // FocusedPreview replaces the normal status bar. focused_preview_panel
+    // now mirrors render_status_bar's priority for the bottom row.
+    use reef::ui;
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "abc\ndef\nghi\n").unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.enter_focused_preview();
+
+    input::handle_key(key(KeyCode::Char('/')), &mut app);
+    assert!(app.search.active, "`/` must arm vim search");
+
+    let backend = TestBackend::new(40, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(|f| ui::render(f, &mut app)).unwrap();
+    // hint_row is the last row (y = height - 1).
+    let bottom_first = terminal.backend().buffer()[(0, 9)].symbol().to_string();
+    assert_eq!(
+        bottom_first, "/",
+        "FocusedPreview bottom row should show the search prompt `/`"
+    );
+}
+
+#[test]
+fn focused_preview_ctrl_f_is_noop() {
+    // Ctrl+F was removed in favour of Space+F (FindWidget). Pressing it
+    // in FocusedPreview must not arm vim search and must not open the
+    // find widget — it's a fully unbound key now.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "abc\n").unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.enter_focused_preview();
+    let view_before = app.view_mode;
+
+    input::handle_key(
+        key_with(KeyCode::Char('f'), KeyModifiers::CONTROL),
+        &mut app,
+    );
+    assert!(!app.search.active, "Ctrl+F must not arm vim search");
+    assert!(
+        !app.find_widget.active,
+        "Ctrl+F must not open the FindWidget"
+    );
+    assert_eq!(app.view_mode, view_before, "view_mode must be unchanged");
+}
+
+#[test]
+fn focused_preview_space_f_opens_find_widget() {
+    // Space+F is the only path into the FindWidget overlay. Make sure it
+    // still works from FocusedPreview — the Space-leader gate runs after
+    // handle_key_focused_preview's fallthrough.
+    use reef::ui;
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "abc\n".repeat(40)).unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.enter_focused_preview();
+
+    // Drive a frame so the preview body publishes `last_preview_rect`;
+    // without that the find widget anchors to None and silently no-op
+    // renders, which would defeat the visibility check below.
+    let backend = TestBackend::new(100, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(|f| ui::render(f, &mut app)).unwrap();
+
+    input::handle_key(key(KeyCode::Char(' ')), &mut app);
+    assert!(
+        app.space_leader_at.is_some(),
+        "Space must arm the leader chord"
+    );
+    input::handle_key(key(KeyCode::Char('f')), &mut app);
+    assert!(
+        app.find_widget.active,
+        "Space+F must open the FindWidget overlay"
+    );
+
+    // Render again and assert the widget actually painted itself.
+    // Without focused_preview_panel calling find_widget_panel::render,
+    // `last_widget_rect` stays `None` even though `find_widget.active`
+    // is true — the overlay would be invisible to the user.
+    terminal.draw(|f| ui::render(f, &mut app)).unwrap();
+    assert!(
+        app.find_widget.last_widget_rect.is_some(),
+        "FindWidget overlay must paint a rect in FocusedPreview, not just \
+         flip the active flag"
+    );
+}
+
+#[test]
+fn gg_scrolls_files_focused_preview_to_top() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "x\n".repeat(200)).unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.enter_focused_preview();
+    app.preview_scroll = 80;
+
+    input::handle_key(key(KeyCode::Char('g')), &mut app);
+    assert!(app.g_pending_at.is_some(), "first `g` arms the chord");
+    assert_eq!(app.preview_scroll, 80, "first `g` must not move yet");
+
+    input::handle_key(key(KeyCode::Char('g')), &mut app);
+    assert_eq!(app.preview_scroll, 0, "second `g` jumps to top");
+    assert!(
+        app.g_pending_at.is_none(),
+        "fired chord clears the pending slot"
+    );
+}
+
+#[test]
+fn gg_scrolls_git_diff_focused_preview_to_top() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+    app.enter_focused_preview();
+    app.diff_scroll = 42;
+
+    input::handle_key(key(KeyCode::Char('g')), &mut app);
+    input::handle_key(key(KeyCode::Char('g')), &mut app);
+    assert_eq!(app.diff_scroll, 0);
+}
+
+#[test]
+fn capital_g_scrolls_files_focused_preview_to_bottom() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "x\n".repeat(200)).unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.enter_focused_preview();
+    app.preview_scroll = 5;
+
+    input::handle_key(key_with(KeyCode::Char('G'), KeyModifiers::SHIFT), &mut app);
+    assert_eq!(
+        app.preview_scroll,
+        usize::MAX,
+        "G sets preview_scroll to the saturation sentinel; render clamps"
+    );
+}
+
+#[test]
+fn gg_timeout_does_not_trigger() {
+    use std::time::{Duration, Instant};
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "x\n".repeat(200)).unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.enter_focused_preview();
+    app.preview_scroll = 50;
+
+    input::handle_key(key(KeyCode::Char('g')), &mut app);
+    // Backdate the pending arm past the 500ms window.
+    app.g_pending_at = Some(Instant::now() - Duration::from_millis(800));
+    input::handle_key(key(KeyCode::Char('g')), &mut app);
+    assert_eq!(
+        app.preview_scroll, 50,
+        "stale `g` must not fire scroll-to-top"
+    );
+    assert!(
+        app.g_pending_at.is_some(),
+        "expired chord re-arms instead of firing"
+    );
+}
+
+#[test]
+fn gg_suppressed_inside_slash_search() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "x\n".repeat(200)).unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.enter_focused_preview();
+    app.preview_scroll = 25;
+
+    input::handle_key(key(KeyCode::Char('/')), &mut app);
+    assert!(app.search.active);
+    input::handle_key(key(KeyCode::Char('g')), &mut app);
+    input::handle_key(key(KeyCode::Char('g')), &mut app);
+    assert_eq!(
+        app.preview_scroll, 25,
+        "while `/` owns input, `gg` must feed the query instead of scrolling"
+    );
+    assert_eq!(
+        app.search.query, "gg",
+        "the two `g` keystrokes should land in the search buffer"
+    );
+}
+
+// ─── Ctrl+F regression guard for Main mode ──────────────────────────────
+
+#[test]
+fn ctrl_f_in_main_mode_git_tab_does_not_toggle_diff_mode() {
+    // Removing the global Ctrl+F binding could leak the keystroke into
+    // `handle_key_git`'s bare-`f` arm (which toggles diff_mode). Guard
+    // against that regression by sending Ctrl+F in Main mode + Tab::Git
+    // and asserting nothing observable changes.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = test_support::tempdir_repo();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+
+    let layout_before = app.diff_layout;
+    let mode_before = app.diff_mode;
+    input::handle_key(
+        key_with(KeyCode::Char('f'), KeyModifiers::CONTROL),
+        &mut app,
+    );
+    assert_eq!(
+        app.diff_layout, layout_before,
+        "Ctrl+F must not call toggle_diff_layout in Git tab"
+    );
+    assert_eq!(
+        app.diff_mode, mode_before,
+        "Ctrl+F must not call toggle_diff_mode in Git tab"
+    );
+    assert!(!app.search.active);
+    assert!(!app.find_widget.active);
+}
+
+#[test]
+fn ctrl_f_in_main_mode_graph_tab_does_not_reach_commit_detail() {
+    // Same guard for the Graph tab's bare-`f` arm at handle_key_graph's
+    // commit_detail dispatch. The commit_detail diff_mode is the
+    // observable side effect.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = test_support::tempdir_repo();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Graph);
+
+    let cd_mode_before = app.commit_detail.diff_mode;
+    let cd_layout_before = app.commit_detail.diff_layout;
+    input::handle_key(
+        key_with(KeyCode::Char('f'), KeyModifiers::CONTROL),
+        &mut app,
+    );
+    assert_eq!(
+        app.commit_detail.diff_mode, cd_mode_before,
+        "Ctrl+F must not flip commit_detail diff_mode in Graph tab"
+    );
+    assert_eq!(
+        app.commit_detail.diff_layout, cd_layout_before,
+        "Ctrl+F must not flip commit_detail diff_layout in Graph tab"
+    );
+}
+
+#[test]
+fn space_f_force_focuses_diff_panel_from_file_tree() {
+    // Regression for the Ctrl+F deletion: the removed global arm used
+    // to set `active_panel = Diff` before calling search::begin, so
+    // pressing find from the file tree would always land on the diff.
+    // The replacement (Space+F → find_widget) needs the same force-
+    // focus, otherwise Space+F is a silent no-op when focus is on the
+    // file tree (the default state).
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "abc\n").unwrap();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    assert_eq!(app.active_panel, reef::app::Panel::Files);
+
+    input::handle_key(key(KeyCode::Char(' ')), &mut app);
+    input::handle_key(key(KeyCode::Char('f')), &mut app);
+
+    assert!(
+        app.find_widget.active,
+        "Space+F must open the FindWidget even with file-tree focus"
+    );
+    assert_eq!(
+        app.active_panel,
+        reef::app::Panel::Diff,
+        "Space+F must force-focus the Diff panel before opening"
+    );
+}
+
+// ─── Stale-leader / chord-state hygiene ─────────────────────────────────
+
+#[test]
+fn stale_space_leader_does_not_bypass_focused_preview_whitelist() {
+    // The FocusedPreview leader-armed bypass must check LEADER_TIMEOUT,
+    // otherwise a Space pressed minutes ago would keep the bypass on
+    // forever and let destructive Git keys (`d` for discard, etc.)
+    // reach per-tab dispatch against an invisible status row.
+    use std::time::Duration as StdDuration;
+    use std::time::Instant as StdInstant;
+
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = test_support::tempdir_repo();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.set_active_tab(Tab::Git);
+    app.enter_focused_preview();
+
+    // Stale leader from "minutes ago".
+    app.space_leader_at = Some(StdInstant::now() - StdDuration::from_secs(60));
+
+    // `d` is destructive in handle_key_git (calls git_status_panel `d`
+    // → discard). It's NOT in the FocusedPreview whitelist, so with the
+    // bypass's timeout check correctly recognising the leader as stale,
+    // the whitelist swallows the keystroke as if no leader were armed.
+    let layout_before = app.diff_layout;
+    let mode_before = app.diff_mode;
+    let stage_count_before = (app.staged_files.len(), app.unstaged_files.len());
+    input::handle_key(key(KeyCode::Char('d')), &mut app);
+    assert_eq!(app.diff_layout, layout_before);
+    assert_eq!(app.diff_mode, mode_before);
+    assert_eq!(
+        (app.staged_files.len(), app.unstaged_files.len()),
+        stage_count_before,
+        "stale leader must not let `d` reach git_status_panel discard"
+    );
+}
+
+#[test]
+fn g_pending_clears_on_tab_switch() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = test_support::tempdir_repo();
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    input::handle_key(key(KeyCode::Char('g')), &mut app);
+    assert!(app.g_pending_at.is_some());
+
+    app.set_active_tab(Tab::Git);
+    assert!(
+        app.g_pending_at.is_none(),
+        "set_active_tab must drop in-flight chord state so a stray `g` \
+         after a mouse-driven tab switch doesn't surprise-scroll the new tab"
+    );
+}


### PR DESCRIPTION
## Summary

Three related fixes for 纯预览模式 (FocusedPreview) input plumbing, plus a vim chord and a cross-cutting Ctrl+F → Space+F migration.

- **`/` search now shows a bottom prompt in 纯预览**. Previously `search.active=true` flipped on keypress but the prompt row was never painted because FocusedPreview replaces the normal status bar — typing `/foo` was invisible. `focused_preview_panel::render` now mirrors `render_status_bar`'s priority (active prompt → dormant n/N counter → hint).
- **New vim `gg` / `G` chord** scrolls the active preview to top / bottom. Works in both Main and FocusedPreview. List panels (file tree, git status, commit graph) move selection; content panels reset scroll. Visual ranges in Graph are preserved via `extend_graph_selection` when an anchor is set. SQLite preview is suppressed so bare `g` keeps its goto-page meaning.
- **Ctrl+F removed; Space+F is now the sole find-in-file entry point**. Per-tab `f` handlers in Git/Graph get `!ctrl` guards so VSCode muscle memory doesn't accidentally flip diff mode/layout. `find_widget::begin_with_selection` force-focuses the Diff panel when called from a list panel (file tree, git status, etc.) so Space+F at startup actually opens the widget instead of silently no-op'ing.
- **`find_widget_panel::render` now runs in FocusedPreview too** — previously the overlay was suppressed because `ui::render` returns early at the FocusedPreview branch before reaching the widget renderer. So Space+F in 纯预览 was setting `active=true` but never painting.

## User-visible behavior changes

| Before | After |
|---|---|
| Ctrl+F (Files/Search tab) → `/` mode | Ctrl+F → no-op everywhere |
| Ctrl+F (Git tab) → no-op | Ctrl+F → no-op (used to leak into `toggle_diff_mode` post-cleanup — guarded) |
| Space+F from file tree → silent no-op | Space+F → force-focus Diff + open FindWidget |
| FocusedPreview `/` → invisible input | FocusedPreview `/` → visible prompt at bottom |
| `gg` / `G` → unhandled | `gg` / `G` → scroll/select to top/bottom |
| Space+V exit from FocusedPreview | Same (was blocked by whitelist before, now works because Space arms the leader inside FocusedPreview too) |

## Defensive fixes shipped alongside

- Stale `space_leader_at` (Space pressed minutes ago) used to keep the FocusedPreview leader-armed bypass open indefinitely — could let destructive Git keys (`d` discard) reach per-tab dispatch. Bypass now checks `LEADER_TIMEOUT`.
- `g_pending_at` and `space_leader_at` are cleared on `set_active_tab` / `enter_focused_preview` / `close_focused_preview` / `dispatch_preview_load` so a `g` held across a tab/view switch doesn't fire against the wrong context.
- `is_sqlite_preview()` narrowed to `Tab::Files` (`handle_key_search` has no `g` → goto-page wiring, so suppressing the chord there left bare `g` as a no-op for no gain).
- `gg`/`G` modifier check uses `contains` + Ctrl/Alt veto rather than strict equality, matching the convention elsewhere in `input.rs`.

## Test plan

- [x] `cargo test --test focused_preview_scroll` — 33/33 (12 new: bottom prompt visible, Ctrl+F no-op in Main Git/Graph, Space+F force-focuses + paints widget rect, `gg`/`G` × 3 tabs, timeout, search-suppress, tab-switch chord clear, stale-leader doesn't bypass whitelist)
- [x] `cargo test` lib — 579/579
- [x] `cargo clippy --all-targets` — clean
- [x] Manual: in 纯预览 Git tab, `/` shows bottom prompt, `n`/`N` step matches, `gg`/`G` scroll diff, Space+F opens floating widget in upper-right of diff column
- [x] Manual: Main mode Tab::Files + file-tree focus, Space+F → widget opens (was silent no-op before)
- [x] Manual: Main mode Tab::Git, Ctrl+F → nothing happens (no diff_mode flip)

`tests/fs_watcher_integration` fails on this branch *and* clean main — pre-existing flake, unrelated.