### PR TITLE
feat(graph): single-branch graph scope + unify all text inputs / pickers

### DIFF
--- a/crates/reef-agent/src/main.rs
+++ b/crates/reef-agent/src/main.rs
@@ -290,7 +290,9 @@ fn dispatch(backend: &dyn Backend, workdir: &Path, env: Envelope) -> Option<Resp
             Err(e) => Err(backend_err(e)),
         },
 
-        Request::ListCommits { limit } => match backend.list_commits(limit as usize) {
+        Request::ListCommits { limit, scope } => match backend
+            .list_commits(&graph_scope_from_dto(scope), limit as usize)
+        {
             Ok(list) => {
                 let dtos: Vec<CommitInfoDto> = list.into_iter().map(commit_info_to_dto).collect();
                 serde_json::to_value(dtos)
@@ -766,6 +768,13 @@ fn ref_label_to_dto(r: reef::git::RefLabel) -> RefLabelDto {
         RefLabel::Branch(s) => RefLabelDto::Branch(s),
         RefLabel::RemoteBranch(s) => RefLabelDto::RemoteBranch(s),
         RefLabel::Tag(s) => RefLabelDto::Tag(s),
+    }
+}
+
+fn graph_scope_from_dto(scope: reef_proto::GraphScopeDto) -> reef::git::GraphScope {
+    match scope {
+        reef_proto::GraphScopeDto::AllRefs => reef::git::GraphScope::AllRefs,
+        reef_proto::GraphScopeDto::Branch(s) => reef::git::GraphScope::Branch(s),
     }
 }
 

--- a/crates/reef-agent/tests/protocol.rs
+++ b/crates/reef-agent/tests/protocol.rs
@@ -229,13 +229,12 @@ fn list_commits_returns_history() {
     commit_file(&raw, "a.txt", "v2", "second");
 
     let mut agent = Agent::spawn(tmp.path());
-    let commits: Vec<CommitInfoDto> = serde_json::from_value(ok_result(agent.request(
-        Request::ListCommits {
+    let commits: Vec<CommitInfoDto> =
+        serde_json::from_value(ok_result(agent.request(Request::ListCommits {
             limit: 10,
             scope: Default::default(),
-        },
-    )))
-    .unwrap();
+        })))
+        .unwrap();
     assert_eq!(commits.len(), 2);
     assert_eq!(commits[0].subject, "second");
     assert_eq!(commits[1].subject, "first");

--- a/crates/reef-agent/tests/protocol.rs
+++ b/crates/reef-agent/tests/protocol.rs
@@ -229,9 +229,13 @@ fn list_commits_returns_history() {
     commit_file(&raw, "a.txt", "v2", "second");
 
     let mut agent = Agent::spawn(tmp.path());
-    let commits: Vec<CommitInfoDto> =
-        serde_json::from_value(ok_result(agent.request(Request::ListCommits { limit: 10 })))
-            .unwrap();
+    let commits: Vec<CommitInfoDto> = serde_json::from_value(ok_result(agent.request(
+        Request::ListCommits {
+            limit: 10,
+            scope: Default::default(),
+        },
+    )))
+    .unwrap();
     assert_eq!(commits.len(), 2);
     assert_eq!(commits[0].subject, "second");
     assert_eq!(commits[1].subject, "first");

--- a/crates/reef-proto/src/lib.rs
+++ b/crates/reef-proto/src/lib.rs
@@ -78,7 +78,16 @@ pub const MAX_FRAME_SIZE: u32 = 16 * 1024 * 1024;
 ///       `protocol_version < 9` (or on `Unimplemented`) and wraps the
 ///       single-schema result back into the V2 shape so the renderer
 ///       stays unified.
-pub const PROTOCOL_VERSION: u32 = 9;
+/// - v10: `ListCommits` gains a required `scope` field so the Graph
+///       tab can restrict its walk to a single branch ref. The field
+///       is intentionally NOT `#[serde(default)]`: a v9 agent
+///       receiving a v10 request will reject it with "missing field
+///       `scope`" (and vice versa), surfacing the version drift as
+///       an explicit RPC error instead of silently degrading to
+///       AllRefs-only on whichever side ignored the field. The
+///       install path is expected to redeploy the agent on version
+///       mismatch so this case should be transient.
+pub const PROTOCOL_VERSION: u32 = 10;
 
 /// Encode a single envelope-level value to `writer` using the
 /// length-prefixed framing. The caller is expected to flush.
@@ -224,6 +233,17 @@ pub enum Request {
     // ── Git: history ────
     ListCommits {
         limit: u64,
+        /// Walk scope. Required on the wire: a v9 agent decoding a v10
+        /// request will fail loudly ("missing field `scope`") rather
+        /// than silently dropping the field and walking every ref,
+        /// which would mask the version drift entirely.
+        ///
+        /// Going the other way — a v9 client hitting a v10 agent —
+        /// also fails decoding, which is fine: the install path is
+        /// expected to redeploy the agent on version mismatch, so
+        /// mixed-version pairings shouldn't exist in steady state
+        /// and getting an explicit error beats silent misbehaviour.
+        scope: GraphScopeDto,
     },
     ListRefs,
     HeadOid,
@@ -692,6 +712,17 @@ pub enum RefLabelDto {
 
 /// Convenience alias — the ref map is keyed by OID (hex).
 pub type RefMapDto = HashMap<String, Vec<RefLabelDto>>;
+
+/// Wire form of `GraphScope`. `AllRefs` is the default so a missing /
+/// older-protocol message decodes to the historical "all refs" walk.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "name", rename_all = "snake_case")]
+pub enum GraphScopeDto {
+    #[default]
+    AllRefs,
+    /// Fully-qualified ref, e.g. `refs/heads/main`.
+    Branch(String),
+}
 
 // ── M3 Track 1: write-op responses ─────────────────────────────────────────
 

--- a/skills/developing-reef/SKILL.md
+++ b/skills/developing-reef/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: developing-reef
-description: Architecture and coding conventions for changing Reef itself. Use before modifying Reef runtime architecture, `App` state, tabs/panels, rendering code, input dispatch, background work, git/file-tree/diff/graph loading, performance-sensitive paths, or when the user asks about "how Reef is structured", "render blocking", "heavy tasks", "new tab", "new feature architecture", or "project conventions". Pair with `testing-reef` whenever adding or changing tests.
+description: REQUIRED before any non-test code change in Reef. Load this skill before modifying Reef runtime architecture, `App` state, tabs/panels, rendering code, input dispatch (`src/input.rs`, any picker overlay, the commit textarea, any new text-input field), background work, git/file-tree/diff/graph loading, performance-sensitive paths, or when the user asks about "how Reef is structured", "render blocking", "heavy tasks", "new tab", "new feature architecture", "input handling", "text input", "picker", "PickerCore", "input_edit", or "project conventions". Do NOT start editing Reef source without loading this skill first — the architecture has non-obvious invariants (render-pure, async generation tokens, three-layer text-input stack) whose violation has been re-introduced and re-fixed across multiple PRs. Pair with `testing-reef` whenever adding or changing tests.
 ---
 
 # Developing Reef
@@ -32,8 +32,27 @@ Read `references/runtime-architecture.md` before changing `src/app.rs`, `src/tas
 - `src/tasks.rs` owns background worker definitions and should stay free of UI concerns.
 - `src/ui/**` owns rendering and local panel command dispatch; keep it pure except transient hit-test registration.
 - `src/input.rs` owns key/mouse routing; use `App::set_active_tab` instead of assigning `active_tab` directly.
+- `src/input_edit{,_multi}.rs` and `src/picker_core.rs` own the shared text-input vocabulary. Don't hand-roll a key table; embed one of the three layers (see "Text Input Stack" below).
 - `src/file_tree.rs` owns tree structure and preview data types; updating Git decorations must not rebuild the tree unless structure changed.
 - `src/git/**` owns direct git2 operations and pure graph algorithms. Open repositories inside workers with `GitRepo::open_at`.
+
+## Text Input Stack
+
+Every text input in Reef routes through one of three layers — L0
+`input_edit` (single-line readline/VSCode vocabulary), L1
+`input_edit_multi` (textarea: Enter→\n, line-aware Up/Down/Home/End),
+or L2 `picker_core::PickerCore` (overlay scaffold: filter + cursor +
+selected_idx + dispatch). 12+ input sites are already migrated; net
+~700 lines of duplicated key dispatch was removed.
+
+**Do NOT add a new text input without reading
+`references/text-input-stack.md` first.** It documents the canonical
+example for each layer plus seven mandatory invariants whose
+violation has been re-introduced and re-fixed across multiple
+review rounds (strict-bare-Enter, Ctrl+letter swallow in textareas,
+close-on-confirm-None, edit-derived work on `Edited`-only, UTF-8
+cursor boundary, exhaustive `InputOutcome` match, protocol bump
+discipline).
 
 ## Adding or Changing Features
 

--- a/skills/developing-reef/references/text-input-stack.md
+++ b/skills/developing-reef/references/text-input-stack.md
@@ -1,0 +1,217 @@
+# Reef Text-Input & Picker Stack
+
+Use this reference when touching `src/input.rs` text-input handlers, any
+picker overlay (`hosts_picker`, `quick_open`, `global_search`,
+`graph_branch_picker`), the commit textarea, the SQLite goto-page input,
+or any new TUI input field. Reef has a deliberate three-layer
+architecture; bypassing it re-introduces the bugs the unification was
+built to prevent.
+
+## The three layers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ L2  picker_core::PickerCore                                 │
+│     overlay scaffold: filter + cursor + selected_idx +      │
+│     last_popup_area + dispatch_key → InputOutcome           │
+│     consumers: 4 overlays (quick_open / global_search /     │
+│                 hosts_picker / graph_branch_picker)         │
+├─────────────────────────────────────────────────────────────┤
+│ L1  input_edit_multi::dispatch_key_multi                    │
+│     multi-line textarea: bare-Enter→\n, Up/Down across      │
+│     lines, line-aware Home/End, Char('\r') swallow          │
+│     consumer: 1 (commit-message textarea)                   │
+├─────────────────────────────────────────────────────────────┤
+│ L0  input_edit::dispatch_key{,_filtered} + free helpers     │
+│     single-line readline / VSCode vocabulary: Alt/Ctrl+←/→  │
+│     word-jump, Home/End, Ctrl+A/E, Alt+B/F/D word-jump/     │
+│     delete, Backspace + Alt/Ctrl/Ctrl+W word-back,          │
+│     Delete + Alt/Ctrl/Alt+D word-forward, Ctrl+U clear,     │
+│     plain char insert, UTF-8 boundary safe                  │
+│     consumers: every input handler in reef                  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+`tree_edit` / `db_goto` use `dispatch_key_filtered` (L0) with a
+content predicate (e.g. digit-only, or "reject `/` `\` NUL").
+
+`find_widget` / `search.rs` (vim `/`) / `settings` editor edit /
+search-tab find+replace inputs use bare `dispatch_key` (L0).
+
+## Why these layers exist
+
+Pre-unification each input had its own ~80-line key table calling the
+same `input_edit::*` helpers. Inconsistencies leaked in: hosts_picker
+had no cursor (only `push/pop`), some pickers handled Alt+B but not
+Alt+Backspace, the commit textarea silently dropped pastes, etc.
+Migration collapsed all 12 input sites into one of the three layers
+above; net diff was −700 lines of duplicated key dispatch.
+
+## Adding a new text input
+
+### Single-line, no list (e.g. inline rename, value prompt)
+
+Hold `(text: String, cursor: usize)` on a state struct. In the input
+handler:
+
+```rust
+// Phase 1: this-input-only shortcuts (Esc, Enter, etc.)
+match key.code {
+    KeyCode::Esc => { /* cancel */ return; }
+    KeyCode::Enter if !ctrl && !alt && !shift => {
+        /* commit on STRICT bare Enter — modifier-bearing Enter is
+           reserved so accidental Shift+Enter doesn't commit a
+           half-typed value. See R9/R10 in past reviews. */
+        return;
+    }
+    _ => {}
+}
+
+// Phase 2: shared editor vocabulary
+let _ = crate::input_edit::dispatch_key(&key, &mut state.text, &mut state.cursor);
+```
+
+If the buffer has a content predicate (digits only, file-name chars
+only, etc.), swap `dispatch_key` → `dispatch_key_filtered` with the
+predicate. Rejected chars return `Outcome::Rejected` (distinct from
+`CursorOnly` so callers using `Edited`-driven recompute hooks don't
+fire on a reject).
+
+### Single-line picker overlay (filter + list)
+
+Embed `picker_core::PickerCore` and write `visible_rows()` /
+`confirm()`:
+
+```rust
+pub struct MyPickerState {
+    pub core: crate::picker_core::PickerCore,
+    pub all_rows: Vec<MyRow>,
+    // … domain-specific fields …
+}
+
+impl MyPickerState {
+    pub fn open(&mut self, all_rows: Vec<MyRow>) {
+        self.all_rows = all_rows;
+        self.core.open();
+    }
+    pub fn close(&mut self) { self.core.close(); }
+    pub fn visible_rows(&self) -> Vec<MyRow> { /* filter against core.filter */ }
+    pub fn confirm(&self) -> Option<MyAction> {
+        self.visible_rows().get(self.core.selected_idx).map(/* … */)
+    }
+}
+```
+
+Handler:
+
+```rust
+fn handle_key_my_picker(key: KeyEvent, app: &mut App) {
+    use crate::picker_core::InputOutcome;
+    // Bespoke shortcuts FIRST (leader chord, mode toggle, etc.)
+    // Then delegate:
+    let visible = app.my_picker.visible_rows().len();
+    match app.my_picker.core.dispatch_key(&key, visible) {
+        InputOutcome::Cancel => app.close_my_picker(),
+        InputOutcome::Quit   => { app.close_my_picker(); app.should_quit = true; }
+        InputOutcome::Confirm => app.confirm_my_picker(),
+        InputOutcome::Edited
+        | InputOutcome::Rejected
+        | InputOutcome::SelectionMoved
+        | InputOutcome::CursorMoved
+        | InputOutcome::Unhandled => {}
+    }
+}
+```
+
+The `match` MUST list every `InputOutcome` variant. `Rejected` is
+unreachable today (PickerCore uses non-filtered `dispatch_key`) but
+the explicit arm is the compile-time net for a future swap.
+
+### Multi-line textarea
+
+Hold `(text: String, cursor: usize)` and route through
+`input_edit_multi::dispatch_key_multi`. The handler must
+**unconditionally consume** Ctrl+letter / Alt+letter chords (return
+true / `Edited`) so the outer handler's unguarded letter arms don't
+fire mid-message. See `handle_key_git_commit` for the canonical
+template — especially the `Char(_)` + (ctrl || alt) swallow guard on
+the Unhandled path.
+
+For paste: route through the appropriate `handle_paste` branch in
+`src/input.rs`. Don't depend on `Char('\r')` / `Char('\n')` events;
+many terminals deliver bracketed-paste payloads instead, and
+non-bracketed terminals deliver discrete key events that the
+defensive `Char('\r') → CursorOnly` arm in `dispatch_key_multi`
+swallows.
+
+## Mandatory invariants
+
+These have all been violated and re-fixed at least once during the
+unification work. Don't repeat the bugs:
+
+1. **Strict bare Enter** for any "commit / accept" action that
+   destroys editing state. Shift+Enter, Alt+Enter, Ctrl+Enter are
+   reserved (modifier-bearing variants are universal "soft newline"
+   muscle memory). Exception: in textareas, `dispatch_key_multi`'s
+   `Enter if !ctrl` correctly treats Shift+Enter / Alt+Enter as
+   newline; only bare `Ctrl+Enter` is "submit" (and the caller
+   intercepts before delegating).
+2. **Multi-line handlers MUST swallow Ctrl/Alt+Char chords on
+   Unhandled.** The outer Git / Files / Graph handlers have
+   `KeyCode::Char('s' | 't' | 'r' | …) =>` arms with NO modifier
+   guards. A textarea that returns `false` on Unhandled leaks
+   Ctrl+S etc. to those arms and silently stages files mid-message.
+3. **Pickers MUST close on `confirm()` returning None.** Filter
+   matching zero rows + Enter must not trap the keyboard. Close
+   FIRST, then act on the `Option`.
+4. **Edit-derived work fires on `Outcome::Edited` ONLY.** Use the
+   pre/post `text.len()` downgrade built into `dispatch_key{,_filtered}`
+   — a no-op Backspace at cursor=0 returns `CursorOnly` so
+   PickerCore's `Edited → selected_idx = 0` doesn't reset the row
+   cursor on a non-edit.
+5. **Cursor is a byte offset into `text`** that must always sit on a
+   UTF-8 char boundary. Use `input_edit::prev_char_boundary` /
+   `next_char_boundary` if you ever set `cursor` manually outside
+   `dispatch_key`. Renderers slicing `&text[..cursor]` will panic
+   mid-codepoint.
+6. **PickerCore consumers must list every `InputOutcome` variant.**
+   When adding a new variant (`Quit`, `Rejected` were added in
+   review rounds), the compiler catches missed arms only if the
+   `match` is exhaustive. Avoid `_ => {}` wildcards on `InputOutcome`.
+7. **No protocol bumps lurking elsewhere.** `Request::ListCommits`
+   gained a required `scope` field at v10; if you change any
+   `Request` / `Response` field shape on `crates/reef-proto`, bump
+   `PROTOCOL_VERSION` AND document the migration so handshake fails
+   loudly rather than degrading silently.
+
+## Picker-specific gotchas (graph_branch_picker)
+
+- `visible_rows()` is memoised in `RefCell<Option<(CacheKey, Vec<…>)>>`.
+  The cache key is `(lowercased_filter, all_branches.len(),
+  recent.len())` — push/pop on either Vec auto-invalidates.
+  In-place mutation of an element does NOT invalidate; call
+  `mark_dirty()` if a future writer needs that.
+- The renderer auto-scrolls `selected_idx` into view. New picker
+  overlays should clone this pattern (`scroll: usize` field +
+  `if sel < scroll { scroll = sel; } else if sel >= scroll + list_h
+  { scroll = sel + 1 - list_h }`); without it, monorepo branch lists
+  push the highlight off-screen on autorepeat.
+- Cold-start guard: `open_graph_branch_picker` refuses to open while
+  `ref_map.is_empty()` AND auto-falls-back to AllRefs when the
+  persisted Branch scope's ref isn't in ref_map. Both prevent a
+  silent overwrite of the user's persisted scope.
+
+## Where to find the canonical example for each layer
+
+| Need | Look at |
+|---|---|
+| L0 single-line | `src/find_widget.rs` (handle_key) — cleanest two-phase pattern |
+| L0 filtered | `src/input.rs::handle_key_db_goto` — digit-only predicate |
+| L1 multi-line | `src/input.rs::handle_key_git_commit` — Ctrl/Alt+Char swallow guard included |
+| L2 picker | `src/input.rs::handle_key_graph_branch_picker` — minimal InputOutcome translation; or `src/input.rs::handle_key_hosts_picker` for the double-buffer (filter + path mode) variant |
+
+Tests live in `src/{input_edit,input_edit_multi,picker_core,
+graph_branch_picker}::tests` plus integration coverage under
+`tests/`. When adding a new text input, mirror the existing test
+patterns: filter + cursor / autorepeat / UTF-8 boundary / no-op
+edits / Ctrl+letter swallow / strict-Enter modifier handling.

--- a/src/app.rs
+++ b/src/app.rs
@@ -2589,9 +2589,10 @@ impl App {
                 self.git_graph
                     .recent_branches
                     .retain(|existing| existing != target);
-                self.toasts.push(Toast::info(
-                    crate::i18n::graph_scope_stale_branch_toast(&short),
-                ));
+                self.toasts
+                    .push(Toast::info(crate::i18n::graph_scope_stale_branch_toast(
+                        &short,
+                    )));
                 self.apply_scope_no_refresh(GraphScope::AllRefs);
                 self.refresh_graph();
             }
@@ -3317,9 +3318,7 @@ impl App {
             self.git_graph
                 .recent_branches
                 .retain(|existing| existing != full_ref);
-            self.git_graph
-                .recent_branches
-                .insert(0, full_ref.clone());
+            self.git_graph.recent_branches.insert(0, full_ref.clone());
             if self.git_graph.recent_branches.len() > GRAPH_RECENT_BRANCHES_MAX {
                 self.git_graph
                     .recent_branches
@@ -5537,8 +5536,7 @@ impl App {
                 // arm collapses into the periodic arm: bootstrap fires
                 // on the first tick (next_graph_revalidate_at is in
                 // the past at construction) but errors back off.
-                let stale_no_error =
-                    self.graph_load.stale && self.graph_load.error.is_none();
+                let stale_no_error = self.graph_load.stale && self.graph_load.error.is_none();
                 if !self.graph_load.loading && (stale_no_error || should_poll_graph) {
                     self.refresh_graph();
                     self.next_graph_revalidate_at = now + Duration::from_secs(5);
@@ -5873,10 +5871,7 @@ mod tests {
         // don't have to babysit the worker round-trip in this test).
         fx.app.git_graph.scope = GraphScope::Branch("refs/heads/ghost".into());
         fx.app.git_graph.recent_branches = vec!["refs/heads/ghost".into()];
-        persist_graph_scope(
-            &fx.app.git_graph.scope,
-            &fx.app.git_graph.recent_branches,
-        );
+        persist_graph_scope(&fx.app.git_graph.scope, &fx.app.git_graph.recent_branches);
 
         let generation = fx.app.graph_load.begin();
         let payload = GraphPayload {
@@ -5892,7 +5887,12 @@ mod tests {
         });
 
         assert_eq!(fx.app.git_graph.scope, GraphScope::AllRefs);
-        assert!(!fx.app.git_graph.recent_branches.contains(&"refs/heads/ghost".to_string()));
+        assert!(
+            !fx.app
+                .git_graph
+                .recent_branches
+                .contains(&"refs/heads/ghost".to_string())
+        );
         assert!(fx.app.toasts.len() > toasts_before);
         assert!(
             fx.app.toasts.last().unwrap().message.contains("ghost"),
@@ -5900,10 +5900,7 @@ mod tests {
         );
 
         // Persisted state matches the fallback.
-        assert_eq!(
-            crate::prefs::get(PREF_GRAPH_SCOPE).as_deref(),
-            Some("all")
-        );
+        assert_eq!(crate::prefs::get(PREF_GRAPH_SCOPE).as_deref(), Some("all"));
         assert_eq!(
             crate::prefs::get(PREF_GRAPH_SCOPE_RECENT)
                 .as_deref()
@@ -5930,7 +5927,10 @@ mod tests {
             !fx.app.graph_branch_picker.core.active,
             "picker must not open while ref_map is empty"
         );
-        assert!(fx.app.toasts.len() > toasts_before, "must surface a hint toast");
+        assert!(
+            fx.app.toasts.len() > toasts_before,
+            "must surface a hint toast"
+        );
         // Persisted scope untouched.
         assert_eq!(
             fx.app.git_graph.scope,
@@ -5974,7 +5974,12 @@ mod tests {
             GraphScope::Branch("refs/heads/feature".into())
         );
         assert_eq!(fx.app.toasts.len(), toasts_before);
-        assert!(fx.app.git_graph.recent_branches.contains(&"refs/heads/feature".to_string()));
+        assert!(
+            fx.app
+                .git_graph
+                .recent_branches
+                .contains(&"refs/heads/feature".to_string())
+        );
     }
 
     #[test]
@@ -6077,10 +6082,10 @@ mod tests {
         let mut fx = make_scope_fixture();
         // Pretend we already have a populated ref_map so open_graph_branch_picker
         // succeeds.
-        fx.app
-            .git_graph
-            .ref_map
-            .insert("oid".into(), vec![crate::git::RefLabel::Branch("main".into())]);
+        fx.app.git_graph.ref_map.insert(
+            "oid".into(),
+            vec![crate::git::RefLabel::Branch("main".into())],
+        );
         fx.app.open_graph_branch_picker();
         assert!(fx.app.graph_branch_picker.core.active);
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 use crate::backend::{Backend, LocalBackend};
 use crate::file_tree::{FileTree, PreviewBody, PreviewContent};
 use crate::git::graph::GraphRow;
-use crate::git::{CommitDetail, CommitInfo, DiffContent, FileEntry, GitRepo, RefLabel};
+use crate::git::{CommitDetail, CommitInfo, DiffContent, FileEntry, GitRepo, GraphScope, RefLabel};
 use crate::tasks::{AsyncState, TaskCoordinator, WorkerResult};
 use crate::ui::confirm_modal::ConfirmModal;
 use crate::ui::highlight::StyledToken;
@@ -332,14 +332,26 @@ pub struct GitStatusState {
     pub commit_error: Option<String>,
 }
 
+/// Maximum number of recent branches we keep in `GitGraphState::recent_branches`.
+/// Past this count the picker stops being useful and starts being noise.
+pub(crate) const GRAPH_RECENT_BRANCHES_MAX: usize = 5;
+
 /// State for the inline commit graph sidebar.
 #[derive(Debug, Default)]
 pub struct GitGraphState {
     pub rows: Vec<GraphRow>,
     pub ref_map: HashMap<String, Vec<RefLabel>>,
-    /// `(head_oid, refs_hash)` — revwalk is skipped when these are unchanged,
-    /// so workdir edits don't trigger a full re-walk on large repos.
-    pub cache_key: Option<(String, u64)>,
+    /// `(head_oid, refs_hash, scope_hash)` — revwalk is skipped when these
+    /// are unchanged, so workdir edits don't trigger a full re-walk on
+    /// large repos. The scope component invalidates the cache when the
+    /// user picks a different branch via the picker.
+    pub cache_key: Option<(String, u64, u64)>,
+    /// Active walk scope. Defaults to `AllRefs` (historical behaviour).
+    /// Mutating this should be followed by `cache_key = None` + a refresh.
+    pub scope: GraphScope,
+    /// Most-recently-used fully-qualified refs surfaced at the top of the
+    /// branch picker. Persisted across sessions via `prefs::set`.
+    pub recent_branches: Vec<String>,
     pub selected_idx: usize,
     pub selected_commit: Option<String>,
     /// Anchor index for Shift-extended range selection. `None` = single-select
@@ -787,6 +799,11 @@ pub struct App {
     /// current App and rebuilds it with the new backend.
     pub hosts_picker: crate::hosts_picker::HostsPickerState,
 
+    /// `b` branch picker (Graph tab). Owns keyboard / mouse while
+    /// `active`, picks a fully-qualified ref or `[ All refs ]` →
+    /// `App::set_graph_scope` swaps the scope and refreshes.
+    pub graph_branch_picker: crate::graph_branch_picker::GraphBranchPickerState,
+
     /// Populated by the hosts picker on confirm. `main.rs` inspects this
     /// after `should_quit_session` fires and uses it to build the next
     /// `RemoteBackend`. Cleared once consumed.
@@ -1124,7 +1141,14 @@ impl App {
                 tree_mode: crate::prefs::get_bool("status.tree_mode"),
                 ..GitStatusState::default()
             },
-            git_graph: GitGraphState::default(),
+            git_graph: {
+                let (scope, recent) = load_graph_scope_pref();
+                GitGraphState {
+                    scope,
+                    recent_branches: recent,
+                    ..GitGraphState::default()
+                }
+            },
             commit_detail: CommitDetailState {
                 diff_layout: crate::prefs::get("commit.diff_layout")
                     .as_deref()
@@ -1152,6 +1176,7 @@ impl App {
             quick_open: crate::quick_open::QuickOpenState::from_prefs(),
             global_search: crate::global_search::GlobalSearchState::default(),
             hosts_picker: crate::hosts_picker::HostsPickerState::default(),
+            graph_branch_picker: crate::graph_branch_picker::GraphBranchPickerState::default(),
             pending_ssh_target: None,
             should_quit_session: false,
             preview_highlight: None,
@@ -2513,6 +2538,44 @@ impl App {
         self.should_quit_session = true;
     }
 
+    /// Open the Graph tab's branch picker. Pulls the branch list out
+    /// of the cached `ref_map` (already loaded by `refresh_graph`) and
+    /// seeds the recents from `GitGraphState::recent_branches`.
+    ///
+    /// Refuses to open before the first graph payload has populated
+    /// `ref_map`: at cold start with a persisted `Branch(X)` scope,
+    /// an empty `ref_map` would render the picker as
+    /// `[ All refs ]`-only, and a stray Enter would silently overwrite
+    /// the user's persisted choice via `set_graph_scope(AllRefs)`.
+    /// Toast instead and let the user retry once the first revwalk lands.
+    pub fn open_graph_branch_picker(&mut self) {
+        if self.git_graph.ref_map.is_empty() {
+            self.toasts
+                .push(Toast::info(crate::i18n::graph_picker_not_ready_toast()));
+            return;
+        }
+        let recent = self.git_graph.recent_branches.clone();
+        let scope = self.git_graph.scope.clone();
+        self.graph_branch_picker
+            .open(&self.git_graph.ref_map, recent, &scope);
+    }
+
+    pub fn close_graph_branch_picker(&mut self) {
+        self.graph_branch_picker.close();
+    }
+
+    /// Apply the picker's current selection and close the overlay. A
+    /// `confirm()` of `None` (filter matched zero rows + Enter) also
+    /// closes the overlay so the user can never get input-trapped on
+    /// an empty result list.
+    pub fn confirm_graph_branch_picker(&mut self) {
+        let scope = self.graph_branch_picker.confirm();
+        self.graph_branch_picker.close();
+        if let Some(scope) = scope {
+            self.set_graph_scope(scope);
+        }
+    }
+
     /// Collapse every expanded folder and async-refresh the tree so
     /// the render path picks up the shorter row list.
     pub fn collapse_all_tree_entries(&mut self) {
@@ -3179,8 +3242,9 @@ impl App {
         touched
     }
 
-    /// Rebuild the commit graph iff HEAD or any ref moved since the last build.
-    /// Working-tree fs events do NOT invalidate the cache — see plan pitfall #2.
+    /// Rebuild the commit graph iff HEAD or any ref (or the active scope)
+    /// moved since the last build. Working-tree fs events do NOT
+    /// invalidate the cache — see plan pitfall #2.
     pub fn refresh_graph(&mut self) {
         const GRAPH_COMMIT_LIMIT: usize = 500;
         if !self.backend.has_repo() {
@@ -3190,8 +3254,97 @@ impl App {
             return;
         };
         let generation = self.graph_load.begin();
-        self.tasks
-            .refresh_graph(generation, Arc::clone(&self.backend), GRAPH_COMMIT_LIMIT);
+        self.tasks.refresh_graph(
+            generation,
+            Arc::clone(&self.backend),
+            GRAPH_COMMIT_LIMIT,
+            self.git_graph.scope.clone(),
+        );
+    }
+
+    /// Switch the graph's walk scope to `scope`, push the previous branch
+    /// onto the recents list (newest-first, deduped, capped), reset
+    /// selection / scroll, invalidate the graph cache and trigger a
+    /// refresh. Persists `graph.scope` and `graph.scope.recent` so the
+    /// choice survives across sessions.
+    pub fn set_graph_scope(&mut self, scope: GraphScope) {
+        if self.git_graph.scope == scope {
+            return;
+        }
+        if let GraphScope::Branch(full_ref) = &scope {
+            self.git_graph
+                .recent_branches
+                .retain(|existing| existing != full_ref);
+            self.git_graph
+                .recent_branches
+                .insert(0, full_ref.clone());
+            if self.git_graph.recent_branches.len() > GRAPH_RECENT_BRANCHES_MAX {
+                self.git_graph
+                    .recent_branches
+                    .truncate(GRAPH_RECENT_BRANCHES_MAX);
+            }
+        }
+        self.apply_scope_no_refresh(scope);
+        self.refresh_graph();
+    }
+
+    /// Inner half of [`set_graph_scope`]: swap the scope, reset every
+    /// selection / scroll cursor that's about to become meaningless,
+    /// invalidate the graph cache, and persist. Does NOT trigger a
+    /// refresh — the caller (`set_graph_scope` or the stale-branch
+    /// fallback in the worker-result merge) owns that side-effect.
+    ///
+    /// Resetting selection here is load-bearing: without it the new
+    /// scope's first frame would render with `scroll` / anchor values
+    /// from the old branch, leaving the user staring at empty rows or
+    /// a stale range highlight until the next nav keystroke.
+    ///
+    /// Bumps `commit_detail_load` / `commit_file_diff_load` so any
+    /// in-flight load issued under the previous selection won't pass
+    /// its `complete_ok` generation check on arrival — otherwise a
+    /// late detail payload would repaint the just-cleared right panel
+    /// with the prior commit's metadata.
+    fn apply_scope_no_refresh(&mut self, scope: GraphScope) {
+        self.git_graph.scope = scope;
+        self.git_graph.cache_key = None;
+        // Old rows belong to the previous scope — keeping them around
+        // until the new payload lands paints the wrong tip-of-branch
+        // at `selected_idx = 0`. `ref_map` is intentionally NOT
+        // cleared: it's used to render ref chips on commits as soon
+        // as the new payload arrives, and the picker's cold-start
+        // guard reads from it too.
+        self.git_graph.rows.clear();
+        self.git_graph.selected_idx = 0;
+        self.git_graph.scroll = 0;
+        self.git_graph.selection_anchor = None;
+        self.git_graph.last_rendered_selected = None;
+        self.git_graph.selected_commit = None;
+        self.commit_detail.detail = None;
+        self.commit_detail.range_detail = None;
+        self.commit_detail.file_diff = None;
+        // Invalidate in-flight detail / file-diff loads so a late
+        // payload tied to the previous selection fails its
+        // `complete_ok` check on arrival. Using `invalidate` instead
+        // of `begin` is load-bearing here: `begin` would set
+        // `loading=true` with no follow-up dispatcher (especially for
+        // `commit_file_diff_load`, which only kicks when the user
+        // picks a file), leaving the status bar stuck on
+        // "commit diff refreshing…" indefinitely.
+        self.commit_detail_load.invalidate();
+        self.commit_file_diff_load.invalidate();
+        // Drop any active CommitGraph search overlay — its `matches`
+        // are byte-ranges into the rows we just cleared, so `n` / `N`
+        // would jump to indices that no longer correspond to anything
+        // visible. Searches targeting other panels (file preview,
+        // commit detail body, diff) are unaffected; they don't index
+        // into `git_graph.rows`.
+        if matches!(
+            self.search.target,
+            Some(crate::search::SearchTarget::CommitGraph)
+        ) {
+            self.search.clear();
+        }
+        persist_graph_scope(&self.git_graph.scope, &self.git_graph.recent_branches);
     }
 
     /// (Re)load commit detail for the currently-selected commit. Clears detail
@@ -3930,6 +4083,35 @@ impl App {
             WorkerResult::Graph { generation, result } => match result {
                 Ok(payload) => {
                     if self.graph_load.complete_ok(generation) {
+                        // Stale branch fallback: scope-targeted walk
+                        // returned nothing AND the freshly-walked
+                        // `ref_map` confirms the branch is genuinely
+                        // missing. The extra `ref_map` lookup matters
+                        // because `list_commits` also returns
+                        // `Vec::new()` on transient `revwalk()` errors
+                        // (libgit2 lock contention, fs jitter, …); we
+                        // don't want a one-tick hiccup to drop a
+                        // healthy branch from recents and surface a
+                        // misleading "gone" toast.
+                        if self.git_graph.scope != GraphScope::AllRefs
+                            && payload.rows.is_empty()
+                            && matches!(payload.scope, GraphScope::Branch(_))
+                            && self.git_graph.scope == payload.scope
+                            && payload_scope_ref_missing(&payload)
+                        {
+                            if let GraphScope::Branch(missing) = &payload.scope {
+                                self.git_graph
+                                    .recent_branches
+                                    .retain(|existing| existing != missing);
+                                let short = shorthand_for_full_ref(missing);
+                                self.toasts.push(Toast::info(
+                                    crate::i18n::graph_scope_stale_branch_toast(short),
+                                ));
+                            }
+                            self.apply_scope_no_refresh(GraphScope::AllRefs);
+                            self.refresh_graph();
+                            return;
+                        }
                         let previous_commit = self.git_graph.selected_commit.clone();
                         // Snapshot the anchor's OID before the re-walk
                         // overwrites `rows`. The graph is revalidated every
@@ -4680,6 +4862,9 @@ impl App {
             // double-click distinction needs `last_click` timing that's only
             // available at the input layer.
             ClickAction::QuickOpenSelect(_) => {}
+            // Graph branch picker: overlay-only, dispatched inline in
+            // `input::handle_mouse_graph_branch_picker`, never reaches here.
+            ClickAction::GraphBranchPickerSelect(_) => {}
             // Tab::Search result clicks DO route through here — the tab is
             // not an overlay, so input::handle_mouse lets the click fall
             // through to hit_test + handle_action. Update the selection and
@@ -5296,10 +5481,22 @@ impl App {
             Tab::Graph => {
                 let has_repo = self.backend.has_repo();
                 let should_poll_graph = has_repo && now >= self.next_graph_revalidate_at;
-                if self.graph_load.should_request()
-                    || (has_repo && self.git_graph.rows.is_empty() && !self.graph_load.loading)
-                    || (should_poll_graph && !self.graph_load.loading)
-                {
+                // Refresh policy:
+                //   - "stale w/o error" (e.g. fs-watcher mark_stale, tab
+                //     activation) → immediate
+                //   - "stale w/ error" → throttled by should_poll_graph
+                //     (otherwise persistent worker failures would
+                //     hammer at frame rate as soon as complete_err
+                //     clears `loading`)
+                //   - periodic poll → throttled by should_poll_graph
+                //
+                // The previous "rows.is_empty() && !loading" recovery
+                // arm collapses into the periodic arm: bootstrap fires
+                // on the first tick (next_graph_revalidate_at is in
+                // the past at construction) but errors back off.
+                let stale_no_error =
+                    self.graph_load.stale && self.graph_load.error.is_none();
+                if !self.graph_load.loading && (stale_no_error || should_poll_graph) {
                     self.refresh_graph();
                     self.next_graph_revalidate_at = now + Duration::from_secs(5);
                 }
@@ -5374,10 +5571,85 @@ fn save_prefs(layout: DiffLayout, mode: DiffMode) {
     crate::prefs::set("diff.mode", mode.pref_str());
 }
 
+/// Prefs key for the Graph tab's active scope (one of `all` or
+/// `branch:<full_ref>`).
+pub(crate) const PREF_GRAPH_SCOPE: &str = "graph.scope";
+/// Prefs key for the recent-branch MRU shown at the top of the
+/// branch picker. Tab-separated full ref names.
+pub(crate) const PREF_GRAPH_SCOPE_RECENT: &str = "graph.scope.recent";
+
+/// Decode the persisted `graph.scope` value. Unknown / malformed
+/// values fall back to `AllRefs` rather than erroring — we'd rather
+/// silently lose a stale pref than refuse to boot.
+pub(crate) fn load_graph_scope_pref() -> (GraphScope, Vec<String>) {
+    let scope = match crate::prefs::get(PREF_GRAPH_SCOPE).as_deref() {
+        Some("all") | None => GraphScope::AllRefs,
+        Some(other) => other
+            .strip_prefix("branch:")
+            .filter(|r| !r.is_empty())
+            .map(|r| GraphScope::Branch(r.to_string()))
+            .unwrap_or(GraphScope::AllRefs),
+    };
+    let recent = crate::prefs::get(PREF_GRAPH_SCOPE_RECENT)
+        .map(|raw| {
+            raw.split('\t')
+                .filter(|s| !s.is_empty())
+                .take(GRAPH_RECENT_BRANCHES_MAX)
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    (scope, recent)
+}
+
+/// Persist the Graph tab's scope + recents. Called from
+/// [`App::set_graph_scope`] every time the user accepts a picker
+/// selection (or the stale-branch fallback fires).
+pub(crate) fn persist_graph_scope(scope: &GraphScope, recent: &[String]) {
+    let value = match scope {
+        GraphScope::AllRefs => "all".to_string(),
+        GraphScope::Branch(s) => format!("branch:{s}"),
+    };
+    crate::prefs::set(PREF_GRAPH_SCOPE, &value);
+    crate::prefs::set(PREF_GRAPH_SCOPE_RECENT, &recent.join("\t"));
+}
+
+/// `true` when the payload's scope ref isn't present anywhere in the
+/// payload's `ref_map`. Used by the stale-branch fallback to confirm
+/// "ref really doesn't exist" before swapping scope back to `AllRefs`
+/// — distinguishes a genuinely-deleted branch from a transient
+/// `revwalk()` error (both surface as empty rows in the payload).
+fn payload_scope_ref_missing(payload: &crate::tasks::GraphPayload) -> bool {
+    let GraphScope::Branch(target) = &payload.scope else {
+        return false;
+    };
+    !payload.ref_map.values().any(|labels| {
+        labels.iter().any(|label| match label {
+            RefLabel::Branch(name) => format!("refs/heads/{name}") == *target,
+            RefLabel::RemoteBranch(name) => format!("refs/remotes/{name}") == *target,
+            _ => false,
+        })
+    })
+}
+
+/// Strip the `refs/heads/` or `refs/remotes/` prefix off a fully-qualified
+/// ref for display purposes (toasts, picker rows, panel titles).
+pub(crate) fn shorthand_for_full_ref(full_ref: &str) -> &str {
+    full_ref
+        .strip_prefix("refs/heads/")
+        .or_else(|| full_ref.strip_prefix("refs/remotes/"))
+        .unwrap_or(full_ref)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{App, GitGraphState, folder_contains};
+    use super::{
+        App, GRAPH_RECENT_BRANCHES_MAX, GitGraphState, PREF_GRAPH_SCOPE, PREF_GRAPH_SCOPE_RECENT,
+        folder_contains, load_graph_scope_pref, persist_graph_scope,
+    };
     use crate::backend::LocalBackend;
+    use crate::git::GraphScope;
+    use crate::tasks::{GraphPayload, WorkerResult};
     use crate::ui::theme::Theme;
     use std::sync::Arc;
     use test_support::{HOME_LOCK, HomeGuard, commit_file, tempdir_repo};
@@ -5425,6 +5697,392 @@ mod tests {
         };
         assert_eq!(g.selected_range(), (4, 9));
         assert!(g.is_range());
+    }
+
+    // ── Graph scope: set / fallback / cache ─────────────────────────────
+
+    /// Per-test HOME isolation. `prefs::*` reads/writes
+    /// `~/.config/reef/prefs`, and the scope tests both write (via
+    /// `set_graph_scope` / `apply_scope_no_refresh`) and assert prefs
+    /// state, so we have to redirect HOME for the duration.
+    struct ScopeFixture {
+        app: App,
+        _home_guard: test_support::HomeGuard,
+        _home: tempfile::TempDir,
+        _repo: tempfile::TempDir,
+        _home_lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    fn make_scope_fixture() -> ScopeFixture {
+        let lock = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::TempDir::new().expect("home tempdir");
+        let home_guard = HomeGuard::enter(home.path());
+        let (repo, raw) = tempdir_repo();
+        // One commit so HEAD resolves; the worker won't deadlock on us
+        // during App construction (it kicks `refresh_graph` synchronously
+        // dispatched onto the channel).
+        commit_file(&raw, "a.txt", "hello\n", "init");
+        let backend = Arc::new(LocalBackend::open_at(repo.path().to_path_buf()));
+        let mut app = App::new_with_backend(Theme::dark(), backend, None);
+        app.fs_watcher_rx = None;
+        ScopeFixture {
+            app,
+            _home_guard: home_guard,
+            _home: home,
+            _repo: repo,
+            _home_lock: lock,
+        }
+    }
+
+    #[test]
+    fn set_graph_scope_pushes_recents_dedupes_and_caps() {
+        // Drive set_graph_scope past the cap; the recents list should
+        // stay newest-first, deduped, and clamped at GRAPH_RECENT_BRANCHES_MAX.
+        let mut fx = make_scope_fixture();
+        for i in 0..(GRAPH_RECENT_BRANCHES_MAX + 2) {
+            fx.app
+                .set_graph_scope(GraphScope::Branch(format!("refs/heads/b{i}")));
+        }
+        assert_eq!(
+            fx.app.git_graph.recent_branches.len(),
+            GRAPH_RECENT_BRANCHES_MAX
+        );
+        // Newest-first. The most recent push was `b{MAX+1}`.
+        let newest = format!("refs/heads/b{}", GRAPH_RECENT_BRANCHES_MAX + 1);
+        assert_eq!(fx.app.git_graph.recent_branches[0], newest);
+
+        // Re-pushing an existing branch moves it to the front without
+        // duplicating.
+        let oldest_kept = fx.app.git_graph.recent_branches.last().cloned().unwrap();
+        fx.app
+            .set_graph_scope(GraphScope::Branch(oldest_kept.clone()));
+        assert_eq!(fx.app.git_graph.recent_branches[0], oldest_kept);
+        let dup_count = fx
+            .app
+            .git_graph
+            .recent_branches
+            .iter()
+            .filter(|s| **s == oldest_kept)
+            .count();
+        assert_eq!(dup_count, 1, "dedupe must keep exactly one entry");
+        assert_eq!(
+            fx.app.git_graph.recent_branches.len(),
+            GRAPH_RECENT_BRANCHES_MAX
+        );
+    }
+
+    #[test]
+    fn set_graph_scope_invalidates_cache_key_and_resets_selection() {
+        // The cache_key is what gates "skip the revwalk"; scope changes
+        // must bust it. Selection state from the previous scope is
+        // meaningless under the new one and must reset.
+        let mut fx = make_scope_fixture();
+        fx.app.git_graph.cache_key = Some(("dead".into(), 0xCAFE, 0xBABE));
+        fx.app.git_graph.selected_idx = 7;
+        fx.app.git_graph.scroll = 5;
+        fx.app.git_graph.selection_anchor = Some(3);
+        fx.app.git_graph.selected_commit = Some("stale".into());
+
+        fx.app
+            .set_graph_scope(GraphScope::Branch("refs/heads/main".into()));
+
+        assert!(fx.app.git_graph.cache_key.is_none());
+        assert_eq!(fx.app.git_graph.selected_idx, 0);
+        assert_eq!(fx.app.git_graph.scroll, 0);
+        assert!(fx.app.git_graph.selection_anchor.is_none());
+        assert!(fx.app.git_graph.selected_commit.is_none());
+    }
+
+    #[test]
+    fn set_graph_scope_persists_to_prefs() {
+        // Round-trip through the on-disk pref file so the next session
+        // really would land back on the same branch.
+        let mut fx = make_scope_fixture();
+        fx.app
+            .set_graph_scope(GraphScope::Branch("refs/heads/feature".into()));
+
+        let (scope, recent) = load_graph_scope_pref();
+        assert_eq!(scope, GraphScope::Branch("refs/heads/feature".into()));
+        assert_eq!(recent, vec!["refs/heads/feature".to_string()]);
+    }
+
+    #[test]
+    fn set_graph_scope_same_scope_is_noop() {
+        let mut fx = make_scope_fixture();
+        fx.app.git_graph.scope = GraphScope::Branch("refs/heads/main".into());
+        fx.app.git_graph.recent_branches = vec!["refs/heads/main".into()];
+        // Pre-seed a cache_key — the no-op path must NOT bust it (only
+        // a genuine scope change should).
+        fx.app.git_graph.cache_key = Some(("h".into(), 1, 2));
+        fx.app
+            .set_graph_scope(GraphScope::Branch("refs/heads/main".into()));
+        assert!(fx.app.git_graph.cache_key.is_some());
+    }
+
+    #[test]
+    fn stale_branch_payload_falls_back_to_all_refs() {
+        // Drive a Graph WorkerResult whose payload claims the scope is a
+        // branch but returned zero rows. The main thread should detect
+        // the missing-branch case, drop the recent entry, swap scope
+        // back to AllRefs, surface a toast, and persist the rollback.
+        let mut fx = make_scope_fixture();
+        // Stash the scope directly (bypassing `set_graph_scope` so we
+        // don't have to babysit the worker round-trip in this test).
+        fx.app.git_graph.scope = GraphScope::Branch("refs/heads/ghost".into());
+        fx.app.git_graph.recent_branches = vec!["refs/heads/ghost".into()];
+        persist_graph_scope(
+            &fx.app.git_graph.scope,
+            &fx.app.git_graph.recent_branches,
+        );
+
+        let generation = fx.app.graph_load.begin();
+        let payload = GraphPayload {
+            rows: Vec::new(),
+            ref_map: std::collections::HashMap::new(),
+            cache_key: ("h".into(), 0, 0),
+            scope: GraphScope::Branch("refs/heads/ghost".into()),
+        };
+        let toasts_before = fx.app.toasts.len();
+        fx.app.apply_worker_result(WorkerResult::Graph {
+            generation,
+            result: Ok(payload),
+        });
+
+        assert_eq!(fx.app.git_graph.scope, GraphScope::AllRefs);
+        assert!(!fx.app.git_graph.recent_branches.contains(&"refs/heads/ghost".to_string()));
+        assert!(fx.app.toasts.len() > toasts_before);
+        assert!(
+            fx.app.toasts.last().unwrap().message.contains("ghost"),
+            "toast should name the lost branch"
+        );
+
+        // Persisted state matches the fallback.
+        assert_eq!(
+            crate::prefs::get(PREF_GRAPH_SCOPE).as_deref(),
+            Some("all")
+        );
+        assert_eq!(
+            crate::prefs::get(PREF_GRAPH_SCOPE_RECENT)
+                .as_deref()
+                .unwrap_or(""),
+            ""
+        );
+    }
+
+    #[test]
+    fn open_graph_branch_picker_refuses_on_cold_start() {
+        // Cold-start safety: with a persisted Branch scope but no
+        // graph payload yet (ref_map still empty), pressing 'b' must
+        // NOT activate the picker — otherwise visible_rows would only
+        // offer `[ All refs ]` and a stray Enter would overwrite the
+        // user's persisted choice.
+        let mut fx = make_scope_fixture();
+        fx.app.git_graph.scope = GraphScope::Branch("refs/heads/feature".into());
+        fx.app.git_graph.ref_map.clear();
+        let toasts_before = fx.app.toasts.len();
+
+        fx.app.open_graph_branch_picker();
+
+        assert!(
+            !fx.app.graph_branch_picker.active,
+            "picker must not open while ref_map is empty"
+        );
+        assert!(fx.app.toasts.len() > toasts_before, "must surface a hint toast");
+        // Persisted scope untouched.
+        assert_eq!(
+            fx.app.git_graph.scope,
+            GraphScope::Branch("refs/heads/feature".into())
+        );
+    }
+
+    #[test]
+    fn stale_branch_fallback_skipped_when_ref_still_present() {
+        // Walk returned empty (transient revwalk error / lock
+        // contention), but the payload's ref_map still lists the
+        // branch. Fallback must NOT misfire — no toast, no scope flip,
+        // no recents drop.
+        let mut fx = make_scope_fixture();
+        fx.app.git_graph.scope = GraphScope::Branch("refs/heads/feature".into());
+        fx.app.git_graph.recent_branches = vec!["refs/heads/feature".into()];
+
+        let mut ref_map: std::collections::HashMap<String, Vec<crate::git::RefLabel>> =
+            std::collections::HashMap::new();
+        ref_map.insert(
+            "abc123".to_string(),
+            vec![crate::git::RefLabel::Branch("feature".into())],
+        );
+
+        let generation = fx.app.graph_load.begin();
+        let payload = GraphPayload {
+            rows: Vec::new(),
+            ref_map,
+            cache_key: ("h".into(), 0, 0),
+            scope: GraphScope::Branch("refs/heads/feature".into()),
+        };
+        let toasts_before = fx.app.toasts.len();
+        fx.app.apply_worker_result(WorkerResult::Graph {
+            generation,
+            result: Ok(payload),
+        });
+
+        // Scope kept; toast not pushed; recents preserved.
+        assert_eq!(
+            fx.app.git_graph.scope,
+            GraphScope::Branch("refs/heads/feature".into())
+        );
+        assert_eq!(fx.app.toasts.len(), toasts_before);
+        assert!(fx.app.git_graph.recent_branches.contains(&"refs/heads/feature".to_string()));
+    }
+
+    #[test]
+    fn apply_scope_no_refresh_invalidates_detail_loads_without_loading() {
+        // Stale in-flight detail / file-diff loads must NOT repaint
+        // the right panel after a scope swap. We bump generation via
+        // `invalidate` (not `begin`) so the status bar doesn't get
+        // stuck on a phantom "refreshing…" — verify both that the
+        // generation advances AND that `loading` stays false.
+        let mut fx = make_scope_fixture();
+        // Pretend an old load was in flight so we can confirm `loading`
+        // gets cleared, not preserved.
+        fx.app.commit_detail_load.loading = true;
+        fx.app.commit_file_diff_load.loading = true;
+        let before_detail = fx.app.commit_detail_load.generation;
+        let before_diff = fx.app.commit_file_diff_load.generation;
+
+        fx.app
+            .set_graph_scope(GraphScope::Branch("refs/heads/main".into()));
+
+        assert_ne!(
+            fx.app.commit_detail_load.generation, before_detail,
+            "commit_detail_load generation must advance"
+        );
+        assert_ne!(
+            fx.app.commit_file_diff_load.generation, before_diff,
+            "commit_file_diff_load generation must advance"
+        );
+        assert!(
+            !fx.app.commit_detail_load.loading,
+            "commit_detail_load.loading must be cleared (no follow-up dispatcher)"
+        );
+        assert!(
+            !fx.app.commit_file_diff_load.loading,
+            "commit_file_diff_load.loading must be cleared (no follow-up dispatcher)"
+        );
+    }
+
+    #[test]
+    fn set_graph_scope_clears_active_commit_graph_search() {
+        // Search matches index into git_graph.rows; clearing rows
+        // without resetting search would leave `n`/`N` jumping to
+        // rows that no longer correspond to anything visible.
+        let mut fx = make_scope_fixture();
+        // Synthesize an active CommitGraph search.
+        fx.app.search = crate::search::SearchState {
+            target: Some(crate::search::SearchTarget::CommitGraph),
+            matches: vec![crate::search::MatchLoc {
+                row: 0,
+                byte_range: 0..3,
+            }],
+            current: Some(0),
+            query: "foo".into(),
+            ..crate::search::SearchState::default()
+        };
+
+        fx.app
+            .set_graph_scope(GraphScope::Branch("refs/heads/main".into()));
+
+        assert!(
+            fx.app.search.matches.is_empty(),
+            "CommitGraph search must be cleared on scope swap"
+        );
+        assert!(fx.app.search.target.is_none());
+    }
+
+    #[test]
+    fn set_graph_scope_preserves_search_targeting_other_panel() {
+        // Searches on file preview, commit detail body, etc. don't
+        // index into git_graph.rows and should survive a scope swap.
+        let mut fx = make_scope_fixture();
+        fx.app.search = crate::search::SearchState {
+            target: Some(crate::search::SearchTarget::FilePreview),
+            matches: vec![crate::search::MatchLoc {
+                row: 5,
+                byte_range: 0..3,
+            }],
+            current: Some(0),
+            query: "foo".into(),
+            ..crate::search::SearchState::default()
+        };
+
+        fx.app
+            .set_graph_scope(GraphScope::Branch("refs/heads/main".into()));
+
+        assert_eq!(
+            fx.app.search.target,
+            Some(crate::search::SearchTarget::FilePreview),
+            "unrelated search target must not be cleared"
+        );
+        assert_eq!(fx.app.search.matches.len(), 1);
+    }
+
+    #[test]
+    fn confirm_graph_branch_picker_closes_overlay_when_filter_matches_nothing() {
+        // Filter "zzz" matches no branches and is not a substring of
+        // "all refs"; visible_rows is empty → confirm() returns None.
+        // The handler must still close the overlay so input isn't
+        // trapped.
+        let mut fx = make_scope_fixture();
+        // Pretend we already have a populated ref_map so open_graph_branch_picker
+        // succeeds.
+        fx.app
+            .git_graph
+            .ref_map
+            .insert("oid".into(), vec![crate::git::RefLabel::Branch("main".into())]);
+        fx.app.open_graph_branch_picker();
+        assert!(fx.app.graph_branch_picker.active);
+
+        fx.app.graph_branch_picker.filter = "zzz".into();
+        assert!(
+            fx.app.graph_branch_picker.confirm().is_none(),
+            "filter 'zzz' has no rows"
+        );
+
+        fx.app.confirm_graph_branch_picker();
+        assert!(
+            !fx.app.graph_branch_picker.active,
+            "picker must close even when confirm() returned None"
+        );
+    }
+
+    #[test]
+    fn payload_with_matching_scope_and_nonempty_rows_does_not_fall_back() {
+        // Sanity: a Branch-scoped payload that returned rows should be
+        // applied normally (no fallback, no toast).
+        let mut fx = make_scope_fixture();
+        fx.app.git_graph.scope = GraphScope::Branch("refs/heads/feature".into());
+
+        let generation = fx.app.graph_load.begin();
+        let payload = GraphPayload {
+            rows: Vec::new(), // emptiness is fine — the OK case is "scope didn't disappear"
+            ref_map: std::collections::HashMap::new(),
+            cache_key: ("h".into(), 0, 1),
+            // Scope mismatched against current: that's the "stale request" path,
+            // not the "ghost branch" path. The guard requires scope match.
+            scope: GraphScope::Branch("refs/heads/other".into()),
+        };
+        let toasts_before = fx.app.toasts.len();
+        fx.app.apply_worker_result(WorkerResult::Graph {
+            generation,
+            result: Ok(payload),
+        });
+
+        // Scope should NOT have flipped — the payload was for a different
+        // branch than the user is currently looking at.
+        assert!(matches!(
+            fx.app.git_graph.scope,
+            GraphScope::Branch(ref s) if s == "refs/heads/feature"
+        ));
+        assert_eq!(fx.app.toasts.len(), toasts_before);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -648,6 +648,11 @@ pub struct App {
     /// cancels. While `Some`, the input dispatcher (see `handle_key`)
     /// fully owns the keyboard — no other binding fires.
     pub db_goto_input: Option<String>,
+    /// Cursor byte-offset into `db_goto_input` when it's `Some`. Only
+    /// meaningful in tandem with `db_goto_input`; reset to 0 each time
+    /// the input opens. Allows mid-buffer editing (Left/Right, Home/End,
+    /// Ctrl+A/E, etc.) via [`crate::input_edit`].
+    pub db_goto_cursor: usize,
     /// Vertical / horizontal scroll axis-lock state. The dispatcher
     /// `observe()`s the firing axis and `locked()`-checks the
     /// orthogonal one — single-event trackpad noise on the
@@ -1113,6 +1118,7 @@ impl App {
             last_preview_rect: None,
             db_preview_state: None,
             db_goto_input: None,
+            db_goto_cursor: 0,
             vertical_scroll_lock: crate::input::AxisLock::new(),
             horizontal_scroll_lock: crate::input::AxisLock::new(),
             vertical_scroll_pacer: crate::input::ScrollPacer::new(),
@@ -3985,6 +3991,7 @@ impl App {
                         // any preview transition so a half-typed page
                         // number doesn't survive a file switch.
                         self.db_goto_input = None;
+                        self.db_goto_cursor = 0;
                         // If `global_search::accept` stashed a highlight for
                         // this file, re-center once the preview actually
                         // lands. `load_preview_for_path` runs async, so the

--- a/src/app.rs
+++ b/src/app.rs
@@ -1365,7 +1365,7 @@ impl App {
         self.tasks.replace_in_files(
             generation,
             self.backend.clone(),
-            self.global_search.query.clone(),
+            self.global_search.core.filter.clone(),
             self.global_search.replace_text.clone(),
             items,
         );
@@ -1436,7 +1436,7 @@ impl App {
         // place mode in `handle_key`), the search prompt would still
         // commandeer the status bar instead of the PLACE badge, and
         // the user would need two Esc presses to fully unwind.
-        self.quick_open.active = false;
+        self.quick_open.core.active = false;
         if self.search.active {
             crate::search::exit_cancel(self);
         }
@@ -4878,7 +4878,7 @@ impl App {
             // trigger live preview.
             ClickAction::GlobalSearchSelect(idx) => {
                 if self.active_tab == Tab::Search {
-                    self.global_search.selected = idx;
+                    self.global_search.core.selected_idx = idx;
                     crate::global_search::navigate_to_selected(self);
                 }
                 // Overlay case is unreachable via this path — handled inline
@@ -4955,7 +4955,7 @@ impl App {
                 // commit. The picker's own keyboard path goes through a
                 // different method, so here we just re-use `move_selection`
                 // by computing the delta.
-                let current = self.hosts_picker.selected_idx;
+                let current = self.hosts_picker.core.selected_idx;
                 let delta = idx as i32 - current as i32;
                 self.hosts_picker.move_selection(delta);
                 // Enter path-mode immediately so user can type /path and
@@ -5350,7 +5350,7 @@ impl App {
         let Some(hit) = self
             .global_search
             .results
-            .get(self.global_search.selected)
+            .get(self.global_search.core.selected_idx)
             .cloned()
         else {
             return;
@@ -5375,7 +5375,7 @@ impl App {
         if Instant::now().duration_since(t) < crate::global_search::DEBOUNCE {
             return;
         }
-        if self.global_search.query == self.global_search.last_searched_query {
+        if self.global_search.core.filter == self.global_search.last_searched_query {
             self.global_search.last_keystroke_at = None;
             return;
         }
@@ -5391,16 +5391,16 @@ impl App {
 
         self.global_search.results.clear();
         self.global_search.truncated = false;
-        self.global_search.selected = 0;
+        self.global_search.core.selected_idx = 0;
         self.global_search.scroll = 0;
         // New query → fresh results → start from smart-view. Leaving a
         // stale h-scroll here would mean the first chunks land already
         // offset, which looks like a bug.
         self.global_search.results_h_scroll = 0;
-        self.global_search.last_searched_query = self.global_search.query.clone();
+        self.global_search.last_searched_query = self.global_search.core.filter.clone();
         self.global_search.last_keystroke_at = None;
 
-        if self.global_search.query.is_empty() {
+        if self.global_search.core.filter.is_empty() {
             // No worker to send. Still bump+complete the AsyncState so any
             // late Done from the previous (now-cancelled) worker is dropped
             // via generation mismatch, and `loading` correctly reads false.
@@ -5418,7 +5418,7 @@ impl App {
             new_gen,
             new_cancel,
             Arc::clone(&self.backend),
-            self.global_search.query.clone(),
+            self.global_search.core.filter.clone(),
         );
     }
 
@@ -5532,7 +5532,7 @@ impl App {
                     && let Some(hit) = self
                         .global_search
                         .results
-                        .get(self.global_search.selected)
+                        .get(self.global_search.core.selected_idx)
                         .cloned()
                 {
                     self.load_preview_for_path(hit.path);
@@ -5891,7 +5891,7 @@ mod tests {
         fx.app.open_graph_branch_picker();
 
         assert!(
-            !fx.app.graph_branch_picker.active,
+            !fx.app.graph_branch_picker.core.active,
             "picker must not open while ref_map is empty"
         );
         assert!(fx.app.toasts.len() > toasts_before, "must surface a hint toast");
@@ -6046,9 +6046,9 @@ mod tests {
             .ref_map
             .insert("oid".into(), vec![crate::git::RefLabel::Branch("main".into())]);
         fx.app.open_graph_branch_picker();
-        assert!(fx.app.graph_branch_picker.active);
+        assert!(fx.app.graph_branch_picker.core.active);
 
-        fx.app.graph_branch_picker.filter = "zzz".into();
+        fx.app.graph_branch_picker.core.filter = "zzz".into();
         assert!(
             fx.app.graph_branch_picker.confirm().is_none(),
             "filter 'zzz' has no rows"
@@ -6056,7 +6056,7 @@ mod tests {
 
         fx.app.confirm_graph_branch_picker();
         assert!(
-            !fx.app.graph_branch_picker.active,
+            !fx.app.graph_branch_picker.core.active,
             "picker must close even when confirm() returned None"
         );
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2529,7 +2529,15 @@ impl App {
     /// we don't build the new backend here because the outer loop owns
     /// the terminal teardown/setup dance around the connect.
     pub fn confirm_hosts_picker(&mut self) {
-        let Some(target) = self.hosts_picker.confirm() else {
+        // Close first, then act on the (optional) target. Same shape as
+        // `confirm_graph_branch_picker` — without it, a `confirm()` of
+        // None (filter matched zero hosts + Enter) would early-return
+        // and leave the overlay open trapping the keyboard, same UX
+        // trap that R3 of the previous review fixed for the graph
+        // picker.
+        let target = self.hosts_picker.confirm();
+        self.hosts_picker.close();
+        let Some(target) = target else {
             return;
         };
         // Persist the chosen target to the recents list before handing
@@ -2539,7 +2547,6 @@ impl App {
         current = crate::hosts_picker::bump_recent(current, target.clone());
         crate::hosts_picker::save_recent(&current);
 
-        self.hosts_picker.close();
         self.pending_ssh_target = Some(target);
         self.should_quit_session = true;
     }
@@ -2559,6 +2566,35 @@ impl App {
             self.toasts
                 .push(Toast::info(crate::i18n::graph_picker_not_ready_toast()));
             return;
+        }
+        // If the persisted scope points at a branch that's no longer
+        // in ref_map (e.g. ref deleted between sessions; the
+        // background revalidator's stale-branch fallback hasn't run
+        // yet), fall back to AllRefs HERE so the picker doesn't open
+        // already-pointing at the AllRefs sentinel row by silent
+        // accident — pressing Enter would otherwise overwrite the
+        // persisted branch with no toast. Surface the same toast the
+        // worker fallback uses, then proceed with the user's normal
+        // picker flow against AllRefs.
+        if let GraphScope::Branch(target) = &self.git_graph.scope.clone() {
+            let still_present = self.git_graph.ref_map.values().any(|labels| {
+                labels.iter().any(|label| match label {
+                    RefLabel::Branch(name) => format!("refs/heads/{name}") == *target,
+                    RefLabel::RemoteBranch(name) => format!("refs/remotes/{name}") == *target,
+                    _ => false,
+                })
+            });
+            if !still_present {
+                let short = shorthand_for_full_ref(target).to_string();
+                self.git_graph
+                    .recent_branches
+                    .retain(|existing| existing != target);
+                self.toasts.push(Toast::info(
+                    crate::i18n::graph_scope_stale_branch_toast(&short),
+                ));
+                self.apply_scope_no_refresh(GraphScope::AllRefs);
+                self.refresh_graph();
+            }
         }
         let recent = self.git_graph.recent_branches.clone();
         let scope = self.git_graph.scope.clone();

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -17,7 +17,7 @@ use super::{
     EditorLaunchSpec, SearchChunkSink, StatusSnapshot, TrashOutcome, WalkOpts, WalkResponse,
 };
 use crate::file_tree::{self, PreviewContent, TreeEntry};
-use crate::git::{CommitDetail, CommitInfo, DiffContent, FileEntry, GitRepo, RefLabel};
+use crate::git::{CommitDetail, CommitInfo, DiffContent, FileEntry, GitRepo, GraphScope, RefLabel};
 use std::ops::ControlFlow;
 
 /// How many decoded previews to keep around. 8 covers the typical
@@ -513,8 +513,12 @@ impl Backend for LocalBackend {
         crate::git::commit_at(&self.workdir, message).map_err(BackendError::Git)
     }
 
-    fn list_commits(&self, limit: usize) -> Result<Vec<CommitInfo>, BackendError> {
-        Ok(self.repo()?.list_commits(limit))
+    fn list_commits(
+        &self,
+        scope: &GraphScope,
+        limit: usize,
+    ) -> Result<Vec<CommitInfo>, BackendError> {
+        Ok(self.repo()?.list_commits(scope, limit))
     }
 
     fn list_refs(&self) -> Result<HashMap<String, Vec<RefLabel>>, BackendError> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -24,7 +24,7 @@ use std::sync::mpsc;
 
 use crate::file_tree::{PreviewContent, TreeEntry};
 use crate::git::graph::GraphRow;
-use crate::git::{CommitDetail, CommitInfo, DiffContent, FileEntry, RefLabel};
+use crate::git::{CommitDetail, CommitInfo, DiffContent, FileEntry, GraphScope, RefLabel};
 use std::collections::{HashMap, HashSet};
 
 pub mod local;
@@ -352,7 +352,13 @@ pub trait Backend: Send + Sync {
     fn commit(&self, message: &str) -> Result<(), BackendError>;
 
     // ─── git: history ───────────────────────────────────────────────────────
-    fn list_commits(&self, limit: usize) -> Result<Vec<CommitInfo>, BackendError>;
+    /// List commits according to `scope` (all refs vs a single branch).
+    /// `scope = GraphScope::AllRefs` preserves the pre-scope behaviour.
+    fn list_commits(
+        &self,
+        scope: &GraphScope,
+        limit: usize,
+    ) -> Result<Vec<CommitInfo>, BackendError>;
     fn list_refs(&self) -> Result<HashMap<String, Vec<RefLabel>>, BackendError>;
     fn head_oid(&self) -> Result<Option<String>, BackendError>;
     fn commit_detail(&self, oid: &str) -> Result<Option<CommitDetail>, BackendError>;

--- a/src/backend/remote.rs
+++ b/src/backend/remote.rs
@@ -28,7 +28,7 @@ use super::{
     EditorLaunchSpec, SearchChunkSink, StatusSnapshot, TrashOutcome, WalkOpts, WalkResponse,
 };
 use crate::file_tree::{PreviewContent, TreeEntry};
-use crate::git::{CommitDetail, CommitInfo, DiffContent, FileEntry, RefLabel};
+use crate::git::{CommitDetail, CommitInfo, DiffContent, FileEntry, GraphScope, RefLabel};
 use std::ops::ControlFlow;
 
 /// Default timeout for a single RPC round-trip. Applied to every `request`
@@ -688,9 +688,14 @@ impl Backend for RemoteBackend {
         Ok(())
     }
 
-    fn list_commits(&self, limit: usize) -> Result<Vec<CommitInfo>, BackendError> {
+    fn list_commits(
+        &self,
+        scope: &GraphScope,
+        limit: usize,
+    ) -> Result<Vec<CommitInfo>, BackendError> {
         let list: Vec<reef_proto::CommitInfoDto> = self.request(Request::ListCommits {
             limit: limit as u64,
+            scope: graph_scope_to_dto(scope),
         })?;
         Ok(list.into_iter().map(Into::into).collect())
     }
@@ -1250,6 +1255,13 @@ impl From<reef_proto::RefLabelDto> for RefLabel {
             reef_proto::RefLabelDto::RemoteBranch(s) => RefLabel::RemoteBranch(s),
             reef_proto::RefLabelDto::Tag(s) => RefLabel::Tag(s),
         }
+    }
+}
+
+fn graph_scope_to_dto(scope: &GraphScope) -> reef_proto::GraphScopeDto {
+    match scope {
+        GraphScope::AllRefs => reef_proto::GraphScopeDto::AllRefs,
+        GraphScope::Branch(s) => reef_proto::GraphScopeDto::Branch(s.clone()),
     }
 }
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -163,6 +163,21 @@ pub enum RefLabel {
     Tag(String),
 }
 
+/// What slice of the commit history the graph should walk. `AllRefs`
+/// matches the historical behaviour (every local head + remote-tracking
+/// branch + tag + HEAD); `Branch` restricts the walk to a single
+/// fully-qualified ref so multi-branch repos don't crowd out the lane
+/// the user actually wants to see.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub enum GraphScope {
+    #[default]
+    AllRefs,
+    /// Fully-qualified ref name, e.g. `refs/heads/main` or
+    /// `refs/remotes/origin/feature`. Stored fully-qualified to avoid
+    /// the local-vs-remote shorthand collision (`main` vs `origin/main`).
+    Branch(String),
+}
+
 pub struct GitRepo {
     repo: Repository,
 }
@@ -791,20 +806,33 @@ impl GitRepo {
             .map(|c| c.id().to_string())
     }
 
-    /// Walk up to `limit` commits reachable from all branches/tags/HEAD, in
-    /// topological + time order (child before parent, newest first).
-    pub fn list_commits(&self, limit: usize) -> Vec<CommitInfo> {
+    /// Walk up to `limit` commits in topological + time order (child before
+    /// parent, newest first). `scope` controls which refs seed the walk:
+    /// `AllRefs` keeps the historical behaviour (every head + remote +
+    /// tag + HEAD); `Branch(full_ref)` walks only commits reachable from
+    /// that one ref. A missing ref yields an empty `Vec` — callers
+    /// detect this and fall back to `AllRefs`.
+    pub fn list_commits(&self, scope: &GraphScope, limit: usize) -> Vec<CommitInfo> {
         let Ok(mut walk) = self.repo.revwalk() else {
             return Vec::new();
         };
         let _ = walk.set_sorting(Sort::TOPOLOGICAL | Sort::TIME);
 
-        // Seed from local branches, remote branches, tags (peeled), and HEAD.
-        // push_glob dereferences annotated tags; non-commit targets are skipped.
-        let _ = walk.push_glob("refs/heads/*");
-        let _ = walk.push_glob("refs/remotes/*");
-        let _ = walk.push_glob("refs/tags/*");
-        let _ = walk.push_head();
+        match scope {
+            GraphScope::AllRefs => {
+                // Seed from local branches, remote branches, tags (peeled), and HEAD.
+                // push_glob dereferences annotated tags; non-commit targets are skipped.
+                let _ = walk.push_glob("refs/heads/*");
+                let _ = walk.push_glob("refs/remotes/*");
+                let _ = walk.push_glob("refs/tags/*");
+                let _ = walk.push_head();
+            }
+            GraphScope::Branch(full_ref) => {
+                if walk.push_ref(full_ref).is_err() {
+                    return Vec::new();
+                }
+            }
+        }
 
         let mut out = Vec::with_capacity(limit.min(256));
         for oid in walk.flatten().take(limit) {

--- a/src/global_search.rs
+++ b/src/global_search.rs
@@ -14,7 +14,6 @@
 //! async preview arrives. See `app::PreviewHighlight` + the tick handler.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
-use ratatui::layout::Rect;
 use std::collections::HashSet;
 use std::ops::Range;
 use std::path::PathBuf;
@@ -72,11 +71,12 @@ pub struct MatchHit {
 }
 
 pub struct GlobalSearchState {
-    pub active: bool,
-    pub query: String,
-    /// Byte offset into `query`. Always on a char boundary.
-    pub cursor: usize,
-    pub selected: usize,
+    /// Shared overlay scaffolding (`active`, `query` → `core.filter`,
+    /// `cursor`, `selected` → `core.selected_idx`, `last_popup_area`).
+    /// `replace_text` / `replace_cursor` are a SECOND single-line
+    /// buffer, edited directly via `input_edit::dispatch_key` when
+    /// `focus == ReplaceInput`. PickerCore only tracks the find buffer.
+    pub core: crate::picker_core::PickerCore,
     pub scroll: usize,
     /// Results are sorted by path so same-file hits are adjacent in the list
     /// (mirrors VSCode's data-layer grouping without a full tree UI).
@@ -102,7 +102,6 @@ pub struct GlobalSearchState {
     pub last_searched_query: String,
 
     pub last_view_h: u16,
-    pub last_popup_area: Option<Rect>,
 
     /// Palette-side Space-leader slot. Re-uses `input::leader_decision` so
     /// Space-F inside the palette (when `query` is empty) closes it, same
@@ -188,10 +187,7 @@ pub struct GlobalSearchState {
 impl Default for GlobalSearchState {
     fn default() -> Self {
         Self {
-            active: false,
-            query: String::new(),
-            cursor: 0,
-            selected: 0,
+            core: crate::picker_core::PickerCore::default(),
             scroll: 0,
             results: Vec::new(),
             truncated: false,
@@ -199,7 +195,6 @@ impl Default for GlobalSearchState {
             last_keystroke_at: None,
             last_searched_query: String::new(),
             last_view_h: 0,
-            last_popup_area: None,
             space_leader_at: None,
             focus: SearchPanelFocus::List,
             replace_open: false,
@@ -309,16 +304,16 @@ pub const PREVIEW_SYNC_DEBOUNCE: std::time::Duration = std::time::Duration::from
 /// and-return doesn't lose state.
 pub fn begin(app: &mut App) {
     if let Some(seed) = current_text_selection(app)
-        && seed != app.global_search.query
+        && seed != app.global_search.core.filter
     {
         // Skip the rerun + excluded-clear when the seed equals the
         // existing query: the user might have ticked off hits in
         // replace mode and we don't want a no-op chord to wipe that.
-        app.global_search.query = seed;
+        app.global_search.core.filter = seed;
         mark_query_edited(&mut app.global_search);
     }
-    app.global_search.cursor = app.global_search.query.len();
-    app.global_search.active = true;
+    app.global_search.core.cursor = app.global_search.core.filter.len();
+    app.global_search.core.active = true;
     // Fresh leader slot — a stale timestamp from a prior session would make
     // the first Space-after-open surprisingly close the palette.
     app.global_search.space_leader_at = None;
@@ -373,7 +368,7 @@ pub(crate) fn first_nonempty_trimmed_line(s: &str) -> Option<String> {
 /// newlines and re-runs the search. Called from `input::handle_paste`
 /// after the drop-path parser has declined the payload.
 pub fn handle_paste_overlay(s: &str, state: &mut GlobalSearchState) {
-    if input_edit::paste_single_line(s, &mut state.query, &mut state.cursor) {
+    if input_edit::paste_single_line(s, &mut state.core.filter, &mut state.core.cursor) {
         mark_query_edited(state);
     }
 }
@@ -385,7 +380,7 @@ pub fn handle_paste_overlay(s: &str, state: &mut GlobalSearchState) {
 pub fn handle_paste_search_tab(s: &str, state: &mut GlobalSearchState) {
     match state.focus {
         SearchPanelFocus::FindInput => {
-            if input_edit::paste_single_line(s, &mut state.query, &mut state.cursor) {
+            if input_edit::paste_single_line(s, &mut state.core.filter, &mut state.core.cursor) {
                 mark_query_edited(state);
             }
         }
@@ -403,10 +398,10 @@ pub fn accept(app: &mut App) {
     let Some(hit) = app
         .global_search
         .results
-        .get(app.global_search.selected)
+        .get(app.global_search.core.selected_idx)
         .cloned()
     else {
-        app.global_search.active = false;
+        app.global_search.core.active = false;
         return;
     };
 
@@ -420,13 +415,13 @@ pub fn accept(app: &mut App) {
             .results
             .retain(|h| root.join(&h.path).exists());
         let len = app.global_search.results.len();
-        if app.global_search.selected >= len {
-            app.global_search.selected = len.saturating_sub(1);
+        if app.global_search.core.selected_idx >= len {
+            app.global_search.core.selected_idx = len.saturating_sub(1);
         }
         return;
     }
 
-    app.global_search.active = false;
+    app.global_search.core.active = false;
     app.set_active_tab(Tab::Files);
     app.file_tree.reveal(&hit.path);
     app.refresh_file_tree_with_target(Some(hit.path.clone()));
@@ -448,7 +443,7 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
     // empty query so a literal space in the search string is allowed.
     match crate::input::leader_decision(
         &key,
-        /* allow_arm */ app.global_search.query.is_empty(),
+        /* allow_arm */ app.global_search.core.filter.is_empty(),
         app.global_search.space_leader_at,
         Instant::now(),
         crate::input::LEADER_TIMEOUT,
@@ -465,7 +460,7 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
             // to the input-append arm rather than silently swallow it.
             app.global_search.space_leader_at = None;
             if key.code == KeyCode::Char('F') && !ctrl && !alt {
-                app.global_search.active = false;
+                app.global_search.core.active = false;
                 return;
             }
             // Fall through — non-Shift-F chord lands in the input handler.
@@ -477,81 +472,50 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         crate::input::LeaderVerdict::None => {}
     }
 
-    // Phase 1: palette-specific shortcuts. These must precede
-    // `dispatch_key` — the editor vocabulary would otherwise eat e.g.
-    // Ctrl+P as a no-op or Enter as an unhandled key.
-    match key.code {
-        KeyCode::Esc => {
-            app.global_search.active = false;
-            return;
-        }
-        KeyCode::Char('c') if ctrl => {
-            app.global_search.active = false;
-            app.should_quit = true;
-            return;
-        }
-        // Pin to Tab::Search — close the overlay, switch to the persistent
-        // search view. Query/results are preserved on `app.global_search`.
-        // Alt and Ctrl both bound because terminal emulators disagree on
-        // which modifier they forward for Shift/Ctrl+Enter: Alt+Enter is
-        // the most portable. VSCode's analogue is "Open Results in Editor"
-        // (workbench.action.search.openInEditor) which is also a two-handed
-        // hand-off of the same state.
-        KeyCode::Enter if alt || ctrl => {
-            app.global_search.active = false;
-            app.global_search.focus = SearchPanelFocus::FindInput;
-            app.set_active_tab(Tab::Search);
-            navigate_to_selected(app);
-            return;
-        }
-        KeyCode::Enter => {
-            accept(app);
-            return;
-        }
-        KeyCode::Up => {
-            move_selection(&mut app.global_search, -1);
-            return;
-        }
-        KeyCode::Down => {
-            move_selection(&mut app.global_search, 1);
-            return;
-        }
-        KeyCode::Char('p' | 'k') if ctrl => {
-            move_selection(&mut app.global_search, -1);
-            return;
-        }
-        KeyCode::Char('n' | 'j') if ctrl => {
-            move_selection(&mut app.global_search, 1);
-            return;
-        }
-        KeyCode::PageUp => {
-            let step = app.global_search.last_view_h.max(1) as i32;
-            move_selection(&mut app.global_search, -step);
-            return;
-        }
-        KeyCode::PageDown => {
-            let step = app.global_search.last_view_h.max(1) as i32;
-            move_selection(&mut app.global_search, step);
-            return;
-        }
-        _ => {}
+    // Palette-specific shortcuts that must precede PickerCore:
+    // - Alt/Ctrl+Enter pins to Tab::Search (otherwise PickerCore would
+    //   treat it as a plain Confirm)
+    // - PageUp/PageDown depend on `last_view_h` which PickerCore
+    //   doesn't see
+    if matches!(key.code, KeyCode::Enter) && (alt || ctrl) {
+        app.global_search.core.active = false;
+        app.global_search.focus = SearchPanelFocus::FindInput;
+        app.set_active_tab(Tab::Search);
+        navigate_to_selected(app);
+        return;
+    }
+    if matches!(key.code, KeyCode::PageUp | KeyCode::PageDown) {
+        let step = app.global_search.last_view_h.max(1) as i32;
+        let signed = if matches!(key.code, KeyCode::PageUp) {
+            -step
+        } else {
+            step
+        };
+        move_selection(&mut app.global_search, signed);
+        return;
     }
 
-    // Phase 2: shared text-input dispatch. `Edited` triggers a
-    // re-run of the search worker via `mark_query_edited`.
-    let outcome = input_edit::dispatch_key(
-        &key,
-        &mut app.global_search.query,
-        &mut app.global_search.cursor,
-    );
-    if outcome == input_edit::Outcome::Edited {
-        mark_query_edited(&mut app.global_search);
+    use crate::picker_core::InputOutcome;
+    let visible = app.global_search.results.len();
+    match app.global_search.core.dispatch_key(&key, visible) {
+        InputOutcome::Cancel => {
+            let ctrl_c = matches!(key.code, KeyCode::Char('c')) && ctrl;
+            app.global_search.core.active = false;
+            if ctrl_c {
+                app.should_quit = true;
+            }
+        }
+        InputOutcome::Confirm => accept(app),
+        InputOutcome::Edited => mark_query_edited(&mut app.global_search),
+        InputOutcome::SelectionMoved
+        | InputOutcome::CursorMoved
+        | InputOutcome::Unhandled => {}
     }
 }
 
 /// Dispatch one mouse event while the palette is active.
 pub fn handle_mouse(mouse: MouseEvent, app: &mut App) {
-    let popup = match app.global_search.last_popup_area {
+    let popup = match app.global_search.core.last_popup_area {
         Some(r) => r,
         None => return,
     };
@@ -563,7 +527,7 @@ pub fn handle_mouse(mouse: MouseEvent, app: &mut App) {
     match mouse.kind {
         MouseEventKind::Down(MouseButton::Left) => {
             if !inside {
-                app.global_search.active = false;
+                app.global_search.core.active = false;
                 app.last_click = None;
                 return;
             }
@@ -580,7 +544,7 @@ pub fn handle_mouse(mouse: MouseEvent, app: &mut App) {
             if let Some(ClickAction::GlobalSearchSelect(idx)) =
                 app.hit_registry.hit_test(mouse.column, mouse.row)
             {
-                app.global_search.selected = idx;
+                app.global_search.core.selected_idx = idx;
                 if is_double {
                     accept(app);
                     app.last_click = None;
@@ -621,13 +585,13 @@ pub(crate) fn mark_query_edited(state: &mut GlobalSearchState) {
 
 fn move_selection(state: &mut GlobalSearchState, delta: i32) {
     if state.results.is_empty() {
-        state.selected = 0;
+        state.core.selected_idx = 0;
         return;
     }
     let last = state.results.len() - 1;
-    let cur = state.selected as i32;
+    let cur = state.core.selected_idx as i32;
     let next = (cur + delta).clamp(0, last as i32) as usize;
-    state.selected = next;
+    state.core.selected_idx = next;
 }
 
 /// Public wrapper around `move_selection` for call sites outside the
@@ -656,7 +620,7 @@ pub fn schedule_preview_sync(app: &mut App) {
 /// debounce gate fires. Does nothing when the query is empty (there's
 /// nothing to reload).
 pub fn reload(app: &mut App) {
-    if app.global_search.query.is_empty() {
+    if app.global_search.core.filter.is_empty() {
         return;
     }
     app.global_search.last_searched_query.clear();
@@ -677,7 +641,7 @@ pub fn navigate_to_selected(app: &mut App) {
     let Some(hit) = app
         .global_search
         .results
-        .get(app.global_search.selected)
+        .get(app.global_search.core.selected_idx)
         .cloned()
     else {
         return;
@@ -778,9 +742,9 @@ mod tests {
             ..GlobalSearchState::default()
         };
         move_selection(&mut s, 10);
-        assert_eq!(s.selected, 2);
+        assert_eq!(s.core.selected_idx, 2);
         move_selection(&mut s, -99);
-        assert_eq!(s.selected, 0);
+        assert_eq!(s.core.selected_idx, 0);
     }
 
     #[test]
@@ -876,11 +840,14 @@ mod tests {
         // want move_selection to snap it back to 0 when there's nothing in
         // the list.
         let mut s = GlobalSearchState {
-            selected: 5,
+            core: crate::picker_core::PickerCore {
+                selected_idx: 5,
+                ..crate::picker_core::PickerCore::default()
+            },
             ..GlobalSearchState::default()
         };
         move_selection(&mut s, 1);
-        assert_eq!(s.selected, 0);
+        assert_eq!(s.core.selected_idx, 0);
     }
 
     fn dummy_hit(name: &str) -> MatchHit {
@@ -927,8 +894,8 @@ mod tests {
         let mut state = GlobalSearchState::default();
         assert!(state.last_keystroke_at.is_none());
         handle_paste_overlay("hello", &mut state);
-        assert_eq!(state.query, "hello");
-        assert_eq!(state.cursor, 5);
+        assert_eq!(state.core.filter, "hello");
+        assert_eq!(state.core.cursor, 5);
         assert!(
             state.last_keystroke_at.is_some(),
             "non-empty paste must arm the search-rerun debounce",
@@ -939,7 +906,7 @@ mod tests {
     fn handle_paste_overlay_pure_newlines_do_not_trigger_rerun() {
         let mut state = GlobalSearchState::default();
         handle_paste_overlay("\n\r\n", &mut state);
-        assert_eq!(state.query, "");
+        assert_eq!(state.core.filter, "");
         assert!(
             state.last_keystroke_at.is_none(),
             "all-newline paste inserts nothing → search rerun must NOT fire",
@@ -953,13 +920,16 @@ mod tests {
         // must survive untouched.
         let mut state = GlobalSearchState {
             results: vec![dummy_hit("a"), dummy_hit("b"), dummy_hit("c")],
-            selected: 2,
+            core: crate::picker_core::PickerCore {
+                selected_idx: 2,
+                ..crate::picker_core::PickerCore::default()
+            },
             replace_text: "kept".to_string(),
             replace_cursor: 4,
             ..GlobalSearchState::default()
         };
         handle_paste_overlay("foo", &mut state);
-        assert_eq!(state.selected, 2);
+        assert_eq!(state.core.selected_idx, 2);
         assert_eq!(state.replace_text, "kept");
         assert_eq!(state.replace_cursor, 4);
     }
@@ -973,8 +943,8 @@ mod tests {
             ..GlobalSearchState::default()
         };
         handle_paste_search_tab("abc", &mut state);
-        assert_eq!(state.query, "abc");
-        assert_eq!(state.cursor, 3);
+        assert_eq!(state.core.filter, "abc");
+        assert_eq!(state.core.cursor, 3);
         assert!(state.last_keystroke_at.is_some());
         assert_eq!(state.replace_text, "");
     }
@@ -989,7 +959,7 @@ mod tests {
         handle_paste_search_tab("xyz", &mut state);
         assert_eq!(state.replace_text, "xyz");
         assert_eq!(state.replace_cursor, 3);
-        assert_eq!(state.query, "");
+        assert_eq!(state.core.filter, "");
         assert!(
             state.last_keystroke_at.is_none(),
             "replace-input edits never re-run the search",
@@ -1002,14 +972,17 @@ mod tests {
         // nowhere to land. Must not silently leak into either field.
         let mut state = GlobalSearchState {
             focus: SearchPanelFocus::List,
-            query: "kept-query".to_string(),
-            cursor: 10,
+            core: crate::picker_core::PickerCore {
+                filter: "kept-query".to_string(),
+                cursor: 10,
+                ..crate::picker_core::PickerCore::default()
+            },
             replace_text: "kept-replace".to_string(),
             replace_cursor: 12,
             ..GlobalSearchState::default()
         };
         handle_paste_search_tab("LEAK", &mut state);
-        assert_eq!(state.query, "kept-query");
+        assert_eq!(state.core.filter, "kept-query");
         assert_eq!(state.replace_text, "kept-replace");
         assert!(state.last_keystroke_at.is_none());
     }

--- a/src/global_search.rs
+++ b/src/global_search.rs
@@ -496,14 +496,13 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
     }
 
     use crate::picker_core::InputOutcome;
+    let _ = ctrl; // Quit branch handles Ctrl+C; no other ctrl-gating here.
     let visible = app.global_search.results.len();
     match app.global_search.core.dispatch_key(&key, visible) {
-        InputOutcome::Cancel => {
-            let ctrl_c = matches!(key.code, KeyCode::Char('c')) && ctrl;
+        InputOutcome::Cancel => app.global_search.core.active = false,
+        InputOutcome::Quit => {
             app.global_search.core.active = false;
-            if ctrl_c {
-                app.should_quit = true;
-            }
+            app.should_quit = true;
         }
         InputOutcome::Confirm => accept(app),
         InputOutcome::Edited => mark_query_edited(&mut app.global_search),

--- a/src/global_search.rs
+++ b/src/global_search.rs
@@ -506,7 +506,12 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         }
         InputOutcome::Confirm => accept(app),
         InputOutcome::Edited => mark_query_edited(&mut app.global_search),
-        InputOutcome::SelectionMoved
+        // Rejected only fires once PickerCore is wired to a filtered
+        // dispatcher (today unreachable). When that lands, decide
+        // whether a rejected char should also re-run the search;
+        // currently the buffer didn't change so the answer is no.
+        InputOutcome::Rejected
+        | InputOutcome::SelectionMoved
         | InputOutcome::CursorMoved
         | InputOutcome::Unhandled => {}
     }

--- a/src/global_search.rs
+++ b/src/global_search.rs
@@ -477,13 +477,18 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         crate::input::LeaderVerdict::None => {}
     }
 
+    // Phase 1: palette-specific shortcuts. These must precede
+    // `dispatch_key` — the editor vocabulary would otherwise eat e.g.
+    // Ctrl+P as a no-op or Enter as an unhandled key.
     match key.code {
         KeyCode::Esc => {
             app.global_search.active = false;
+            return;
         }
         KeyCode::Char('c') if ctrl => {
             app.global_search.active = false;
             app.should_quit = true;
+            return;
         }
         // Pin to Tab::Search — close the overlay, switch to the persistent
         // search view. Query/results are preserved on `app.global_search`.
@@ -494,145 +499,53 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         // hand-off of the same state.
         KeyCode::Enter if alt || ctrl => {
             app.global_search.active = false;
-            // Land in input mode — the user was typing inside the overlay,
-            // so keeping the input focused is the no-surprise hand-off.
-            // From the other entry paths (digit key, Tab cycle) the tab
-            // starts in list mode; see `handle_key_search`.
             app.global_search.focus = SearchPanelFocus::FindInput;
             app.set_active_tab(Tab::Search);
-            // Sync preview_highlight to the current selection so the tab's
-            // right panel lights up without waiting for another keystroke.
             navigate_to_selected(app);
+            return;
         }
-        KeyCode::Enter => accept(app),
-
-        // ── Deletion ─────────────────────────────────────────────
-        KeyCode::Backspace if alt || ctrl => {
-            input_edit::delete_word_backward(
-                &mut app.global_search.query,
-                &mut app.global_search.cursor,
-            );
-            mark_query_edited(&mut app.global_search);
+        KeyCode::Enter => {
+            accept(app);
+            return;
         }
-        KeyCode::Char('w') if ctrl => {
-            input_edit::delete_word_backward(
-                &mut app.global_search.query,
-                &mut app.global_search.cursor,
-            );
-            mark_query_edited(&mut app.global_search);
+        KeyCode::Up => {
+            move_selection(&mut app.global_search, -1);
+            return;
         }
-        KeyCode::Char('u') if ctrl => {
-            input_edit::clear(&mut app.global_search.query, &mut app.global_search.cursor);
-            mark_query_edited(&mut app.global_search);
+        KeyCode::Down => {
+            move_selection(&mut app.global_search, 1);
+            return;
         }
-        KeyCode::Backspace => {
-            input_edit::backspace(&mut app.global_search.query, &mut app.global_search.cursor);
-            mark_query_edited(&mut app.global_search);
+        KeyCode::Char('p' | 'k') if ctrl => {
+            move_selection(&mut app.global_search, -1);
+            return;
         }
-
-        // ── List navigation ──────────────────────────────────────
-        KeyCode::Up => move_selection(&mut app.global_search, -1),
-        KeyCode::Char('p') if ctrl => move_selection(&mut app.global_search, -1),
-        KeyCode::Char('k') if ctrl => move_selection(&mut app.global_search, -1),
-        KeyCode::Down => move_selection(&mut app.global_search, 1),
-        KeyCode::Char('n') if ctrl => move_selection(&mut app.global_search, 1),
-        KeyCode::Char('j') if ctrl => move_selection(&mut app.global_search, 1),
+        KeyCode::Char('n' | 'j') if ctrl => {
+            move_selection(&mut app.global_search, 1);
+            return;
+        }
         KeyCode::PageUp => {
             let step = app.global_search.last_view_h.max(1) as i32;
             move_selection(&mut app.global_search, -step);
+            return;
         }
         KeyCode::PageDown => {
             let step = app.global_search.last_view_h.max(1) as i32;
             move_selection(&mut app.global_search, step);
-        }
-
-        // ── Cursor movement inside the query ────────────────────
-        // Alt/Ctrl + arrow = jump by word, matching readline (Meta+B/F),
-        // macOS Option+Arrow, and Windows/Linux Ctrl+Arrow conventions.
-        // Must come before the bare-arrow arms so modifier combos win.
-        KeyCode::Left if alt || ctrl => {
-            input_edit::move_cursor_word_backward(
-                &app.global_search.query,
-                &mut app.global_search.cursor,
-            );
-        }
-        KeyCode::Right if alt || ctrl => {
-            input_edit::move_cursor_word_forward(
-                &app.global_search.query,
-                &mut app.global_search.cursor,
-            );
-        }
-        KeyCode::Left => {
-            input_edit::move_cursor(&app.global_search.query, &mut app.global_search.cursor, -1);
-        }
-        KeyCode::Right => {
-            input_edit::move_cursor(&app.global_search.query, &mut app.global_search.cursor, 1);
-        }
-        KeyCode::Home => {
-            app.global_search.cursor = 0;
-        }
-        KeyCode::End => {
-            app.global_search.cursor = app.global_search.query.len();
-        }
-
-        // ── Forward-delete ──────────────────────────────────────
-        // Symmetric with Backspace: plain Delete kills one char, Alt/Ctrl
-        // +Delete kills a word. Both re-run the search via mark_query_edited.
-        KeyCode::Delete if alt || ctrl => {
-            input_edit::delete_word_forward(
-                &mut app.global_search.query,
-                &mut app.global_search.cursor,
-            );
-            mark_query_edited(&mut app.global_search);
-        }
-        KeyCode::Delete => {
-            input_edit::delete_char_forward(
-                &mut app.global_search.query,
-                &mut app.global_search.cursor,
-            );
-            mark_query_edited(&mut app.global_search);
-        }
-
-        // ── Readline aliases ────────────────────────────────────
-        // Reliable fallback for terminals that don't pass Alt/Ctrl+Arrow
-        // through cleanly (the kitty kbd protocol in main.rs helps, but
-        // isn't universally supported). `Alt+b/f/d` and `Ctrl+A/E` are
-        // what bash-readline users type anyway.
-        KeyCode::Char('b') if alt => {
-            input_edit::move_cursor_word_backward(
-                &app.global_search.query,
-                &mut app.global_search.cursor,
-            );
-        }
-        KeyCode::Char('f') if alt => {
-            input_edit::move_cursor_word_forward(
-                &app.global_search.query,
-                &mut app.global_search.cursor,
-            );
-        }
-        KeyCode::Char('d') if alt => {
-            input_edit::delete_word_forward(
-                &mut app.global_search.query,
-                &mut app.global_search.cursor,
-            );
-            mark_query_edited(&mut app.global_search);
-        }
-        KeyCode::Char('a') if ctrl => {
-            app.global_search.cursor = 0;
-        }
-        KeyCode::Char('e') if ctrl => {
-            app.global_search.cursor = app.global_search.query.len();
-        }
-
-        KeyCode::Char(c) if !ctrl => {
-            input_edit::insert_char(
-                &mut app.global_search.query,
-                &mut app.global_search.cursor,
-                c,
-            );
-            mark_query_edited(&mut app.global_search);
+            return;
         }
         _ => {}
+    }
+
+    // Phase 2: shared text-input dispatch. `Edited` triggers a
+    // re-run of the search worker via `mark_query_edited`.
+    let outcome = input_edit::dispatch_key(
+        &key,
+        &mut app.global_search.query,
+        &mut app.global_search.cursor,
+    );
+    if outcome == input_edit::Outcome::Edited {
+        mark_query_edited(&mut app.global_search);
     }
 }
 

--- a/src/graph_branch_picker.rs
+++ b/src/graph_branch_picker.rs
@@ -1,0 +1,450 @@
+//! `b` branch picker for the Graph tab.
+//!
+//! Overlay that lets the user restrict the commit graph to a single
+//! local or remote-tracking branch. Modeled on `hosts_picker` — a
+//! filter input on top of a scrolling list, plus a `[ All refs ]`
+//! sentinel row that resets the scope to the default and a "recent"
+//! section seeded from `GitGraphState::recent_branches`.
+
+use ratatui::layout::Rect;
+
+use crate::git::{GraphScope, RefLabel};
+use std::collections::HashMap;
+
+/// Soft cap for how many branches we render below the recents list.
+/// Big monorepos can have thousands of remote branches and the picker
+/// only loses signal at that scale — the filter input narrows things
+/// fast enough that a cap on the rendered list keeps us out of the
+/// "10,000-row Vec" trap on every redraw.
+pub const MAX_BRANCH_ROWS: usize = 500;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BranchKind {
+    Local,
+    Remote,
+}
+
+/// One selectable branch row.
+#[derive(Debug, Clone)]
+pub struct BranchEntry {
+    /// Fully-qualified ref name (`refs/heads/main`).
+    pub full_ref: String,
+    /// User-facing label (`main`, `origin/feature/x`).
+    pub display: String,
+    pub kind: BranchKind,
+    /// Whether HEAD currently points at this branch.
+    pub is_head: bool,
+}
+
+/// Picker-list row in render order. `AllRefs` is the sentinel; recents
+/// come from MRU prefs; locals / remotes are alphabetised.
+#[derive(Debug, Clone)]
+pub enum BranchPickerRow {
+    AllRefs,
+    Recent(BranchEntry),
+    Branch(BranchEntry),
+}
+
+impl BranchPickerRow {
+    /// What scope this row selects when the user presses Enter.
+    pub fn to_scope(&self) -> GraphScope {
+        match self {
+            BranchPickerRow::AllRefs => GraphScope::AllRefs,
+            BranchPickerRow::Recent(b) | BranchPickerRow::Branch(b) => {
+                GraphScope::Branch(b.full_ref.clone())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct GraphBranchPickerState {
+    pub active: bool,
+    /// All branches derived once from `git_graph.ref_map` when the
+    /// picker opens. Stored sorted (locals first, then remotes,
+    /// alphabetised within each group).
+    pub all_branches: Vec<BranchEntry>,
+    /// Recents as fully-qualified refs (newest first). Filtered against
+    /// `all_branches` so a deleted recent silently disappears from the
+    /// rendered list.
+    pub recent: Vec<String>,
+    pub filter: String,
+    /// Byte offset into `filter`. Always on a UTF-8 char boundary.
+    /// Maintained by [`crate::input_edit`] alongside `filter` so the
+    /// caret survives word-motion / word-delete chords correctly.
+    pub cursor: usize,
+    pub selected_idx: usize,
+    pub last_popup_area: Option<Rect>,
+}
+
+impl GraphBranchPickerState {
+    /// Prep state from the cached `ref_map` and recents and activate
+    /// the overlay. Idempotent — re-opening just resets filter +
+    /// selection so the user always lands at the top with no leftover
+    /// query.
+    pub fn open(
+        &mut self,
+        ref_map: &HashMap<String, Vec<RefLabel>>,
+        recent: Vec<String>,
+        current_scope: &GraphScope,
+    ) {
+        self.all_branches = collect_branches(ref_map);
+        self.recent = recent;
+        self.filter.clear();
+        self.cursor = 0;
+        // Land on whatever row matches the active scope so the picker
+        // is "where you are" by default — pressing Esc cancels with no
+        // surprise, and Enter is a no-op rebuild rather than an
+        // accidental change.
+        self.selected_idx = self
+            .visible_rows()
+            .iter()
+            .position(|row| match (row, current_scope) {
+                (BranchPickerRow::AllRefs, GraphScope::AllRefs) => true,
+                (BranchPickerRow::Recent(b), GraphScope::Branch(s))
+                | (BranchPickerRow::Branch(b), GraphScope::Branch(s)) => b.full_ref == *s,
+                _ => false,
+            })
+            .unwrap_or(0);
+        self.active = true;
+    }
+
+    pub fn close(&mut self) {
+        self.active = false;
+        self.filter.clear();
+        self.cursor = 0;
+        self.selected_idx = 0;
+        self.last_popup_area = None;
+    }
+
+    /// Apply the current filter against AllRefs + recents + branches.
+    /// `AllRefs` always renders when the filter is empty or matches
+    /// the literal "all" — gives the user a deterministic way back to
+    /// the default scope.
+    pub fn visible_rows(&self) -> Vec<BranchPickerRow> {
+        let mut out: Vec<BranchPickerRow> = Vec::new();
+        let f = self.filter.to_ascii_lowercase();
+
+        // Sentinel is shown ONLY on the empty filter. Substring /
+        // prefix matching against literal labels turned out to be a
+        // footgun: common letters (`r`, `e`, `f`, `s`, space) keep
+        // AllRefs visible at row 0 while every keystroke also resets
+        // `selected_idx` to 0 — pressing Enter mid-typing would
+        // commit AllRefs instead of the branch the user was
+        // filtering toward. Once the user has typed anything, they
+        // can clearly only be looking for a branch; cancel out with
+        // Backspace or Esc to get back to AllRefs.
+        if f.is_empty() {
+            out.push(BranchPickerRow::AllRefs);
+        }
+
+        let recent_set: std::collections::HashSet<&str> =
+            self.recent.iter().map(String::as_str).collect();
+
+        for full in &self.recent {
+            // Drop recents that point at a branch no longer in the
+            // ref_map (deleted upstream). They'll silently fall off
+            // the list rather than waste a row.
+            let Some(entry) = self
+                .all_branches
+                .iter()
+                .find(|b| b.full_ref == *full)
+                .cloned()
+            else {
+                continue;
+            };
+            if f.is_empty() || entry.display.to_ascii_lowercase().contains(&f) {
+                out.push(BranchPickerRow::Recent(entry));
+            }
+        }
+
+        let mut shown = 0usize;
+        for entry in &self.all_branches {
+            if recent_set.contains(entry.full_ref.as_str()) {
+                continue;
+            }
+            if !(f.is_empty() || entry.display.to_ascii_lowercase().contains(&f)) {
+                continue;
+            }
+            out.push(BranchPickerRow::Branch(entry.clone()));
+            shown += 1;
+            if shown >= MAX_BRANCH_ROWS {
+                break;
+            }
+        }
+
+        out
+    }
+
+    pub fn confirm(&self) -> Option<GraphScope> {
+        self.visible_rows()
+            .get(self.selected_idx)
+            .map(BranchPickerRow::to_scope)
+    }
+
+    pub fn move_selection(&mut self, delta: i32) {
+        let rows = self.visible_rows();
+        if rows.is_empty() {
+            self.selected_idx = 0;
+            return;
+        }
+        let last = rows.len() as i32 - 1;
+        let next = (self.selected_idx as i32 + delta).clamp(0, last);
+        self.selected_idx = next as usize;
+    }
+}
+
+/// Flatten a ref_map (OID → labels) into the picker's branch list.
+/// Local branches first (alphabetised), then remote-tracking branches
+/// (alphabetised). Tags + HEAD don't get rows — HEAD is annotated on
+/// whichever local row matches.
+pub fn collect_branches(ref_map: &HashMap<String, Vec<RefLabel>>) -> Vec<BranchEntry> {
+    let mut locals: Vec<BranchEntry> = Vec::new();
+    let mut remotes: Vec<BranchEntry> = Vec::new();
+
+    let mut head_local: Option<String> = None;
+    for labels in ref_map.values() {
+        if labels.iter().any(|l| matches!(l, RefLabel::Head)) {
+            for label in labels {
+                if let RefLabel::Branch(name) = label {
+                    head_local = Some(name.clone());
+                    break;
+                }
+            }
+        }
+    }
+
+    for labels in ref_map.values() {
+        for label in labels {
+            match label {
+                RefLabel::Branch(name) => locals.push(BranchEntry {
+                    full_ref: format!("refs/heads/{name}"),
+                    display: name.clone(),
+                    kind: BranchKind::Local,
+                    is_head: head_local.as_deref() == Some(name.as_str()),
+                }),
+                RefLabel::RemoteBranch(name) => remotes.push(BranchEntry {
+                    full_ref: format!("refs/remotes/{name}"),
+                    display: name.clone(),
+                    kind: BranchKind::Remote,
+                    is_head: false,
+                }),
+                _ => {}
+            }
+        }
+    }
+
+    locals.sort_by(|a, b| a.display.cmp(&b.display));
+    remotes.sort_by(|a, b| a.display.cmp(&b.display));
+    locals.append(&mut remotes);
+    locals
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ref_map(pairs: &[(&str, &[RefLabel])]) -> HashMap<String, Vec<RefLabel>> {
+        pairs
+            .iter()
+            .map(|(oid, labels)| (oid.to_string(), labels.to_vec()))
+            .collect()
+    }
+
+    #[test]
+    fn collect_branches_sorts_and_flags_head() {
+        let map = ref_map(&[
+            (
+                "aaaa",
+                &[
+                    RefLabel::Head,
+                    RefLabel::Branch("main".into()),
+                    RefLabel::Branch("dev".into()),
+                ],
+            ),
+            ("bbbb", &[RefLabel::Branch("feature".into())]),
+            (
+                "cccc",
+                &[
+                    RefLabel::RemoteBranch("origin/main".into()),
+                    RefLabel::Tag("v1".into()),
+                ],
+            ),
+        ]);
+        let branches = collect_branches(&map);
+        // Locals alphabetised, then remotes. HEAD points at "main".
+        assert_eq!(
+            branches.iter().map(|b| b.display.as_str()).collect::<Vec<_>>(),
+            vec!["dev", "feature", "main", "origin/main"]
+        );
+        assert!(branches.iter().find(|b| b.display == "main").unwrap().is_head);
+        assert!(!branches.iter().find(|b| b.display == "dev").unwrap().is_head);
+    }
+
+    #[test]
+    fn visible_rows_starts_with_all_refs_and_filters_others() {
+        let mut s = GraphBranchPickerState::default();
+        s.open(
+            &ref_map(&[
+                ("aaaa", &[RefLabel::Branch("main".into())]),
+                ("bbbb", &[RefLabel::Branch("dev".into())]),
+            ]),
+            vec![],
+            &GraphScope::AllRefs,
+        );
+        let rows = s.visible_rows();
+        assert!(matches!(rows[0], BranchPickerRow::AllRefs));
+        s.filter = "mai".into();
+        let rows = s.visible_rows();
+        assert!(matches!(
+            rows.last().unwrap(),
+            BranchPickerRow::Branch(b) if b.display == "main"
+        ));
+    }
+
+    #[test]
+    fn open_resets_cursor_to_zero() {
+        // Make sure re-opening the picker after a previous filter
+        // leaves the cursor at the start, matching the cleared filter.
+        let mut s = GraphBranchPickerState::default();
+        s.cursor = 7;
+        s.filter = "stale-from-last-time".into();
+        s.open(
+            &ref_map(&[("a", &[RefLabel::Branch("main".into())])]),
+            vec![],
+            &GraphScope::AllRefs,
+        );
+        assert_eq!(s.cursor, 0);
+        assert!(s.filter.is_empty());
+    }
+
+    #[test]
+    fn dispatch_key_drives_filter_via_input_edit() {
+        // Sanity that the shared input_edit primitives operate on the
+        // picker's filter + cursor pair. We don't exhaustively test
+        // editor keys here (input_edit::tests already covers those) —
+        // just confirm the wiring round-trips for an insert + Ctrl+U
+        // clear, and that the cursor advances past UTF-8 chars cleanly.
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut s = GraphBranchPickerState::default();
+        s.open(
+            &ref_map(&[("a", &[RefLabel::Branch("main".into())])]),
+            vec![],
+            &GraphScope::AllRefs,
+        );
+
+        // Insert "ab"
+        for c in ['a', 'b'] {
+            let outcome = crate::input_edit::dispatch_key(
+                &KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE),
+                &mut s.filter,
+                &mut s.cursor,
+            );
+            assert_eq!(outcome, crate::input_edit::Outcome::Edited);
+        }
+        assert_eq!(s.filter, "ab");
+        assert_eq!(s.cursor, 2);
+
+        // Ctrl+U wipes the line via input_edit's editor vocabulary.
+        let outcome = crate::input_edit::dispatch_key(
+            &KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL),
+            &mut s.filter,
+            &mut s.cursor,
+        );
+        assert_eq!(outcome, crate::input_edit::Outcome::Edited);
+        assert!(s.filter.is_empty());
+        assert_eq!(s.cursor, 0);
+
+        // Insert a CJK codepoint, then confirm the cursor lands on a
+        // valid char boundary (3-byte char advances cursor by 3).
+        let outcome = crate::input_edit::dispatch_key(
+            &KeyEvent::new(KeyCode::Char('你'), KeyModifiers::NONE),
+            &mut s.filter,
+            &mut s.cursor,
+        );
+        assert_eq!(outcome, crate::input_edit::Outcome::Edited);
+        assert_eq!(s.filter, "你");
+        assert_eq!(s.cursor, 3);
+    }
+
+    #[test]
+    fn sentinel_hidden_once_user_starts_typing() {
+        // Regression: previously the sentinel used substring matching
+        // against literal labels ("all refs"), so common letters like
+        // 'r', 'e', 'f', 's', space kept it at row 0 even mid-typing.
+        // Combined with `selected_idx` resetting to 0 on each
+        // keystroke, that meant Enter mid-typing committed AllRefs
+        // instead of the branch the user was filtering toward.
+        let mut s = GraphBranchPickerState::default();
+        s.open(
+            &ref_map(&[
+                ("aaaa", &[RefLabel::Branch("release/v1".into())]),
+                ("bbbb", &[RefLabel::Branch("main".into())]),
+            ]),
+            vec![],
+            &GraphScope::AllRefs,
+        );
+        // Empty filter: sentinel visible at top.
+        assert!(matches!(s.visible_rows()[0], BranchPickerRow::AllRefs));
+
+        // Any non-empty filter, even a single letter that "happens to
+        // be in 'all refs'", must drop the sentinel.
+        for f in ["a", "r", "e", "f", "s", " ", "all"] {
+            s.filter = f.to_string();
+            let rows = s.visible_rows();
+            assert!(
+                !rows.iter().any(|r| matches!(r, BranchPickerRow::AllRefs)),
+                "filter {f:?} unexpectedly kept the AllRefs sentinel visible"
+            );
+        }
+    }
+
+    #[test]
+    fn recents_render_above_branches_and_dedupe() {
+        let mut s = GraphBranchPickerState::default();
+        s.open(
+            &ref_map(&[
+                ("a", &[RefLabel::Branch("main".into())]),
+                ("b", &[RefLabel::Branch("feature".into())]),
+            ]),
+            vec!["refs/heads/main".to_string()],
+            &GraphScope::AllRefs,
+        );
+        let rows = s.visible_rows();
+        // [AllRefs, Recent(main), Branch(feature)]
+        assert!(matches!(rows[0], BranchPickerRow::AllRefs));
+        assert!(matches!(&rows[1], BranchPickerRow::Recent(e) if e.display == "main"));
+        assert!(matches!(&rows[2], BranchPickerRow::Branch(e) if e.display == "feature"));
+    }
+
+    #[test]
+    fn confirm_returns_scope_for_selected_row() {
+        let mut s = GraphBranchPickerState::default();
+        s.open(
+            &ref_map(&[("a", &[RefLabel::Branch("main".into())])]),
+            vec![],
+            &GraphScope::AllRefs,
+        );
+        // Row 0 is AllRefs, row 1 is "main".
+        s.selected_idx = 1;
+        assert_eq!(
+            s.confirm(),
+            Some(GraphScope::Branch("refs/heads/main".into()))
+        );
+        s.selected_idx = 0;
+        assert_eq!(s.confirm(), Some(GraphScope::AllRefs));
+    }
+
+    #[test]
+    fn stale_recent_silently_disappears() {
+        let mut s = GraphBranchPickerState::default();
+        s.open(
+            &ref_map(&[("a", &[RefLabel::Branch("main".into())])]),
+            vec!["refs/heads/ghost".to_string()],
+            &GraphScope::AllRefs,
+        );
+        let rows = s.visible_rows();
+        // Only AllRefs + main; ghost dropped.
+        assert_eq!(rows.len(), 2);
+    }
+}

--- a/src/graph_branch_picker.rs
+++ b/src/graph_branch_picker.rs
@@ -70,18 +70,27 @@ pub struct GraphBranchPickerState {
     /// `all_branches` so a deleted recent silently disappears from the
     /// rendered list.
     pub recent: Vec<String>,
-    /// Memoised result of [`visible_rows`]. The cache key is the
-    /// lowercased filter string — `all_branches` / `recent` only
-    /// change at `open()` time (which calls `invalidate_cache`), so
-    /// the filter alone is enough to distinguish identical recomputes.
+    /// Memoised result of [`visible_rows`].
+    ///
+    /// Cache key is `(lowercased_filter, all_branches.len(),
+    /// recent.len())`. The two length fields guard against the case
+    /// where a future caller mutates `all_branches` or `recent` in
+    /// place without going through `open()` / `close()` — any
+    /// push/pop changes the length and forces a recompute. Identical
+    /// length but different content (e.g. swap one entry for another
+    /// of the same kind) would still hit a stale cache, but that
+    /// scenario has no current writer in the codebase.
     ///
     /// `RefCell` so `visible_rows(&self)` can populate it lazily
     /// without forcing every caller to a `&mut` receiver. The
     /// alternative — recomputing N keystrokes/second on a 2k-branch
     /// monorepo — would allocate ~60k Strings per second of held
     /// autorepeat.
-    cache: std::cell::RefCell<Option<(String, Vec<BranchPickerRow>)>>,
+    cache: std::cell::RefCell<Option<(CacheKey, Vec<BranchPickerRow>)>>,
 }
+
+/// Composite key for [`GraphBranchPickerState::cache`].
+type CacheKey = (String, usize, usize);
 
 impl GraphBranchPickerState {
     /// Prep state from the cached `ref_map` and recents and activate
@@ -130,12 +139,14 @@ impl GraphBranchPickerState {
     /// whenever the filter shifts.
     pub fn visible_rows(&self) -> Vec<BranchPickerRow> {
         let f = self.core.filter.to_ascii_lowercase();
+        let key: CacheKey = (f, self.all_branches.len(), self.recent.len());
         // Cache hit?
-        if let Some((cached_filter, cached_rows)) = self.cache.borrow().as_ref() {
-            if cached_filter == &f {
+        if let Some((cached_key, cached_rows)) = self.cache.borrow().as_ref() {
+            if cached_key == &key {
                 return cached_rows.clone();
             }
         }
+        let f: &str = key.0.as_str();
         let mut out: Vec<BranchPickerRow> = Vec::new();
 
         // Sentinel is shown ONLY on the empty filter. Substring /
@@ -166,7 +177,7 @@ impl GraphBranchPickerState {
             else {
                 continue;
             };
-            if f.is_empty() || entry.display.to_ascii_lowercase().contains(&f) {
+            if f.is_empty() || entry.display.to_ascii_lowercase().contains(f) {
                 out.push(BranchPickerRow::Recent(entry));
             }
         }
@@ -176,7 +187,7 @@ impl GraphBranchPickerState {
             if recent_set.contains(entry.full_ref.as_str()) {
                 continue;
             }
-            if !(f.is_empty() || entry.display.to_ascii_lowercase().contains(&f)) {
+            if !(f.is_empty() || entry.display.to_ascii_lowercase().contains(f)) {
                 continue;
             }
             out.push(BranchPickerRow::Branch(entry.clone()));
@@ -188,7 +199,7 @@ impl GraphBranchPickerState {
 
         // Populate cache. Borrow is short-lived; `Vec::clone` is a
         // single heap-block memcpy of small enums (~24 bytes each).
-        *self.cache.borrow_mut() = Some((f, out.clone()));
+        *self.cache.borrow_mut() = Some((key, out.clone()));
         out
     }
 

--- a/src/graph_branch_picker.rs
+++ b/src/graph_branch_picker.rs
@@ -70,6 +70,12 @@ pub struct GraphBranchPickerState {
     /// `all_branches` so a deleted recent silently disappears from the
     /// rendered list.
     pub recent: Vec<String>,
+    /// First visible row in the list — read by the panel renderer to
+    /// scroll the viewport when `selected_idx` leaves the window.
+    /// Without this, big monorepos (hundreds of branches > visible
+    /// list_h) leave the user's selection rendered off-screen on
+    /// Down-key autorepeat. Reset to 0 by `open()` / `close()`.
+    pub scroll: usize,
     /// Memoised result of [`visible_rows`].
     ///
     /// Cache key is `(lowercased_filter, all_branches.len(),
@@ -106,6 +112,7 @@ impl GraphBranchPickerState {
         self.all_branches = collect_branches(ref_map);
         self.recent = recent;
         self.cache.get_mut().take(); // ref_map / recent changed — drop cache
+        self.scroll = 0;
         self.core.open();
         // Land on whatever row matches the active scope so the picker
         // is "where you are" by default — pressing Esc cancels with no
@@ -125,7 +132,18 @@ impl GraphBranchPickerState {
 
     pub fn close(&mut self) {
         self.cache.get_mut().take();
+        self.scroll = 0;
         self.core.close();
+    }
+
+    /// Drop the memoised [`visible_rows`] result. Call this if any
+    /// future writer mutates `all_branches` or `recent` IN PLACE
+    /// (e.g. swapping one entry for another of the same kind, or
+    /// editing a `BranchEntry` field). Push/pop changes are already
+    /// covered by the `.len()` components of the cache key, but
+    /// content-only mutations would otherwise return stale rows.
+    pub fn mark_dirty(&mut self) {
+        self.cache.get_mut().take();
     }
 
     /// Apply the current filter against AllRefs + recents + branches.

--- a/src/graph_branch_picker.rs
+++ b/src/graph_branch_picker.rs
@@ -70,6 +70,17 @@ pub struct GraphBranchPickerState {
     /// `all_branches` so a deleted recent silently disappears from the
     /// rendered list.
     pub recent: Vec<String>,
+    /// Memoised result of [`visible_rows`]. The cache key is the
+    /// lowercased filter string — `all_branches` / `recent` only
+    /// change at `open()` time (which calls `invalidate_cache`), so
+    /// the filter alone is enough to distinguish identical recomputes.
+    ///
+    /// `RefCell` so `visible_rows(&self)` can populate it lazily
+    /// without forcing every caller to a `&mut` receiver. The
+    /// alternative — recomputing N keystrokes/second on a 2k-branch
+    /// monorepo — would allocate ~60k Strings per second of held
+    /// autorepeat.
+    cache: std::cell::RefCell<Option<(String, Vec<BranchPickerRow>)>>,
 }
 
 impl GraphBranchPickerState {
@@ -85,6 +96,7 @@ impl GraphBranchPickerState {
     ) {
         self.all_branches = collect_branches(ref_map);
         self.recent = recent;
+        self.cache.get_mut().take(); // ref_map / recent changed — drop cache
         self.core.open();
         // Land on whatever row matches the active scope so the picker
         // is "where you are" by default — pressing Esc cancels with no
@@ -103,16 +115,28 @@ impl GraphBranchPickerState {
     }
 
     pub fn close(&mut self) {
+        self.cache.get_mut().take();
         self.core.close();
     }
 
     /// Apply the current filter against AllRefs + recents + branches.
-    /// `AllRefs` always renders when the filter is empty or matches
-    /// the literal "all" — gives the user a deterministic way back to
-    /// the default scope.
+    /// `AllRefs` always renders when the filter is empty.
+    ///
+    /// Memoised via [`Self::cache`] keyed on the lowercased filter
+    /// string — autorepeat on j/k holding 30Hz used to reallocate a
+    /// HashSet + N String::to_ascii_lowercase + up to MAX_BRANCH_ROWS
+    /// `BranchEntry` clones per tick. The cache is invalidated on
+    /// `open` / `close` (data inputs change) and inside this method
+    /// whenever the filter shifts.
     pub fn visible_rows(&self) -> Vec<BranchPickerRow> {
-        let mut out: Vec<BranchPickerRow> = Vec::new();
         let f = self.core.filter.to_ascii_lowercase();
+        // Cache hit?
+        if let Some((cached_filter, cached_rows)) = self.cache.borrow().as_ref() {
+            if cached_filter == &f {
+                return cached_rows.clone();
+            }
+        }
+        let mut out: Vec<BranchPickerRow> = Vec::new();
 
         // Sentinel is shown ONLY on the empty filter. Substring /
         // prefix matching against literal labels turned out to be a
@@ -162,6 +186,9 @@ impl GraphBranchPickerState {
             }
         }
 
+        // Populate cache. Borrow is short-lived; `Vec::clone` is a
+        // single heap-block memcpy of small enums (~24 bytes each).
+        *self.cache.borrow_mut() = Some((f, out.clone()));
         out
     }
 

--- a/src/graph_branch_picker.rs
+++ b/src/graph_branch_picker.rs
@@ -6,8 +6,6 @@
 //! sentinel row that resets the scope to the default and a "recent"
 //! section seeded from `GitGraphState::recent_branches`.
 
-use ratatui::layout::Rect;
-
 use crate::git::{GraphScope, RefLabel};
 use std::collections::HashMap;
 
@@ -59,7 +57,11 @@ impl BranchPickerRow {
 
 #[derive(Debug, Default)]
 pub struct GraphBranchPickerState {
-    pub active: bool,
+    /// Shared overlay scaffolding (`active`, `filter`, `cursor`,
+    /// `selected_idx`, `last_popup_area`). Edits route through
+    /// [`crate::picker_core::PickerCore::dispatch_key`]; see
+    /// `input::handle_key_graph_branch_picker` for the call site.
+    pub core: crate::picker_core::PickerCore,
     /// All branches derived once from `git_graph.ref_map` when the
     /// picker opens. Stored sorted (locals first, then remotes,
     /// alphabetised within each group).
@@ -68,13 +70,6 @@ pub struct GraphBranchPickerState {
     /// `all_branches` so a deleted recent silently disappears from the
     /// rendered list.
     pub recent: Vec<String>,
-    pub filter: String,
-    /// Byte offset into `filter`. Always on a UTF-8 char boundary.
-    /// Maintained by [`crate::input_edit`] alongside `filter` so the
-    /// caret survives word-motion / word-delete chords correctly.
-    pub cursor: usize,
-    pub selected_idx: usize,
-    pub last_popup_area: Option<Rect>,
 }
 
 impl GraphBranchPickerState {
@@ -90,13 +85,12 @@ impl GraphBranchPickerState {
     ) {
         self.all_branches = collect_branches(ref_map);
         self.recent = recent;
-        self.filter.clear();
-        self.cursor = 0;
+        self.core.open();
         // Land on whatever row matches the active scope so the picker
         // is "where you are" by default — pressing Esc cancels with no
         // surprise, and Enter is a no-op rebuild rather than an
         // accidental change.
-        self.selected_idx = self
+        self.core.selected_idx = self
             .visible_rows()
             .iter()
             .position(|row| match (row, current_scope) {
@@ -106,15 +100,10 @@ impl GraphBranchPickerState {
                 _ => false,
             })
             .unwrap_or(0);
-        self.active = true;
     }
 
     pub fn close(&mut self) {
-        self.active = false;
-        self.filter.clear();
-        self.cursor = 0;
-        self.selected_idx = 0;
-        self.last_popup_area = None;
+        self.core.close();
     }
 
     /// Apply the current filter against AllRefs + recents + branches.
@@ -123,7 +112,7 @@ impl GraphBranchPickerState {
     /// the default scope.
     pub fn visible_rows(&self) -> Vec<BranchPickerRow> {
         let mut out: Vec<BranchPickerRow> = Vec::new();
-        let f = self.filter.to_ascii_lowercase();
+        let f = self.core.filter.to_ascii_lowercase();
 
         // Sentinel is shown ONLY on the empty filter. Substring /
         // prefix matching against literal labels turned out to be a
@@ -178,19 +167,18 @@ impl GraphBranchPickerState {
 
     pub fn confirm(&self) -> Option<GraphScope> {
         self.visible_rows()
-            .get(self.selected_idx)
+            .get(self.core.selected_idx)
             .map(BranchPickerRow::to_scope)
     }
 
+    /// Move the row cursor by `delta`, clamped against the current
+    /// `visible_rows()` count. Thin wrapper around the shared
+    /// [`crate::picker_core::PickerCore::move_selection`] that handles
+    /// the row-count lookup so callers (mouse wheel, etc.) don't have
+    /// to recompute `visible_rows()` themselves.
     pub fn move_selection(&mut self, delta: i32) {
-        let rows = self.visible_rows();
-        if rows.is_empty() {
-            self.selected_idx = 0;
-            return;
-        }
-        let last = rows.len() as i32 - 1;
-        let next = (self.selected_idx as i32 + delta).clamp(0, last);
-        self.selected_idx = next as usize;
+        let visible_count = self.visible_rows().len();
+        self.core.move_selection(visible_count, delta);
     }
 }
 
@@ -294,7 +282,7 @@ mod tests {
         );
         let rows = s.visible_rows();
         assert!(matches!(rows[0], BranchPickerRow::AllRefs));
-        s.filter = "mai".into();
+        s.core.filter = "mai".into();
         let rows = s.visible_rows();
         assert!(matches!(
             rows.last().unwrap(),
@@ -307,15 +295,15 @@ mod tests {
         // Make sure re-opening the picker after a previous filter
         // leaves the cursor at the start, matching the cleared filter.
         let mut s = GraphBranchPickerState::default();
-        s.cursor = 7;
-        s.filter = "stale-from-last-time".into();
+        s.core.cursor = 7;
+        s.core.filter = "stale-from-last-time".into();
         s.open(
             &ref_map(&[("a", &[RefLabel::Branch("main".into())])]),
             vec![],
             &GraphScope::AllRefs,
         );
-        assert_eq!(s.cursor, 0);
-        assert!(s.filter.is_empty());
+        assert_eq!(s.core.cursor, 0);
+        assert!(s.core.filter.is_empty());
     }
 
     #[test]
@@ -337,34 +325,34 @@ mod tests {
         for c in ['a', 'b'] {
             let outcome = crate::input_edit::dispatch_key(
                 &KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE),
-                &mut s.filter,
-                &mut s.cursor,
+                &mut s.core.filter,
+                &mut s.core.cursor,
             );
             assert_eq!(outcome, crate::input_edit::Outcome::Edited);
         }
-        assert_eq!(s.filter, "ab");
-        assert_eq!(s.cursor, 2);
+        assert_eq!(s.core.filter, "ab");
+        assert_eq!(s.core.cursor, 2);
 
         // Ctrl+U wipes the line via input_edit's editor vocabulary.
         let outcome = crate::input_edit::dispatch_key(
             &KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL),
-            &mut s.filter,
-            &mut s.cursor,
+            &mut s.core.filter,
+            &mut s.core.cursor,
         );
         assert_eq!(outcome, crate::input_edit::Outcome::Edited);
-        assert!(s.filter.is_empty());
-        assert_eq!(s.cursor, 0);
+        assert!(s.core.filter.is_empty());
+        assert_eq!(s.core.cursor, 0);
 
         // Insert a CJK codepoint, then confirm the cursor lands on a
         // valid char boundary (3-byte char advances cursor by 3).
         let outcome = crate::input_edit::dispatch_key(
             &KeyEvent::new(KeyCode::Char('你'), KeyModifiers::NONE),
-            &mut s.filter,
-            &mut s.cursor,
+            &mut s.core.filter,
+            &mut s.core.cursor,
         );
         assert_eq!(outcome, crate::input_edit::Outcome::Edited);
-        assert_eq!(s.filter, "你");
-        assert_eq!(s.cursor, 3);
+        assert_eq!(s.core.filter, "你");
+        assert_eq!(s.core.cursor, 3);
     }
 
     #[test]
@@ -390,7 +378,7 @@ mod tests {
         // Any non-empty filter, even a single letter that "happens to
         // be in 'all refs'", must drop the sentinel.
         for f in ["a", "r", "e", "f", "s", " ", "all"] {
-            s.filter = f.to_string();
+            s.core.filter = f.to_string();
             let rows = s.visible_rows();
             assert!(
                 !rows.iter().any(|r| matches!(r, BranchPickerRow::AllRefs)),
@@ -426,12 +414,12 @@ mod tests {
             &GraphScope::AllRefs,
         );
         // Row 0 is AllRefs, row 1 is "main".
-        s.selected_idx = 1;
+        s.core.selected_idx = 1;
         assert_eq!(
             s.confirm(),
             Some(GraphScope::Branch("refs/heads/main".into()))
         );
-        s.selected_idx = 0;
+        s.core.selected_idx = 0;
         assert_eq!(s.confirm(), Some(GraphScope::AllRefs));
     }
 

--- a/src/graph_branch_picker.rs
+++ b/src/graph_branch_picker.rs
@@ -318,11 +318,26 @@ mod tests {
         let branches = collect_branches(&map);
         // Locals alphabetised, then remotes. HEAD points at "main".
         assert_eq!(
-            branches.iter().map(|b| b.display.as_str()).collect::<Vec<_>>(),
+            branches
+                .iter()
+                .map(|b| b.display.as_str())
+                .collect::<Vec<_>>(),
             vec!["dev", "feature", "main", "origin/main"]
         );
-        assert!(branches.iter().find(|b| b.display == "main").unwrap().is_head);
-        assert!(!branches.iter().find(|b| b.display == "dev").unwrap().is_head);
+        assert!(
+            branches
+                .iter()
+                .find(|b| b.display == "main")
+                .unwrap()
+                .is_head
+        );
+        assert!(
+            !branches
+                .iter()
+                .find(|b| b.display == "dev")
+                .unwrap()
+                .is_head
+        );
     }
 
     #[test]

--- a/src/hosts_picker.rs
+++ b/src/hosts_picker.rs
@@ -79,10 +79,16 @@ pub struct HostsPickerState {
     /// rendered in the "recent" section and omitted from the main list.
     pub recent: Vec<SshTarget>,
     pub filter: String,
+    /// Byte offset into `filter` (UTF-8 char boundary). Maintained by
+    /// [`crate::input_edit`] so word-motion / word-delete chords work
+    /// uniformly with the rest of the input fields.
+    pub filter_cursor: usize,
     pub selected_idx: usize,
     pub input_mode: InputMode,
     /// Raw buffer for the path input mode (typed `[user@]host[:path]`).
     pub path_buffer: String,
+    /// Byte offset into `path_buffer`. Same role as `filter_cursor`.
+    pub path_cursor: usize,
     pub last_popup_area: Option<Rect>,
 }
 
@@ -93,9 +99,11 @@ impl Default for HostsPickerState {
             all_hosts: Vec::new(),
             recent: Vec::new(),
             filter: String::new(),
+            filter_cursor: 0,
             selected_idx: 0,
             input_mode: InputMode::Search,
             path_buffer: String::new(),
+            path_cursor: 0,
             last_popup_area: None,
         }
     }
@@ -118,7 +126,9 @@ impl HostsPickerState {
         self.all_hosts = all_hosts;
         self.recent = recent;
         self.filter.clear();
+        self.filter_cursor = 0;
         self.path_buffer.clear();
+        self.path_cursor = 0;
         self.selected_idx = 0;
         self.input_mode = InputMode::Search;
         self.active = true;
@@ -127,7 +137,9 @@ impl HostsPickerState {
     pub fn close(&mut self) {
         self.active = false;
         self.filter.clear();
+        self.filter_cursor = 0;
         self.path_buffer.clear();
+        self.path_cursor = 0;
         self.input_mode = InputMode::Search;
         self.selected_idx = 0;
     }
@@ -139,6 +151,7 @@ impl HostsPickerState {
         // common "oh this alias isn't here, let me type it" path.
         if self.path_buffer.is_empty() {
             self.path_buffer = self.filter.clone();
+            self.path_cursor = self.path_buffer.len();
         }
     }
 

--- a/src/hosts_picker.rs
+++ b/src/hosts_picker.rs
@@ -6,8 +6,6 @@
 //! build a fresh `RemoteBackend` and swap the running `App` for a new
 //! one via the outer `'session:` loop.
 
-use ratatui::layout::Rect;
-
 use crate::hosts::HostEntry;
 
 /// Maximum number of recent hosts we persist in prefs. Anything beyond
@@ -72,39 +70,34 @@ impl SshTarget {
 }
 
 pub struct HostsPickerState {
-    pub active: bool,
+    /// Shared overlay scaffolding: `active`, `filter`, `cursor` (into
+    /// the filter buffer), `selected_idx`, `last_popup_area`. Hosts
+    /// picker has TWO single-line buffers (filter + path); only the
+    /// filter is part of PickerCore — `path_buffer` / `path_cursor`
+    /// stand alongside and are driven directly via
+    /// [`crate::input_edit::dispatch_key`] when `input_mode == Path`.
+    pub core: crate::picker_core::PickerCore,
     pub all_hosts: Vec<HostEntry>,
     /// Recent targets as declared by the user in prior sessions, in
     /// most-recent-first order. Duplicates against `all_hosts` are
     /// rendered in the "recent" section and omitted from the main list.
     pub recent: Vec<SshTarget>,
-    pub filter: String,
-    /// Byte offset into `filter` (UTF-8 char boundary). Maintained by
-    /// [`crate::input_edit`] so word-motion / word-delete chords work
-    /// uniformly with the rest of the input fields.
-    pub filter_cursor: usize,
-    pub selected_idx: usize,
     pub input_mode: InputMode,
     /// Raw buffer for the path input mode (typed `[user@]host[:path]`).
     pub path_buffer: String,
-    /// Byte offset into `path_buffer`. Same role as `filter_cursor`.
+    /// Byte offset into `path_buffer`.
     pub path_cursor: usize,
-    pub last_popup_area: Option<Rect>,
 }
 
 impl Default for HostsPickerState {
     fn default() -> Self {
         Self {
-            active: false,
+            core: crate::picker_core::PickerCore::default(),
             all_hosts: Vec::new(),
             recent: Vec::new(),
-            filter: String::new(),
-            filter_cursor: 0,
-            selected_idx: 0,
             input_mode: InputMode::Search,
             path_buffer: String::new(),
             path_cursor: 0,
-            last_popup_area: None,
         }
     }
 }
@@ -125,23 +118,17 @@ impl HostsPickerState {
     pub fn open(&mut self, all_hosts: Vec<HostEntry>, recent: Vec<SshTarget>) {
         self.all_hosts = all_hosts;
         self.recent = recent;
-        self.filter.clear();
-        self.filter_cursor = 0;
         self.path_buffer.clear();
         self.path_cursor = 0;
-        self.selected_idx = 0;
         self.input_mode = InputMode::Search;
-        self.active = true;
+        self.core.open();
     }
 
     pub fn close(&mut self) {
-        self.active = false;
-        self.filter.clear();
-        self.filter_cursor = 0;
         self.path_buffer.clear();
         self.path_cursor = 0;
         self.input_mode = InputMode::Search;
-        self.selected_idx = 0;
+        self.core.close();
     }
 
     pub fn enter_path_mode(&mut self) {
@@ -150,7 +137,7 @@ impl HostsPickerState {
         // typed so they don't lose it. Filter-as-prefix covers the
         // common "oh this alias isn't here, let me type it" path.
         if self.path_buffer.is_empty() {
-            self.path_buffer = self.filter.clone();
+            self.path_buffer = self.core.filter.clone();
             self.path_cursor = self.path_buffer.len();
         }
     }
@@ -162,7 +149,7 @@ impl HostsPickerState {
     /// rendering.
     pub fn visible_rows(&self) -> Vec<PickerRow> {
         let mut out: Vec<PickerRow> = Vec::new();
-        let f = self.filter.to_ascii_lowercase();
+        let f = self.core.filter.to_ascii_lowercase();
 
         let recent_aliases: std::collections::HashSet<String> = self
             .recent
@@ -205,7 +192,7 @@ impl HostsPickerState {
             }
             InputMode::Search => {
                 let rows = self.visible_rows();
-                rows.get(self.selected_idx).map(|row| match row {
+                rows.get(self.core.selected_idx).map(|row| match row {
                     PickerRow::Recent(t) => t.clone(),
                     PickerRow::Entry(h) => SshTarget {
                         host: h.alias.clone(),
@@ -219,14 +206,8 @@ impl HostsPickerState {
     /// Bump the selection, clamped to the current row count. `delta` is
     /// signed so callers can use `+1` / `-1` without a separate method.
     pub fn move_selection(&mut self, delta: i32) {
-        let rows = self.visible_rows();
-        if rows.is_empty() {
-            self.selected_idx = 0;
-            return;
-        }
-        let last = rows.len() as i32 - 1;
-        let next = (self.selected_idx as i32 + delta).clamp(0, last);
-        self.selected_idx = next as usize;
+        let visible_count = self.visible_rows().len();
+        self.core.move_selection(visible_count, delta);
     }
 }
 
@@ -319,7 +300,7 @@ mod tests {
     fn filter_is_case_insensitive_substring() {
         let mut s = HostsPickerState::default();
         s.open(vec![h("ProdDb"), h("staging"), h("dev-a")], vec![]);
-        s.filter = "db".into();
+        s.core.filter = "db".into();
         let rows = s.visible_rows();
         assert_eq!(rows.len(), 1);
         assert!(matches!(rows[0], PickerRow::Entry(ref e) if e.alias == "ProdDb"));
@@ -361,7 +342,7 @@ mod tests {
     fn confirm_in_search_mode_returns_selected_entry() {
         let mut s = HostsPickerState::default();
         s.open(vec![h("one"), h("two")], vec![]);
-        s.selected_idx = 1;
+        s.core.selected_idx = 1;
         let t = s.confirm().unwrap();
         assert_eq!(t.host, "two");
         assert_eq!(t.path, ".");
@@ -372,9 +353,9 @@ mod tests {
         let mut s = HostsPickerState::default();
         s.open(vec![h("a"), h("b"), h("c")], vec![]);
         s.move_selection(10);
-        assert_eq!(s.selected_idx, 2);
+        assert_eq!(s.core.selected_idx, 2);
         s.move_selection(-99);
-        assert_eq!(s.selected_idx, 0);
+        assert_eq!(s.core.selected_idx, 0);
     }
 
     #[test]

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -657,6 +657,28 @@ pub fn push_failed_toast(e: &str) -> String {
     }
 }
 
+/// Toast shown by the Graph tab when the user's persisted branch scope
+/// resolves to a ref that no longer exists. Surfaces the human-readable
+/// branch shorthand and tells the user we fell back to the default
+/// "all refs" view.
+pub fn graph_scope_stale_branch_toast(name: &str) -> String {
+    match lang() {
+        Lang::Zh => format!("分支 '{name}' 已不存在 — 切回显示全部 refs。"),
+        Lang::En => format!("Branch '{name}' is gone — showing all refs."),
+    }
+}
+
+/// Toast shown when the user opens the Graph branch picker before the
+/// first commit-graph load has populated `ref_map`. Without this guard
+/// the picker would only offer `[ All refs ]` and accidentally
+/// overwrite the user's persisted Branch scope.
+pub fn graph_picker_not_ready_toast() -> &'static str {
+    match lang() {
+        Lang::Zh => "分支列表加载中,请稍候…",
+        Lang::En => "Branch list still loading — try again in a moment.",
+    }
+}
+
 /// Toast variant for commit failure. Commit errors are often multi-line
 /// (hook output, rejected commit-msg template, etc.); the toast picks
 /// the first non-empty line so it stays readable next to other status

--- a/src/input.rs
+++ b/src/input.rs
@@ -1488,13 +1488,19 @@ fn handle_key_git_commit(key: KeyEvent, app: &mut App, ctrl: bool, alt: bool) ->
     if app.active_panel != Panel::Files || !app.git_status.commit_editing {
         return false;
     }
-    // Phase 1: commit-box-specific shortcuts.
+    let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+    // Phase 1: commit-box-specific shortcuts. Strict `Ctrl+Enter`
+    // (no alt, no shift) is the only commit-submit chord; the `!alt`
+    // guard defends against Linux WMs forwarding Ctrl+Alt+Enter and
+    // `!shift` defends against kitty-style enhanced keyboard
+    // protocols that report Shift+Ctrl+Enter as a distinct chord.
+    // Shift+Enter alone is left to Phase 2 (newline insert).
     match key.code {
         KeyCode::Esc => {
             app.git_status.commit_editing = false;
             return true;
         }
-        KeyCode::Enter if ctrl && !alt => {
+        KeyCode::Enter if ctrl && !alt && !shift => {
             app.run_commit();
             return true;
         }
@@ -1502,14 +1508,32 @@ fn handle_key_git_commit(key: KeyEvent, app: &mut App, ctrl: bool, alt: bool) ->
     }
 
     // Phase 2: shared multi-line text-input dispatch. Forward
-    // `Unhandled` to the caller as "not consumed" so unknown keys
-    // (PageUp / Shift+Arrow / F-keys / …) can flow up to the outer
-    // Git-tab handler instead of being silently swallowed mid-edit.
+    // `Unhandled` to the caller as "not consumed" so unknown
+    // navigation keys (PageUp / Shift+Arrow / F-keys / …) can flow
+    // up to the outer Git-tab handler instead of being silently
+    // swallowed mid-edit.
+    //
+    // EXCEPT: Ctrl+letter and Alt+letter chords are deliberately
+    // swallowed even on Unhandled, because the outer Git handler's
+    // letter arms (`Char('s')` → stage, `Char('r')` → refresh,
+    // `Char('e') | Enter` → open in $EDITOR, etc. at lines ~1603-1645)
+    // are NOT modifier-gated and would mis-fire from VSCode muscle
+    // memory like Ctrl+S mid-message. The commit box's invariant —
+    // documented at the top of `handle_key_git` as "letter chords
+    // don't fire mid-message" — depends on this guard.
     let outcome = crate::input_edit_multi::dispatch_key_multi(
         &key,
         &mut app.git_status.commit_message,
         &mut app.git_status.commit_cursor,
     );
+    if matches!(outcome, crate::input_edit::Outcome::Unhandled)
+        && matches!(key.code, KeyCode::Char(_))
+        && (ctrl || alt)
+    {
+        // Swallow any ctrl/alt-modified char chord the editor didn't
+        // recognise. Returning true keeps focus on the commit box.
+        return true;
+    }
     !matches!(outcome, crate::input_edit::Outcome::Unhandled)
 }
 
@@ -2074,6 +2098,7 @@ fn handle_key_graph_branch_picker(key: KeyEvent, app: &mut App) {
         }
         InputOutcome::Confirm => app.confirm_graph_branch_picker(),
         InputOutcome::Edited
+        | InputOutcome::Rejected
         | InputOutcome::SelectionMoved
         | InputOutcome::CursorMoved
         | InputOutcome::Unhandled => {}

--- a/src/input.rs
+++ b/src/input.rs
@@ -133,7 +133,7 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
 
     // Hosts picker (Ctrl+O) — fully owns input while active, same contract
     // as the other overlays.
-    if app.hosts_picker.active {
+    if app.hosts_picker.core.active {
         handle_key_hosts_picker(key, app);
         return;
     }
@@ -141,7 +141,7 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
     // Graph branch picker (`b` on Graph tab) — same exclusive ownership
     // as the other overlays. Sits next to `hosts_picker` because it's a
     // peer overlay (filter input + commit-on-Enter + Esc-cancel).
-    if app.graph_branch_picker.active {
+    if app.graph_branch_picker.core.active {
         handle_key_graph_branch_picker(key, app);
         return;
     }
@@ -156,14 +156,14 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
     }
 
     // Global-search palette — fully owns input while active.
-    if app.global_search.active {
+    if app.global_search.core.active {
         global_search::handle_key(key, app);
         return;
     }
 
     // Quick-open palette has the next-highest priority — while active it
     // fully owns input (character append, cursor, Enter/Esc, Space-P close).
-    if app.quick_open.active {
+    if app.quick_open.core.active {
         quick_open::handle_key(key, app);
         return;
     }
@@ -304,7 +304,7 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         && !app.global_search.input_focused()
         && app.global_search.replace_open;
     let leader_allow_arm = if search_input_focused {
-        app.global_search.query.is_empty()
+        app.global_search.core.filter.is_empty()
     } else if commit_input_focused {
         app.git_status.commit_message.is_empty()
     } else {
@@ -325,8 +325,8 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
             app.space_leader_at = None;
             // Only one palette at a time — opening either implicitly closes
             // the other. `begin()` then activates the chosen one.
-            app.quick_open.active = false;
-            app.global_search.active = false;
+            app.quick_open.core.active = false;
+            app.global_search.core.active = false;
             match key.code {
                 KeyCode::Char('p') | KeyCode::Char('P') => quick_open::begin(app),
                 // Space+F = VSCode-style find widget (selection-seeded,
@@ -379,10 +379,10 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
     let gg_suppressed = in_input_mode
         || app.search.active
         || app.find_widget.active
-        || app.global_search.active
-        || app.quick_open.active
-        || app.hosts_picker.active
-        || app.graph_branch_picker.active
+        || app.global_search.core.active
+        || app.quick_open.core.active
+        || app.hosts_picker.core.active
+        || app.graph_branch_picker.core.active
         || app.tree_edit.active
         || app.db_goto_input.is_some()
         || app.is_sqlite_preview();
@@ -1104,7 +1104,7 @@ fn handle_key_search_list_mode(key: KeyEvent, app: &mut App, ctrl: bool) {
         // Space-leader is disarmed in this state (see `handle_key`);
         // bare Space toggles the current row's checkbox.
         KeyCode::Char(' ') if key.modifiers.is_empty() && app.global_search.replace_open => {
-            let idx = app.global_search.selected;
+            let idx = app.global_search.core.selected_idx;
             app.global_search.toggle_match_excluded(idx);
         }
 
@@ -1206,8 +1206,8 @@ fn handle_key_search_find_input(key: KeyEvent, app: &mut App, ctrl: bool, alt: b
     // `mark_query_edited`; cursor-only and unhandled keys are silent.
     let outcome = crate::input_edit::dispatch_key(
         &key,
-        &mut app.global_search.query,
-        &mut app.global_search.cursor,
+        &mut app.global_search.core.filter,
+        &mut app.global_search.core.cursor,
     );
     if outcome == crate::input_edit::Outcome::Edited {
         global_search::mark_query_edited(&mut app.global_search);
@@ -2058,153 +2058,99 @@ fn handle_key_tree_context_menu(key: KeyEvent, app: &mut App) {
 
 /// Keyboard handler for the Ctrl+O hosts picker overlay.
 ///
-/// Two-phase routing (same shape as `handle_key_graph_branch_picker`):
-///   1. Picker-specific keys — Esc / Ctrl+C close, Enter commits,
-///      Up/Down + Ctrl+J/K + Ctrl+N/P navigate the list, Ctrl+P
-///      enters path mode (literal `[user@]host[:path]` input).
-///   2. Anything left flows into [`input_edit::dispatch_key`] against
-///      whichever buffer is active (filter vs path_buffer), giving
-///      both the same readline / VSCode editor shortcuts as every
-///      other input in reef.
+/// Splits along the picker's input-mode:
+/// - **Filter mode**: standard `PickerCore::dispatch_key` (list nav +
+///   Esc/Enter + full editor vocabulary). One bespoke shortcut on top:
+///   Ctrl+P switches to path mode.
+/// - **Path mode**: no list, just a literal `[user@]host[:path]`
+///   buffer. Esc demotes back to filter mode (preserves picker
+///   state); Enter commits. Editor keys flow straight through
+///   `input_edit::dispatch_key` against `path_buffer` / `path_cursor`.
 fn handle_key_hosts_picker(key: KeyEvent, app: &mut App) {
     use crate::hosts_picker::InputMode;
+    use crate::picker_core::InputOutcome;
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
 
-    // Phase 1: picker-specific shortcuts.
-    match key.code {
-        KeyCode::Esc => {
-            if app.hosts_picker.input_mode == InputMode::Path {
-                // Esc in path mode drops back to the filter view rather
-                // than closing outright — gives the user a way out of
-                // the path buffer without losing the picker state.
-                app.hosts_picker.input_mode = InputMode::Search;
-                app.hosts_picker.path_buffer.clear();
-                app.hosts_picker.path_cursor = 0;
-            } else {
-                app.close_hosts_picker();
+    match app.hosts_picker.input_mode {
+        InputMode::Search => {
+            // Picker-specific shortcut that has to precede PickerCore:
+            // Ctrl+P would otherwise be eaten as list-up.
+            if ctrl && matches!(key.code, KeyCode::Char('p')) {
+                app.hosts_picker.enter_path_mode();
+                return;
             }
-            return;
+            let visible = app.hosts_picker.visible_rows().len();
+            match app.hosts_picker.core.dispatch_key(&key, visible) {
+                InputOutcome::Cancel => {
+                    let ctrl_c = matches!(key.code, KeyCode::Char('c')) && ctrl;
+                    app.close_hosts_picker();
+                    if ctrl_c {
+                        app.should_quit = true;
+                    }
+                }
+                InputOutcome::Confirm => app.confirm_hosts_picker(),
+                _ => {}
+            }
         }
-        KeyCode::Char('c') if ctrl => {
-            app.close_hosts_picker();
-            app.should_quit = true;
-            return;
+        InputMode::Path => {
+            match key.code {
+                KeyCode::Esc => {
+                    // Drop back to filter view rather than closing
+                    // outright — gives the user a way out of the path
+                    // buffer without losing the picker state.
+                    app.hosts_picker.input_mode = InputMode::Search;
+                    app.hosts_picker.path_buffer.clear();
+                    app.hosts_picker.path_cursor = 0;
+                    return;
+                }
+                KeyCode::Char('c') if ctrl => {
+                    app.close_hosts_picker();
+                    app.should_quit = true;
+                    return;
+                }
+                KeyCode::Enter => {
+                    app.confirm_hosts_picker();
+                    return;
+                }
+                _ => {}
+            }
+            // Editor keys against the path buffer. No list = no
+            // selected_idx side effect.
+            let _ = crate::input_edit::dispatch_key(
+                &key,
+                &mut app.hosts_picker.path_buffer,
+                &mut app.hosts_picker.path_cursor,
+            );
         }
-        KeyCode::Char('p') if ctrl => {
-            app.hosts_picker.enter_path_mode();
-            return;
-        }
-        KeyCode::Enter => {
-            app.confirm_hosts_picker();
-            return;
-        }
-        KeyCode::Up => {
-            app.hosts_picker.move_selection(-1);
-            return;
-        }
-        KeyCode::Down => {
-            app.hosts_picker.move_selection(1);
-            return;
-        }
-        // Note: Ctrl+P is consumed above as the path-mode toggle
-        // (hosts_picker's bespoke shortcut), so the list-up alias here
-        // is only Ctrl+K. Ctrl+N (next) is unambiguous as down.
-        KeyCode::Char('k') if ctrl => {
-            app.hosts_picker.move_selection(-1);
-            return;
-        }
-        KeyCode::Char('j' | 'n') if ctrl => {
-            app.hosts_picker.move_selection(1);
-            return;
-        }
-        _ => {}
-    }
-
-    // Phase 2: shared text-input dispatch against the active buffer.
-    let (buf, cur) = match app.hosts_picker.input_mode {
-        InputMode::Search => (
-            &mut app.hosts_picker.filter,
-            &mut app.hosts_picker.filter_cursor,
-        ),
-        InputMode::Path => (
-            &mut app.hosts_picker.path_buffer,
-            &mut app.hosts_picker.path_cursor,
-        ),
-    };
-    let outcome = crate::input_edit::dispatch_key(&key, buf, cur);
-    if outcome == crate::input_edit::Outcome::Edited
-        && app.hosts_picker.input_mode == InputMode::Search
-    {
-        // Filter edits reset list cursor (path mode has no list).
-        app.hosts_picker.selected_idx = 0;
     }
 }
 
 /// Keyboard handler for the Graph tab's `b` branch picker.
 ///
-/// Routing is two-phase to match the convention shared with
-/// `find_widget` / `quick_open`:
-///
-///   1. Picker-specific keys first — Esc / Ctrl+C close, Enter commits,
-///      Up/Down + Ctrl+J/K + Ctrl+N/P navigate the list.
-///   2. Anything left over flows into [`input_edit::dispatch_key`], which
-///      owns the readline / VSCode text-input vocabulary: Alt/Ctrl+←/→
-///      word-jump, Home/End, Ctrl+A/E, Alt+B/F word-jump, Backspace +
-///      Ctrl+W word-delete, Alt+Backspace / Ctrl+W word-back, Alt+D /
-///      Ctrl+Delete word-forward, Ctrl+U clear, plain char insert.
-///
-/// Edits reset `selected_idx` to 0 so the filtered list always lands
-/// the cursor on the first match (matches the contract of every other
-/// fuzzy picker in reef).
+/// All standard picker keys (Esc / Ctrl+C close, Enter commit,
+/// Up/Down/Ctrl+J/K/N/P navigate, full text-editing vocabulary) are
+/// owned by [`crate::picker_core::PickerCore::dispatch_key`]; we just
+/// translate the returned `InputOutcome` into the picker-specific
+/// app methods. No bespoke shortcuts (the graph picker has no leader
+/// chord or mode-switch key), so the handler stays trivial.
 fn handle_key_graph_branch_picker(key: KeyEvent, app: &mut App) {
-    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-    // Phase 1: picker-specific shortcuts. These must run before
-    // `dispatch_key`, which would otherwise eat e.g. Ctrl+N as a no-op
-    // (it isn't in the editor vocabulary) and `n` would fall through
-    // to the printable-char insert.
-    match key.code {
-        KeyCode::Esc => {
+    use crate::picker_core::InputOutcome;
+    let visible = app.graph_branch_picker.visible_rows().len();
+    match app.graph_branch_picker.core.dispatch_key(&key, visible) {
+        InputOutcome::Cancel => {
+            // Ctrl+C also requests app quit; plain Esc just closes.
+            let ctrl_c = matches!(key.code, KeyCode::Char('c'))
+                && key.modifiers.contains(KeyModifiers::CONTROL);
             app.close_graph_branch_picker();
-            return;
+            if ctrl_c {
+                app.should_quit = true;
+            }
         }
-        KeyCode::Char('c') if ctrl => {
-            app.close_graph_branch_picker();
-            app.should_quit = true;
-            return;
-        }
-        KeyCode::Enter => {
-            app.confirm_graph_branch_picker();
-            return;
-        }
-        KeyCode::Up => {
-            app.graph_branch_picker.move_selection(-1);
-            return;
-        }
-        KeyCode::Down => {
-            app.graph_branch_picker.move_selection(1);
-            return;
-        }
-        KeyCode::Char('k' | 'p') if ctrl => {
-            app.graph_branch_picker.move_selection(-1);
-            return;
-        }
-        KeyCode::Char('j' | 'n') if ctrl => {
-            app.graph_branch_picker.move_selection(1);
-            return;
-        }
-        _ => {}
-    }
-
-    // Phase 2: shared text-input dispatch. Any `Edited` outcome resets
-    // the list cursor so the filtered view always opens at row 0 —
-    // same UX convention as quick_open / find_widget.
-    let outcome = crate::input_edit::dispatch_key(
-        &key,
-        &mut app.graph_branch_picker.filter,
-        &mut app.graph_branch_picker.cursor,
-    );
-    if outcome == crate::input_edit::Outcome::Edited {
-        app.graph_branch_picker.selected_idx = 0;
+        InputOutcome::Confirm => app.confirm_graph_branch_picker(),
+        InputOutcome::Edited
+        | InputOutcome::SelectionMoved
+        | InputOutcome::CursorMoved
+        | InputOutcome::Unhandled => {}
     }
 }
 
@@ -2425,19 +2371,19 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
     // Palettes fully own mouse input while active (global-search first,
     // then quick-open): clicks must not leak through to hidden panels,
     // and scroll wheels inside the popup should move the selection.
-    if app.hosts_picker.active {
+    if app.hosts_picker.core.active {
         handle_mouse_hosts_picker(mouse, app);
         return;
     }
-    if app.graph_branch_picker.active {
+    if app.graph_branch_picker.core.active {
         handle_mouse_graph_branch_picker(mouse, app);
         return;
     }
-    if app.global_search.active {
+    if app.global_search.core.active {
         global_search::handle_mouse(mouse, app);
         return;
     }
-    if app.quick_open.active {
+    if app.quick_open.core.active {
         quick_open::handle_mouse(mouse, app);
         return;
     }
@@ -2664,7 +2610,7 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
                 // Handled here rather than in `handle_action` because the
                 // is_double signal isn't threaded through App methods.
                 if is_double && let ui::mouse::ClickAction::GlobalSearchSelect(idx) = action {
-                    app.global_search.selected = idx;
+                    app.global_search.core.selected_idx = idx;
                     global_search::accept(app);
                     app.last_click = None;
                     return;
@@ -3775,7 +3721,7 @@ fn apply_scroll_delta(field: &mut usize, delta: i32) {
 /// select a row (and double-click commits); clicks outside dismiss the
 /// overlay, matching the quick-open / global-search click-away behaviour.
 fn handle_mouse_hosts_picker(mouse: MouseEvent, app: &mut App) {
-    let popup = match app.hosts_picker.last_popup_area {
+    let popup = match app.hosts_picker.core.last_popup_area {
         Some(r) => r,
         None => return,
     };
@@ -3802,7 +3748,7 @@ fn handle_mouse_hosts_picker(mouse: MouseEvent, app: &mut App) {
             if let Some(ui::mouse::ClickAction::HostsPickerSelect(idx)) =
                 app.hit_registry.hit_test(mouse.column, mouse.row)
             {
-                app.hosts_picker.selected_idx = idx;
+                app.hosts_picker.core.selected_idx = idx;
                 if is_double {
                     app.confirm_hosts_picker();
                     app.last_click = None;
@@ -3831,7 +3777,7 @@ fn handle_mouse_hosts_picker(mouse: MouseEvent, app: &mut App) {
 /// `handle_mouse_hosts_picker`: click inside selects (double-click
 /// commits), click outside dismisses, scroll moves the selection.
 fn handle_mouse_graph_branch_picker(mouse: MouseEvent, app: &mut App) {
-    let popup = match app.graph_branch_picker.last_popup_area {
+    let popup = match app.graph_branch_picker.core.last_popup_area {
         Some(r) => r,
         None => return,
     };
@@ -3858,7 +3804,7 @@ fn handle_mouse_graph_branch_picker(mouse: MouseEvent, app: &mut App) {
             if let Some(ui::mouse::ClickAction::GraphBranchPickerSelect(idx)) =
                 app.hit_registry.hit_test(mouse.column, mouse.row)
             {
-                app.graph_branch_picker.selected_idx = idx;
+                app.graph_branch_picker.core.selected_idx = idx;
                 if is_double {
                     app.confirm_graph_branch_picker();
                     app.last_click = None;
@@ -3939,11 +3885,11 @@ pub fn handle_paste(s: String, app: &mut App) {
         app.enter_place_mode(paths);
         return;
     }
-    if app.quick_open.active {
+    if app.quick_open.core.active {
         quick_open::handle_paste(&s, app);
     } else if app.search.active {
         search::handle_paste(&s, app);
-    } else if app.global_search.active {
+    } else if app.global_search.core.active {
         global_search::handle_paste_overlay(&s, &mut app.global_search);
     } else if app.active_tab == Tab::Search
         && app.active_panel == Panel::Files

--- a/src/input.rs
+++ b/src/input.rs
@@ -1464,131 +1464,46 @@ fn handle_key_graph(key: KeyEvent, app: &mut App) {
 }
 
 /// Route a key event to the commit-box buffer when the Git tab's
-/// commit input is focused. Mirrors the text-input contract used by
-/// `handle_key_search_input_mode`: typing fills the draft, standard
-/// nav / edit keys move the cursor, Esc blurs, Ctrl+Enter submits,
-/// bare Enter inserts a newline (subject + body pattern). Returns
-/// `true` when the key was consumed.
-fn handle_key_git_commit(key: KeyEvent, app: &mut App, ctrl: bool, alt: bool) -> bool {
+/// commit input is focused.
+///
+/// Two-phase routing matching every other input in reef:
+///   1. Commit-box-specific shortcuts (Esc blur, Ctrl+Enter submit).
+///   2. Everything else flows into
+///      [`input_edit_multi::dispatch_key_multi`], which extends the
+///      shared single-line vocabulary with line-aware Up/Down
+///      navigation, line-aware Home/End, and bare-Enter newline
+///      insert. Returns `true` when the key was consumed by either
+///      phase — never falls through to global Git-tab shortcuts
+///      while the commit box is focused.
+fn handle_key_git_commit(key: KeyEvent, app: &mut App, ctrl: bool, _alt: bool) -> bool {
     use crate::app::Panel;
     if app.active_panel != Panel::Files || !app.git_status.commit_editing {
         return false;
     }
+    // Phase 1: commit-box-specific shortcuts.
     match key.code {
         KeyCode::Esc => {
             app.git_status.commit_editing = false;
-            true
+            return true;
         }
         KeyCode::Enter if ctrl => {
             app.run_commit();
-            true
+            return true;
         }
-        KeyCode::Enter => {
-            crate::input_edit::insert_char(
-                &mut app.git_status.commit_message,
-                &mut app.git_status.commit_cursor,
-                '\n',
-            );
-            true
-        }
-        KeyCode::Backspace if alt || ctrl => {
-            crate::input_edit::delete_word_backward(
-                &mut app.git_status.commit_message,
-                &mut app.git_status.commit_cursor,
-            );
-            true
-        }
-        KeyCode::Backspace => {
-            crate::input_edit::backspace(
-                &mut app.git_status.commit_message,
-                &mut app.git_status.commit_cursor,
-            );
-            true
-        }
-        KeyCode::Delete if alt || ctrl => {
-            crate::input_edit::delete_word_forward(
-                &mut app.git_status.commit_message,
-                &mut app.git_status.commit_cursor,
-            );
-            true
-        }
-        KeyCode::Delete => {
-            crate::input_edit::delete_char_forward(
-                &mut app.git_status.commit_message,
-                &mut app.git_status.commit_cursor,
-            );
-            true
-        }
-        KeyCode::Left if alt || ctrl => {
-            crate::input_edit::move_cursor_word_backward(
-                &app.git_status.commit_message,
-                &mut app.git_status.commit_cursor,
-            );
-            true
-        }
-        KeyCode::Right if alt || ctrl => {
-            crate::input_edit::move_cursor_word_forward(
-                &app.git_status.commit_message,
-                &mut app.git_status.commit_cursor,
-            );
-            true
-        }
-        KeyCode::Left => {
-            crate::input_edit::move_cursor(
-                &app.git_status.commit_message,
-                &mut app.git_status.commit_cursor,
-                -1,
-            );
-            true
-        }
-        KeyCode::Right => {
-            crate::input_edit::move_cursor(
-                &app.git_status.commit_message,
-                &mut app.git_status.commit_cursor,
-                1,
-            );
-            true
-        }
-        KeyCode::Home => {
-            app.git_status.commit_cursor = 0;
-            true
-        }
-        KeyCode::End => {
-            app.git_status.commit_cursor = app.git_status.commit_message.len();
-            true
-        }
-        KeyCode::Char('u') if ctrl => {
-            crate::input_edit::clear(
-                &mut app.git_status.commit_message,
-                &mut app.git_status.commit_cursor,
-            );
-            true
-        }
-        KeyCode::Char('w') if ctrl => {
-            crate::input_edit::delete_word_backward(
-                &mut app.git_status.commit_message,
-                &mut app.git_status.commit_cursor,
-            );
-            true
-        }
-        KeyCode::Char('a') if ctrl => {
-            app.git_status.commit_cursor = 0;
-            true
-        }
-        KeyCode::Char('e') if ctrl => {
-            app.git_status.commit_cursor = app.git_status.commit_message.len();
-            true
-        }
-        KeyCode::Char(c) if !ctrl => {
-            crate::input_edit::insert_char(
-                &mut app.git_status.commit_message,
-                &mut app.git_status.commit_cursor,
-                c,
-            );
-            true
-        }
-        _ => false,
+        _ => {}
     }
+
+    // Phase 2: shared multi-line text-input dispatch.
+    let outcome = crate::input_edit_multi::dispatch_key_multi(
+        &key,
+        &mut app.git_status.commit_message,
+        &mut app.git_status.commit_cursor,
+    );
+    // Even on `Unhandled` we return `true` — the commit box owns the
+    // keyboard while focused; falling through to Git-tab letter
+    // shortcuts (s / u / d / …) mid-message would clobber the draft.
+    let _ = outcome;
+    true
 }
 
 fn handle_key_git(key: KeyEvent, app: &mut App) {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1467,15 +1467,23 @@ fn handle_key_graph(key: KeyEvent, app: &mut App) {
 /// commit input is focused.
 ///
 /// Two-phase routing matching every other input in reef:
-///   1. Commit-box-specific shortcuts (Esc blur, Ctrl+Enter submit).
+///   1. Commit-box-specific shortcuts (Esc blur, Ctrl+Enter submit;
+///      Ctrl+Enter requires `!alt` so a stray Ctrl+Alt+Enter on
+///      Linux WMs doesn't silently commit).
 ///   2. Everything else flows into
 ///      [`input_edit_multi::dispatch_key_multi`], which extends the
 ///      shared single-line vocabulary with line-aware Up/Down
 ///      navigation, line-aware Home/End, and bare-Enter newline
-///      insert. Returns `true` when the key was consumed by either
-///      phase — never falls through to global Git-tab shortcuts
-///      while the commit box is focused.
-fn handle_key_git_commit(key: KeyEvent, app: &mut App, ctrl: bool, _alt: bool) -> bool {
+///      insert.
+///
+/// Returns `true` when the key was actually consumed (Phase 1 hit
+/// OR Phase 2 returned `Edited` / `CursorOnly`). Keys the multi-line
+/// editor doesn't recognise (PageUp / PageDown / Shift+Arrow / F-keys
+/// …) yield `Unhandled` and we return `false` so the outer Git-tab
+/// handler can do its own thing with them. Letter chords like
+/// `s` / `u` / `d` arrive here as `Char(c)` which the editor DOES
+/// handle (as a literal insert), so the draft is safe.
+fn handle_key_git_commit(key: KeyEvent, app: &mut App, ctrl: bool, alt: bool) -> bool {
     use crate::app::Panel;
     if app.active_panel != Panel::Files || !app.git_status.commit_editing {
         return false;
@@ -1486,24 +1494,23 @@ fn handle_key_git_commit(key: KeyEvent, app: &mut App, ctrl: bool, _alt: bool) -
             app.git_status.commit_editing = false;
             return true;
         }
-        KeyCode::Enter if ctrl => {
+        KeyCode::Enter if ctrl && !alt => {
             app.run_commit();
             return true;
         }
         _ => {}
     }
 
-    // Phase 2: shared multi-line text-input dispatch.
+    // Phase 2: shared multi-line text-input dispatch. Forward
+    // `Unhandled` to the caller as "not consumed" so unknown keys
+    // (PageUp / Shift+Arrow / F-keys / …) can flow up to the outer
+    // Git-tab handler instead of being silently swallowed mid-edit.
     let outcome = crate::input_edit_multi::dispatch_key_multi(
         &key,
         &mut app.git_status.commit_message,
         &mut app.git_status.commit_cursor,
     );
-    // Even on `Unhandled` we return `true` — the commit box owns the
-    // keyboard while focused; falling through to Git-tab letter
-    // shortcuts (s / u / d / …) mid-message would clobber the draft.
-    let _ = outcome;
-    true
+    !matches!(outcome, crate::input_edit::Outcome::Unhandled)
 }
 
 fn handle_key_git(key: KeyEvent, app: &mut App) {
@@ -1996,12 +2003,10 @@ fn handle_key_hosts_picker(key: KeyEvent, app: &mut App) {
             }
             let visible = app.hosts_picker.visible_rows().len();
             match app.hosts_picker.core.dispatch_key(&key, visible) {
-                InputOutcome::Cancel => {
-                    let ctrl_c = matches!(key.code, KeyCode::Char('c')) && ctrl;
+                InputOutcome::Cancel => app.close_hosts_picker(),
+                InputOutcome::Quit => {
                     app.close_hosts_picker();
-                    if ctrl_c {
-                        app.should_quit = true;
-                    }
+                    app.should_quit = true;
                 }
                 InputOutcome::Confirm => app.confirm_hosts_picker(),
                 _ => {}
@@ -2013,6 +2018,16 @@ fn handle_key_hosts_picker(key: KeyEvent, app: &mut App) {
                     // Drop back to filter view rather than closing
                     // outright — gives the user a way out of the path
                     // buffer without losing the picker state.
+                    app.hosts_picker.input_mode = InputMode::Search;
+                    app.hosts_picker.path_buffer.clear();
+                    app.hosts_picker.path_cursor = 0;
+                    return;
+                }
+                // Symmetric with the path-mode entry: Ctrl+P also
+                // exits back to filter mode. Without this, the only
+                // way out is Esc, which is a UX asymmetry every
+                // tester trips on at least once.
+                KeyCode::Char('p') if ctrl => {
                     app.hosts_picker.input_mode = InputMode::Search;
                     app.hosts_picker.path_buffer.clear();
                     app.hosts_picker.path_cursor = 0;
@@ -2052,14 +2067,10 @@ fn handle_key_graph_branch_picker(key: KeyEvent, app: &mut App) {
     use crate::picker_core::InputOutcome;
     let visible = app.graph_branch_picker.visible_rows().len();
     match app.graph_branch_picker.core.dispatch_key(&key, visible) {
-        InputOutcome::Cancel => {
-            // Ctrl+C also requests app quit; plain Esc just closes.
-            let ctrl_c = matches!(key.code, KeyCode::Char('c'))
-                && key.modifiers.contains(KeyModifiers::CONTROL);
+        InputOutcome::Cancel => app.close_graph_branch_picker(),
+        InputOutcome::Quit => {
             app.close_graph_branch_picker();
-            if ctrl_c {
-                app.should_quit = true;
-            }
+            app.should_quit = true;
         }
         InputOutcome::Confirm => app.confirm_graph_branch_picker(),
         InputOutcome::Edited

--- a/src/input.rs
+++ b/src/input.rs
@@ -673,12 +673,9 @@ fn handle_key_db_goto(key: KeyEvent, app: &mut App) {
     // applies only to NEW insertions, not to e.g. Backspace / cursor
     // motion, hence wrapping it inside the predicate.
     let current_len = buf.len();
-    let _ = crate::input_edit::dispatch_key_filtered(
-        &key,
-        buf,
-        &mut app.db_goto_cursor,
-        |c| c.is_ascii_digit() && current_len < 18,
-    );
+    let _ = crate::input_edit::dispatch_key_filtered(&key, buf, &mut app.db_goto_cursor, |c| {
+        c.is_ascii_digit() && current_len < 18
+    });
 }
 
 /// 纯预览模式的早期闸门 —— 拦截退出语义 + 文件 picker 相关按键。

--- a/src/input.rs
+++ b/src/input.rs
@@ -1998,47 +1998,30 @@ fn handle_key_tree_edit(key: KeyEvent, app: &mut App) {
         app.tree_edit.error = None;
     }
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    // Phase 1: tree-edit-specific shortcuts (Esc/Enter/Ctrl+C).
     match key.code {
-        KeyCode::Esc => app.cancel_tree_edit(),
-        KeyCode::Char('c') if ctrl => app.cancel_tree_edit(),
-        KeyCode::Enter => app.commit_tree_edit(),
-        KeyCode::Backspace => {
-            if ctrl || key.modifiers.contains(KeyModifiers::ALT) {
-                crate::input_edit::delete_word_backward(
-                    &mut app.tree_edit.buffer,
-                    &mut app.tree_edit.cursor,
-                );
-            } else {
-                crate::input_edit::backspace(&mut app.tree_edit.buffer, &mut app.tree_edit.cursor);
-            }
+        KeyCode::Esc => {
+            app.cancel_tree_edit();
+            return;
         }
-        KeyCode::Char('w') if ctrl => {
-            crate::input_edit::delete_word_backward(
-                &mut app.tree_edit.buffer,
-                &mut app.tree_edit.cursor,
-            );
+        KeyCode::Char('c') if ctrl => {
+            app.cancel_tree_edit();
+            return;
         }
-        KeyCode::Char('u') if ctrl => {
-            app.tree_edit.buffer.clear();
-            app.tree_edit.cursor = 0;
-        }
-        KeyCode::Left => {
-            crate::input_edit::move_cursor(&app.tree_edit.buffer, &mut app.tree_edit.cursor, -1);
-        }
-        KeyCode::Right => {
-            crate::input_edit::move_cursor(&app.tree_edit.buffer, &mut app.tree_edit.cursor, 1);
-        }
-        KeyCode::Home => {
-            app.tree_edit.cursor = 0;
-        }
-        KeyCode::End => {
-            app.tree_edit.cursor = app.tree_edit.buffer.len();
-        }
-        KeyCode::Char(c) if !ctrl => {
-            crate::input_edit::insert_char(&mut app.tree_edit.buffer, &mut app.tree_edit.cursor, c);
+        KeyCode::Enter => {
+            app.commit_tree_edit();
+            return;
         }
         _ => {}
     }
+
+    // Phase 2: shared text-input dispatch. No edit-derived side
+    // effect — validation runs on commit, not per-keystroke.
+    let _ = crate::input_edit::dispatch_key(
+        &key,
+        &mut app.tree_edit.buffer,
+        &mut app.tree_edit.cursor,
+    );
 }
 
 /// Keyboard navigation for the right-click context menu popup.
@@ -2061,14 +2044,21 @@ fn handle_key_tree_context_menu(key: KeyEvent, app: &mut App) {
     }
 }
 
-/// Keyboard handler for the Ctrl+O hosts picker overlay. Mirrors the
-/// quick-open contract: Esc / Ctrl+C close, Enter commits, arrows
-/// navigate, printable chars append to the active input (filter or
-/// path). Ctrl+P toggles between the two input modes so the user can
-/// swap from "filter my config" to "type a target literally".
+/// Keyboard handler for the Ctrl+O hosts picker overlay.
+///
+/// Two-phase routing (same shape as `handle_key_graph_branch_picker`):
+///   1. Picker-specific keys — Esc / Ctrl+C close, Enter commits,
+///      Up/Down + Ctrl+J/K + Ctrl+N/P navigate the list, Ctrl+P
+///      enters path mode (literal `[user@]host[:path]` input).
+///   2. Anything left flows into [`input_edit::dispatch_key`] against
+///      whichever buffer is active (filter vs path_buffer), giving
+///      both the same readline / VSCode editor shortcuts as every
+///      other input in reef.
 fn handle_key_hosts_picker(key: KeyEvent, app: &mut App) {
     use crate::hosts_picker::InputMode;
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+
+    // Phase 1: picker-specific shortcuts.
     match key.code {
         KeyCode::Esc => {
             if app.hosts_picker.input_mode == InputMode::Path {
@@ -2077,41 +2067,64 @@ fn handle_key_hosts_picker(key: KeyEvent, app: &mut App) {
                 // the path buffer without losing the picker state.
                 app.hosts_picker.input_mode = InputMode::Search;
                 app.hosts_picker.path_buffer.clear();
+                app.hosts_picker.path_cursor = 0;
             } else {
                 app.close_hosts_picker();
             }
+            return;
         }
         KeyCode::Char('c') if ctrl => {
             app.close_hosts_picker();
             app.should_quit = true;
+            return;
         }
         KeyCode::Char('p') if ctrl => {
             app.hosts_picker.enter_path_mode();
+            return;
         }
-        KeyCode::Enter => app.confirm_hosts_picker(),
-        KeyCode::Up => app.hosts_picker.move_selection(-1),
-        KeyCode::Down => app.hosts_picker.move_selection(1),
-        KeyCode::Char('k') if ctrl => app.hosts_picker.move_selection(-1),
-        KeyCode::Char('j') if ctrl => app.hosts_picker.move_selection(1),
-        KeyCode::Backspace => match app.hosts_picker.input_mode {
-            InputMode::Search => {
-                app.hosts_picker.filter.pop();
-                app.hosts_picker.selected_idx = 0;
-            }
-            InputMode::Path => {
-                app.hosts_picker.path_buffer.pop();
-            }
-        },
-        KeyCode::Char(c) if !ctrl => match app.hosts_picker.input_mode {
-            InputMode::Search => {
-                app.hosts_picker.filter.push(c);
-                app.hosts_picker.selected_idx = 0;
-            }
-            InputMode::Path => {
-                app.hosts_picker.path_buffer.push(c);
-            }
-        },
+        KeyCode::Enter => {
+            app.confirm_hosts_picker();
+            return;
+        }
+        KeyCode::Up => {
+            app.hosts_picker.move_selection(-1);
+            return;
+        }
+        KeyCode::Down => {
+            app.hosts_picker.move_selection(1);
+            return;
+        }
+        // Note: Ctrl+P is consumed above as the path-mode toggle
+        // (hosts_picker's bespoke shortcut), so the list-up alias here
+        // is only Ctrl+K. Ctrl+N (next) is unambiguous as down.
+        KeyCode::Char('k') if ctrl => {
+            app.hosts_picker.move_selection(-1);
+            return;
+        }
+        KeyCode::Char('j' | 'n') if ctrl => {
+            app.hosts_picker.move_selection(1);
+            return;
+        }
         _ => {}
+    }
+
+    // Phase 2: shared text-input dispatch against the active buffer.
+    let (buf, cur) = match app.hosts_picker.input_mode {
+        InputMode::Search => (
+            &mut app.hosts_picker.filter,
+            &mut app.hosts_picker.filter_cursor,
+        ),
+        InputMode::Path => (
+            &mut app.hosts_picker.path_buffer,
+            &mut app.hosts_picker.path_cursor,
+        ),
+    };
+    let outcome = crate::input_edit::dispatch_key(&key, buf, cur);
+    if outcome == crate::input_edit::Outcome::Edited
+        && app.hosts_picker.input_mode == InputMode::Search
+    {
+        // Filter edits reset list cursor (path mode has no list).
+        app.hosts_picker.selected_idx = 0;
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -138,6 +138,14 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         return;
     }
 
+    // Graph branch picker (`b` on Graph tab) — same exclusive ownership
+    // as the other overlays. Sits next to `hosts_picker` because it's a
+    // peer overlay (filter input + commit-on-Enter + Esc-cancel).
+    if app.graph_branch_picker.active {
+        handle_key_graph_branch_picker(key, app);
+        return;
+    }
+
     // VSCode-style find widget — fully owns input while active. Sits
     // above the global-search palette because the widget is opened by
     // a Space leader chord (`Space+F`) and is the most-recently-opened
@@ -374,6 +382,7 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         || app.global_search.active
         || app.quick_open.active
         || app.hosts_picker.active
+        || app.graph_branch_picker.active
         || app.tree_edit.active
         || app.db_goto_input.is_some()
         || app.is_sqlite_preview();
@@ -1424,6 +1433,15 @@ fn handle_key_graph(key: KeyEvent, app: &mut App) {
             app.git_graph.cache_key = None;
             app.refresh_graph();
         }
+        // `b` opens the branch picker overlay (see `graph_branch_picker`).
+        // Available from every panel on the Graph tab — the picker is a
+        // tab-level navigation, not a sidebar-local action, so the user
+        // can switch branches while focus is on the commit pane or the
+        // diff column too. (`V`/visual-mode stays gated on Panel::Files
+        // because it's specifically a sidebar-row range selection.)
+        KeyCode::Char('b') if !ctrl => {
+            app.open_graph_branch_picker();
+        }
         // m/f/t target the commit-detail panel regardless of focus.
         // `!ctrl` guards so Ctrl+F/M/T (e.g. VSCode muscle-memory Ctrl+F
         // for find) don't silently flip diff layout/mode — the global
@@ -2097,6 +2115,74 @@ fn handle_key_hosts_picker(key: KeyEvent, app: &mut App) {
     }
 }
 
+/// Keyboard handler for the Graph tab's `b` branch picker.
+///
+/// Routing is two-phase to match the convention shared with
+/// `find_widget` / `quick_open`:
+///
+///   1. Picker-specific keys first — Esc / Ctrl+C close, Enter commits,
+///      Up/Down + Ctrl+J/K + Ctrl+N/P navigate the list.
+///   2. Anything left over flows into [`input_edit::dispatch_key`], which
+///      owns the readline / VSCode text-input vocabulary: Alt/Ctrl+←/→
+///      word-jump, Home/End, Ctrl+A/E, Alt+B/F word-jump, Backspace +
+///      Ctrl+W word-delete, Alt+Backspace / Ctrl+W word-back, Alt+D /
+///      Ctrl+Delete word-forward, Ctrl+U clear, plain char insert.
+///
+/// Edits reset `selected_idx` to 0 so the filtered list always lands
+/// the cursor on the first match (matches the contract of every other
+/// fuzzy picker in reef).
+fn handle_key_graph_branch_picker(key: KeyEvent, app: &mut App) {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    // Phase 1: picker-specific shortcuts. These must run before
+    // `dispatch_key`, which would otherwise eat e.g. Ctrl+N as a no-op
+    // (it isn't in the editor vocabulary) and `n` would fall through
+    // to the printable-char insert.
+    match key.code {
+        KeyCode::Esc => {
+            app.close_graph_branch_picker();
+            return;
+        }
+        KeyCode::Char('c') if ctrl => {
+            app.close_graph_branch_picker();
+            app.should_quit = true;
+            return;
+        }
+        KeyCode::Enter => {
+            app.confirm_graph_branch_picker();
+            return;
+        }
+        KeyCode::Up => {
+            app.graph_branch_picker.move_selection(-1);
+            return;
+        }
+        KeyCode::Down => {
+            app.graph_branch_picker.move_selection(1);
+            return;
+        }
+        KeyCode::Char('k' | 'p') if ctrl => {
+            app.graph_branch_picker.move_selection(-1);
+            return;
+        }
+        KeyCode::Char('j' | 'n') if ctrl => {
+            app.graph_branch_picker.move_selection(1);
+            return;
+        }
+        _ => {}
+    }
+
+    // Phase 2: shared text-input dispatch. Any `Edited` outcome resets
+    // the list cursor so the filtered view always opens at row 0 —
+    // same UX convention as quick_open / find_widget.
+    let outcome = crate::input_edit::dispatch_key(
+        &key,
+        &mut app.graph_branch_picker.filter,
+        &mut app.graph_branch_picker.cursor,
+    );
+    if outcome == crate::input_edit::Outcome::Edited {
+        app.graph_branch_picker.selected_idx = 0;
+    }
+}
+
 /// Keyboard handler for the generic `ConfirmModal`.
 ///
 /// Routing:
@@ -2315,6 +2401,10 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
     // and scroll wheels inside the popup should move the selection.
     if app.hosts_picker.active {
         handle_mouse_hosts_picker(mouse, app);
+        return;
+    }
+    if app.graph_branch_picker.active {
+        handle_mouse_graph_branch_picker(mouse, app);
         return;
     }
     if app.global_search.active {
@@ -3706,6 +3796,62 @@ fn handle_mouse_hosts_picker(mouse: MouseEvent, app: &mut App) {
         MouseEventKind::ScrollDown if inside => {
             let step = app.vertical_scroll_pacer.step() as i32;
             app.hosts_picker.move_selection(step);
+        }
+        _ => {}
+    }
+}
+
+/// Mouse dispatch for the Graph tab branch picker. Same shape as
+/// `handle_mouse_hosts_picker`: click inside selects (double-click
+/// commits), click outside dismisses, scroll moves the selection.
+fn handle_mouse_graph_branch_picker(mouse: MouseEvent, app: &mut App) {
+    let popup = match app.graph_branch_picker.last_popup_area {
+        Some(r) => r,
+        None => return,
+    };
+    let inside = mouse.column >= popup.x
+        && mouse.column < popup.x + popup.width
+        && mouse.row >= popup.y
+        && mouse.row < popup.y + popup.height;
+
+    match mouse.kind {
+        MouseEventKind::Down(MouseButton::Left) => {
+            if !inside {
+                app.close_graph_branch_picker();
+                app.last_click = None;
+                return;
+            }
+            let now = Instant::now();
+            let is_double = matches!(
+                app.last_click,
+                Some((t, c, r))
+                    if c == mouse.column
+                        && r == mouse.row
+                        && now.duration_since(t) < DOUBLE_CLICK_WINDOW
+            );
+            if let Some(ui::mouse::ClickAction::GraphBranchPickerSelect(idx)) =
+                app.hit_registry.hit_test(mouse.column, mouse.row)
+            {
+                app.graph_branch_picker.selected_idx = idx;
+                if is_double {
+                    app.confirm_graph_branch_picker();
+                    app.last_click = None;
+                    return;
+                }
+            }
+            app.last_click = if is_double {
+                None
+            } else {
+                Some((now, mouse.column, mouse.row))
+            };
+        }
+        MouseEventKind::ScrollUp if inside => {
+            let step = app.vertical_scroll_pacer.step() as i32;
+            app.graph_branch_picker.move_selection(-step);
+        }
+        MouseEventKind::ScrollDown if inside => {
+            let step = app.vertical_scroll_pacer.step() as i32;
+            app.graph_branch_picker.move_selection(step);
         }
         _ => {}
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1203,13 +1203,18 @@ fn handle_key_search_find_input(key: KeyEvent, app: &mut App, ctrl: bool, alt: b
     }
 
     // Pass 2: text-buffer edits. Edit outcomes re-run the search via
-    // `mark_query_edited`; cursor-only and unhandled keys are silent.
+    // `mark_query_edited` AND immediately reset `selected_idx = 0`
+    // (mirroring the overlay path's PickerCore behavior) so PageUp /
+    // PageDown handled above against stale results-from-old-query
+    // don't paginate into rows that won't survive the next debounced
+    // search rerun.
     let outcome = crate::input_edit::dispatch_key(
         &key,
         &mut app.global_search.core.filter,
         &mut app.global_search.core.cursor,
     );
     if outcome == crate::input_edit::Outcome::Edited {
+        app.global_search.core.selected_idx = 0;
         global_search::mark_query_edited(&mut app.global_search);
     }
 }
@@ -1488,19 +1493,22 @@ fn handle_key_git_commit(key: KeyEvent, app: &mut App, ctrl: bool, alt: bool) ->
     if app.active_panel != Panel::Files || !app.git_status.commit_editing {
         return false;
     }
-    let shift = key.modifiers.contains(KeyModifiers::SHIFT);
-    // Phase 1: commit-box-specific shortcuts. Strict `Ctrl+Enter`
-    // (no alt, no shift) is the only commit-submit chord; the `!alt`
-    // guard defends against Linux WMs forwarding Ctrl+Alt+Enter and
-    // `!shift` defends against kitty-style enhanced keyboard
-    // protocols that report Shift+Ctrl+Enter as a distinct chord.
-    // Shift+Enter alone is left to Phase 2 (newline insert).
+    // Phase 1: commit-box-specific shortcuts. ANY Ctrl-modified
+    // Enter submits the commit — Shift/Alt extra modifier bits are
+    // accepted because terminals disagree about which subset gets
+    // forwarded (kitty enhanced-keyboard sends Shift on Enter; some
+    // Linux WMs bundle Alt). Without this, Ctrl+Shift+Enter /
+    // Ctrl+Alt+Enter would fall through Phase 2 (which only matches
+    // `Enter if !ctrl`) as Unhandled — and Enter isn't `Char`, so the
+    // Ctrl-letter swallow guard below doesn't catch it — landing on
+    // the outer Git handler's `Char('e') | Enter` arm that opens
+    // `$EDITOR` on the selected file.
     match key.code {
         KeyCode::Esc => {
             app.git_status.commit_editing = false;
             return true;
         }
-        KeyCode::Enter if ctrl && !alt && !shift => {
+        KeyCode::Enter if ctrl => {
             app.run_commit();
             return true;
         }
@@ -1949,7 +1957,14 @@ fn handle_key_tree_edit(key: KeyEvent, app: &mut App) {
         app.tree_edit.error = None;
     }
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
+    let shift = key.modifiers.contains(KeyModifiers::SHIFT);
     // Phase 1: tree-edit-specific shortcuts (Esc/Enter/Ctrl+C).
+    // Enter is strict bare-Enter only: Shift+Enter / Alt+Enter /
+    // Ctrl+Enter would otherwise commit the rename on a stray
+    // modifier press (the commit-box right next door treats
+    // Shift+Enter as soft-newline; consistent muscle-memory says
+    // Shift+Enter is non-destructive).
     match key.code {
         KeyCode::Esc => {
             app.cancel_tree_edit();
@@ -1959,7 +1974,7 @@ fn handle_key_tree_edit(key: KeyEvent, app: &mut App) {
             app.cancel_tree_edit();
             return;
         }
-        KeyCode::Enter => {
+        KeyCode::Enter if !ctrl && !alt && !shift => {
             app.commit_tree_edit();
             return;
         }
@@ -2037,6 +2052,8 @@ fn handle_key_hosts_picker(key: KeyEvent, app: &mut App) {
             }
         }
         InputMode::Path => {
+            let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+            let alt = key.modifiers.contains(KeyModifiers::ALT);
             match key.code {
                 KeyCode::Esc => {
                     // Drop back to filter view rather than closing
@@ -2062,7 +2079,11 @@ fn handle_key_hosts_picker(key: KeyEvent, app: &mut App) {
                     app.should_quit = true;
                     return;
                 }
-                KeyCode::Enter => {
+                // Strict bare Enter — Shift+Enter / Alt+Enter would
+                // otherwise commit a half-typed target on a stray
+                // modifier press (users muscle-memory Shift+Enter as
+                // "newline" even in single-line buffers).
+                KeyCode::Enter if !ctrl && !alt && !shift => {
                     app.confirm_hosts_picker();
                     return;
                 }
@@ -3847,6 +3868,23 @@ pub fn handle_paste(s: String, app: &mut App) {
         && app.global_search.input_focused()
     {
         global_search::handle_paste_search_tab(&s, &mut app.global_search);
+    } else if app.active_tab == Tab::Git
+        && app.active_panel == Panel::Files
+        && app.git_status.commit_editing
+    {
+        // Multi-line textarea: keep `\n` (the textarea is multi-line)
+        // but strip `\r` so CRLF clipboard payloads don't embed
+        // carriage returns into the commit message. Without this,
+        // Windows users pasting a multi-line draft on a terminal that
+        // disagrees with bracketed-paste land with `^M` characters in
+        // `git log` and tripped commit-lint hooks.
+        let filtered: String = s.chars().filter(|c| *c != '\r').collect();
+        if !filtered.is_empty() {
+            let buf = &mut app.git_status.commit_message;
+            let cur = &mut app.git_status.commit_cursor;
+            buf.insert_str(*cur, &filtered);
+            *cur += filtered.len();
+        }
     }
     // No focused input; intentionally dropped. A stray paste into the
     // global keymap has no defined meaning, and we don't want to

--- a/src/input.rs
+++ b/src/input.rs
@@ -630,31 +630,21 @@ fn next_panel(current: Panel, three_col: bool, reverse: bool) -> Panel {
 }
 
 /// SQLite preview page-jump input. While `app.db_goto_input` is
-/// `Some(_)`, this handler fully owns the keyboard. Digits append,
-/// Backspace pops, Enter parses and jumps via
-/// [`App::db_navigate_to_page`], Esc cancels. Anything else is
-/// silently ignored so a stray modifier doesn't accidentally commit
-/// a partial number.
+/// `Some(_)`, this handler fully owns the keyboard.
+///
+/// Two-phase routing matching every other input in reef:
+///   1. Enter parses-and-jumps; Esc cancels.
+///   2. Everything else flows into [`input_edit::dispatch_key_filtered`]
+///      with a digit-only predicate, so the user gets word-motion,
+///      Home/End, Ctrl+U clear, etc. for free while non-digit chars
+///      are silently swallowed.
 fn handle_key_db_goto(key: KeyEvent, app: &mut App) {
     let buf = match app.db_goto_input.as_mut() {
         Some(b) => b,
         None => return,
     };
     match key.code {
-        crossterm::event::KeyCode::Char(c) if c.is_ascii_digit() => {
-            // Cap input length at 18 chars — that's beyond u64::MAX
-            // digit count, so anything longer is the user fat-
-            // fingering rather than a real page number. Silently
-            // dropping the extra keystroke is friendlier than
-            // rejecting the whole buffer.
-            if buf.len() < 18 {
-                buf.push(c);
-            }
-        }
-        crossterm::event::KeyCode::Backspace => {
-            buf.pop();
-        }
-        crossterm::event::KeyCode::Enter => {
+        KeyCode::Enter => {
             // Empty input on Enter → treat as Esc (cancel) rather
             // than parsing "" → 0 → page 0. Keeps the contract
             // friendlier when the user opens the prompt by accident.
@@ -664,17 +654,31 @@ fn handle_key_db_goto(key: KeyEvent, app: &mut App) {
                 buf.parse::<u64>().ok()
             };
             app.db_goto_input = None;
+            app.db_goto_cursor = 0;
             if let Some(page) = parsed {
                 if page > 0 {
                     app.db_navigate_to_page(page);
                 }
             }
+            return;
         }
-        crossterm::event::KeyCode::Esc => {
+        KeyCode::Esc => {
             app.db_goto_input = None;
+            app.db_goto_cursor = 0;
+            return;
         }
         _ => {}
     }
+    // Digit-only + 18-char cap (beyond u64::MAX digit count). The cap
+    // applies only to NEW insertions, not to e.g. Backspace / cursor
+    // motion, hence wrapping it inside the predicate.
+    let current_len = buf.len();
+    let _ = crate::input_edit::dispatch_key_filtered(
+        &key,
+        buf,
+        &mut app.db_goto_cursor,
+        |c| c.is_ascii_digit() && current_len < 18,
+    );
 }
 
 /// 纯预览模式的早期闸门 —— 拦截退出语义 + 文件 picker 相关按键。
@@ -1858,6 +1862,7 @@ fn handle_key_files(key: KeyEvent, app: &mut App) {
                     .is_some_and(|p| p.is_database()) =>
         {
             app.db_goto_input = Some(String::new());
+            app.db_goto_cursor = 0;
         }
         KeyCode::Left if app.active_panel == Panel::Diff => {
             let step = if key.modifiers.contains(KeyModifiers::SHIFT) {
@@ -2015,12 +2020,19 @@ fn handle_key_tree_edit(key: KeyEvent, app: &mut App) {
         _ => {}
     }
 
-    // Phase 2: shared text-input dispatch. No edit-derived side
-    // effect — validation runs on commit, not per-keystroke.
-    let _ = crate::input_edit::dispatch_key(
+    // Phase 2: shared text-input dispatch with inline char filter.
+    // We reject path separators, NUL, and control characters at the
+    // point of insertion — `validate_basename` already rejects them
+    // at commit, but swallowing here gives the user an immediate
+    // signal (no character appears) and keeps the buffer in a
+    // perpetually-valid state. Empty / "." / ".." stay as commit-
+    // time validations since they depend on the full buffer, not a
+    // single char.
+    let _ = crate::input_edit::dispatch_key_filtered(
         &key,
         &mut app.tree_edit.buffer,
         &mut app.tree_edit.cursor,
+        |c| c != '/' && c != '\\' && c != '\0' && !c.is_control(),
     );
 }
 
@@ -2406,6 +2418,7 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
         )
     {
         app.db_goto_input = None;
+        app.db_goto_cursor = 0;
         return;
     }
 

--- a/src/input_edit.rs
+++ b/src/input_edit.rs
@@ -70,7 +70,18 @@ pub fn dispatch_key_filtered(
 ) -> Outcome {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
     let alt = key.modifiers.contains(KeyModifiers::ALT);
-    match key.code {
+    // Snapshot before the dispatch so we can downgrade a "claimed
+    // edit" that didn't actually change anything to `CursorOnly`.
+    // Examples this prevents from firing spurious recomputes:
+    // - Backspace at cursor=0
+    // - Delete at cursor=text.len()
+    // - Ctrl+U on an empty buffer
+    // - Word-delete at the relevant boundary
+    // Without the downgrade, PickerCore maps `Edited → selected_idx
+    // = 0`, so a no-op Backspace would jump the highlighted row from
+    // (say) #5 back to #0 even though the filter didn't change.
+    let pre_len = text.len();
+    let outcome = match key.code {
         // ── Cursor motion ──
         KeyCode::Left if alt || ctrl => {
             move_cursor_word_backward(text, cursor);
@@ -158,7 +169,17 @@ pub fn dispatch_key_filtered(
             }
         }
         _ => Outcome::Unhandled,
+    };
+    // Downgrade an `Edited` that didn't actually move the buffer
+    // length. (Length is a cheap proxy — every edit op that we emit
+    // changes either `text.len()` or fills a previously-empty buffer.
+    // Insert / delete / clear ALL touch length. The single false
+    // negative would be an edit that ADDS one char and REMOVES one
+    // char in the same call, which none of our ops do.)
+    if outcome == Outcome::Edited && text.len() == pre_len {
+        return Outcome::CursorOnly;
     }
+    outcome
 }
 
 pub fn insert_char(text: &mut String, cursor: &mut usize, c: char) {
@@ -576,6 +597,51 @@ mod tests {
         assert_eq!(outcome, Outcome::Rejected);
         assert_eq!(t, "12", "buffer untouched");
         assert_eq!(c, 2, "cursor untouched");
+    }
+
+    #[test]
+    fn backspace_at_cursor_zero_downgrades_to_cursor_only() {
+        // Regression: pre-fix, Backspace at cursor=0 returned
+        // Outcome::Edited even though the buffer was untouched.
+        // PickerCore wrappers map Edited → selected_idx = 0, so a
+        // no-op Backspace would jump the highlighted row from #5 to
+        // #0 with no apparent input change. Downgrade is via the
+        // pre/post length comparison in dispatch_key_filtered.
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let (mut t, mut c) = state("abc", 0);
+        let outcome = dispatch_key(
+            &KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+            &mut t,
+            &mut c,
+        );
+        assert_eq!(outcome, Outcome::CursorOnly);
+        assert_eq!(t, "abc");
+        assert_eq!(c, 0);
+    }
+
+    #[test]
+    fn delete_at_cursor_end_downgrades_to_cursor_only() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let (mut t, mut c) = state("abc", 3);
+        let outcome = dispatch_key(
+            &KeyEvent::new(KeyCode::Delete, KeyModifiers::NONE),
+            &mut t,
+            &mut c,
+        );
+        assert_eq!(outcome, Outcome::CursorOnly);
+        assert_eq!(t, "abc");
+    }
+
+    #[test]
+    fn ctrl_u_on_empty_buffer_downgrades_to_cursor_only() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let (mut t, mut c) = state("", 0);
+        let outcome = dispatch_key(
+            &KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL),
+            &mut t,
+            &mut c,
+        );
+        assert_eq!(outcome, Outcome::CursorOnly);
     }
 
     #[test]

--- a/src/input_edit.rs
+++ b/src/input_edit.rs
@@ -52,9 +52,10 @@ pub fn dispatch_key(key: &KeyEvent, text: &mut String, cursor: &mut usize) -> Ou
 /// Filtered variant of [`dispatch_key`]: every other op (cursor
 /// motion, word-delete, paste, …) is unchanged, but plain-char
 /// insertion is gated by `accept_char`. Rejected chars are swallowed
-/// (Outcome::Unhandled-like effect: returns
-/// [`Outcome::CursorOnly`] so the caller still recognises the key as
-/// consumed but knows the buffer is untouched).
+/// and reported as [`Outcome::Rejected`] so callers can distinguish
+/// "predicate filtered out a char" from "cursor moved without edit"
+/// — important if any derived work (e.g. `mark_query_edited`) only
+/// fires on `Outcome::Edited`.
 ///
 /// Use this for inputs where the buffer has a content predicate the
 /// caller wants enforced inline: db_goto's digit-only page number,

--- a/src/input_edit.rs
+++ b/src/input_edit.rs
@@ -17,16 +17,23 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-/// Result of [`dispatch_key`]. `Edited` and `CursorOnly` both mean the
-/// key was consumed; `Unhandled` lets the caller try its own arms (for
-/// keys that aren't part of the text-input vocabulary, e.g. Esc, Tab,
-/// list navigation).
+/// Result of [`dispatch_key`]. `Edited`, `CursorOnly` and `Rejected`
+/// all mean the key was consumed; `Unhandled` lets the caller try
+/// its own arms (for keys that aren't part of the text-input
+/// vocabulary, e.g. Esc, Tab, list navigation).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Outcome {
     /// Buffer content changed (insert, delete, clear, …).
     Edited,
     /// Recognized cursor-motion key; buffer untouched.
     CursorOnly,
+    /// A printable char was recognised but the caller's
+    /// [`dispatch_key_filtered`] predicate rejected its insertion.
+    /// The key is treated as consumed (no fall-through to global
+    /// hotkeys) but the buffer is unchanged — callers that re-run
+    /// derived work on `Edited` (e.g. `mark_query_edited`) should
+    /// NOT treat this as an edit.
+    Rejected,
     /// Not a text-input key. Caller should match it against its own
     /// per-field handlers.
     Unhandled,
@@ -140,11 +147,13 @@ pub fn dispatch_key_filtered(
                 Outcome::Edited
             } else {
                 // Recognised the keystroke as a printable character but
-                // the caller's predicate rejected it. Treat as consumed
-                // (so the key doesn't fall through to global hotkeys)
-                // but report no edit so the caller can avoid spurious
-                // re-search / re-filter.
-                Outcome::CursorOnly
+                // the caller's predicate rejected it. `Rejected` is
+                // distinct from `CursorOnly` so callers that re-run
+                // derived work on `Edited` (mark_query_edited, etc.)
+                // don't accidentally treat a filtered char as a cursor
+                // move either. Both report "consumed" — the key won't
+                // fall through to global hotkeys.
+                Outcome::Rejected
             }
         }
         _ => Outcome::Unhandled,
@@ -554,7 +563,7 @@ mod tests {
     fn dispatch_filtered_swallows_rejected_char() {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         // Predicate rejects non-digit: 'a' is swallowed but treated
-        // as consumed (CursorOnly, not Unhandled) so it doesn't fall
+        // as consumed (Rejected, not Unhandled) so it doesn't fall
         // through to global hotkeys.
         let (mut t, mut c) = state("12", 2);
         let outcome = dispatch_key_filtered(
@@ -563,7 +572,7 @@ mod tests {
             &mut c,
             |c| c.is_ascii_digit(),
         );
-        assert_eq!(outcome, Outcome::CursorOnly);
+        assert_eq!(outcome, Outcome::Rejected);
         assert_eq!(t, "12", "buffer untouched");
         assert_eq!(c, 2, "cursor untouched");
     }

--- a/src/input_edit.rs
+++ b/src/input_edit.rs
@@ -39,6 +39,27 @@ pub enum Outcome {
 /// invokes any edit-derived side effect (e.g. `mark_query_edited`)
 /// when the result is `Outcome::Edited`.
 pub fn dispatch_key(key: &KeyEvent, text: &mut String, cursor: &mut usize) -> Outcome {
+    dispatch_key_filtered(key, text, cursor, |_| true)
+}
+
+/// Filtered variant of [`dispatch_key`]: every other op (cursor
+/// motion, word-delete, paste, …) is unchanged, but plain-char
+/// insertion is gated by `accept_char`. Rejected chars are swallowed
+/// (Outcome::Unhandled-like effect: returns
+/// [`Outcome::CursorOnly`] so the caller still recognises the key as
+/// consumed but knows the buffer is untouched).
+///
+/// Use this for inputs where the buffer has a content predicate the
+/// caller wants enforced inline: db_goto's digit-only page number,
+/// tree_edit's reject `/`, `\`, NUL, control chars during rename.
+/// Bracketed-paste payloads are NOT filtered here — call
+/// [`paste_single_line`] manually if needed.
+pub fn dispatch_key_filtered(
+    key: &KeyEvent,
+    text: &mut String,
+    cursor: &mut usize,
+    accept_char: impl Fn(char) -> bool,
+) -> Outcome {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
     let alt = key.modifiers.contains(KeyModifiers::ALT);
     match key.code {
@@ -114,8 +135,17 @@ pub fn dispatch_key(key: &KeyEvent, text: &mut String, cursor: &mut usize) -> Ou
             Outcome::Edited
         }
         KeyCode::Char(c) if !ctrl => {
-            insert_char(text, cursor, c);
-            Outcome::Edited
+            if accept_char(c) {
+                insert_char(text, cursor, c);
+                Outcome::Edited
+            } else {
+                // Recognised the keystroke as a printable character but
+                // the caller's predicate rejected it. Treat as consumed
+                // (so the key doesn't fall through to global hotkeys)
+                // but report no edit so the caller can avoid spurious
+                // re-search / re-filter.
+                Outcome::CursorOnly
+            }
         }
         _ => Outcome::Unhandled,
     }
@@ -503,6 +533,56 @@ mod tests {
         assert!(!paste_single_line("\n\r\n", &mut t, &mut c));
         assert_eq!(t, "keep");
         assert_eq!(c, 4);
+    }
+
+    #[test]
+    fn dispatch_filtered_inserts_accepted_char() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let (mut t, mut c) = state("", 0);
+        let outcome = dispatch_key_filtered(
+            &KeyEvent::new(KeyCode::Char('5'), KeyModifiers::NONE),
+            &mut t,
+            &mut c,
+            |c| c.is_ascii_digit(),
+        );
+        assert_eq!(outcome, Outcome::Edited);
+        assert_eq!(t, "5");
+        assert_eq!(c, 1);
+    }
+
+    #[test]
+    fn dispatch_filtered_swallows_rejected_char() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        // Predicate rejects non-digit: 'a' is swallowed but treated
+        // as consumed (CursorOnly, not Unhandled) so it doesn't fall
+        // through to global hotkeys.
+        let (mut t, mut c) = state("12", 2);
+        let outcome = dispatch_key_filtered(
+            &KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
+            &mut t,
+            &mut c,
+            |c| c.is_ascii_digit(),
+        );
+        assert_eq!(outcome, Outcome::CursorOnly);
+        assert_eq!(t, "12", "buffer untouched");
+        assert_eq!(c, 2, "cursor untouched");
+    }
+
+    #[test]
+    fn dispatch_filtered_still_routes_editor_keys() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        // Predicate-rejection only gates Char(c) inserts; word-motion,
+        // delete, Home/End, etc. still route through unchanged.
+        let (mut t, mut c) = state("123", 3);
+        let outcome = dispatch_key_filtered(
+            &KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+            &mut t,
+            &mut c,
+            |_| false, // predicate doesn't matter for non-Char keys
+        );
+        assert_eq!(outcome, Outcome::Edited);
+        assert_eq!(t, "12");
+        assert_eq!(c, 2);
     }
 
     #[test]

--- a/src/input_edit_multi.rs
+++ b/src/input_edit_multi.rs
@@ -35,35 +35,41 @@ use crate::input_edit::{self, Outcome};
 ///   word-motion, delete, Ctrl+A/E, paste, plain-char insert all
 ///   behave identically to the single-line path.
 pub fn dispatch_key_multi(key: &KeyEvent, text: &mut String, cursor: &mut usize) -> Outcome {
-    let no_mods = key.modifiers.is_empty();
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    // All multi-line specifics accept `!ctrl` (Shift / Alt are OK).
+    // Without Shift-tolerance, Shift+Up / Shift+Down / Shift+Home /
+    // Shift+End fall through to the caller as Unhandled, and the
+    // outer Git handler's `Up | Char('k') if !ctrl` arm fires
+    // `navigate_files` mid-message. Shift+arrow text-selection isn't
+    // a thing in this textarea today, so accepting the modifier as
+    // equivalent to bare-key motion is the right call.
     match key.code {
-        // Enter without Ctrl → newline insert (Shift+Enter, Alt+Enter,
-        // Ctrl+Alt+Enter all count). Ctrl+Enter is left for the caller
-        // to interpret as "submit" — Shift+Enter / Alt+Enter falling
-        // through would land in the outer Git handler's
-        // `Char('e') | Enter` arm and open the selected file in
-        // $EDITOR, which is the opposite of "soft newline".
         KeyCode::Enter if !ctrl => {
             input_edit::insert_char(text, cursor, '\n');
             Outcome::Edited
         }
-        KeyCode::Up if no_mods => {
+        KeyCode::Up if !ctrl => {
             move_line_vertical(text, cursor, -1);
             Outcome::CursorOnly
         }
-        KeyCode::Down if no_mods => {
+        KeyCode::Down if !ctrl => {
             move_line_vertical(text, cursor, 1);
             Outcome::CursorOnly
         }
-        KeyCode::Home if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+        KeyCode::Home if !ctrl => {
             *cursor = line_start_of(text, *cursor);
             Outcome::CursorOnly
         }
-        KeyCode::End if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+        KeyCode::End if !ctrl => {
             *cursor = line_end_of(text, *cursor);
             Outcome::CursorOnly
         }
+        // Defensive `\r` filter. Bracketed-paste payloads go through
+        // the paste handler which strips CR explicitly, but some
+        // terminals deliver Char('\r') as a literal key event on
+        // raw paste; without this guard the buffer ingests CR and
+        // `git commit -F -` surfaces `^M` in `git log`.
+        KeyCode::Char('\r') => Outcome::CursorOnly,
         _ => input_edit::dispatch_key(key, text, cursor),
     }
 }
@@ -234,6 +240,20 @@ mod tests {
         let mut c = 0; // start of first line
         dispatch_key_multi(&k(KeyCode::End, KeyModifiers::NONE), &mut t, &mut c);
         assert_eq!(c, 5, "cursor on the '\\n' that ends line 1");
+    }
+
+    #[test]
+    fn shift_up_moves_cursor_like_bare_up() {
+        // Regression: Shift+Up previously failed the `no_mods` gate,
+        // fell through as Unhandled, and the outer Git handler's
+        // `Up | Char('k') if !ctrl` arm navigated the files list
+        // instead of the textarea cursor. With the widened `!ctrl`
+        // gate, Shift+Up behaves identically to bare Up.
+        let mut t = "alpha\nbeta\ngamma".to_string();
+        let mut c = "alpha\nbeta\nga".len(); // column 2 on "gamma"
+        let outcome = dispatch_key_multi(&k(KeyCode::Up, KeyModifiers::SHIFT), &mut t, &mut c);
+        assert_eq!(outcome, Outcome::CursorOnly);
+        assert_eq!(c, 8, "should land at column 2 on 'beta'");
     }
 
     #[test]

--- a/src/input_edit_multi.rs
+++ b/src/input_edit_multi.rs
@@ -116,7 +116,7 @@ pub fn move_line_vertical(text: &str, cursor: &mut usize, delta: i32) {
         let prev_line_start = line_start_of(text, prev_line_end);
         let prev_line_len = prev_line_end - prev_line_start;
         let target = prev_line_start + column.min(prev_line_len);
-        *cursor = next_safe_boundary(text, target);
+        *cursor = prev_safe_boundary(text, target);
     } else {
         // Move to the next line.
         let line_end = line_end_of(text, clamped);
@@ -129,20 +129,26 @@ pub fn move_line_vertical(text: &str, cursor: &mut usize, delta: i32) {
         let next_line_end = line_end_of(text, next_line_start);
         let next_line_len = next_line_end - next_line_start;
         let target = next_line_start + column.min(next_line_len);
-        *cursor = next_safe_boundary(text, target);
+        *cursor = prev_safe_boundary(text, target);
     }
 }
 
-/// Snap to the nearest valid UTF-8 char boundary at or after `target`.
-/// Defends `move_line_vertical` against the case where the byte-column
-/// from the source line lands mid-codepoint on the destination line
-/// (e.g. source line had "abc" + cursor at 2, destination is "你好"
-/// — byte 2 is mid-`你`). Walks forward to the next boundary to keep
-/// the cursor invariant: always on a char boundary.
-fn next_safe_boundary(text: &str, target: usize) -> usize {
+/// Snap to the nearest valid UTF-8 char boundary at or BEFORE
+/// `target`. Defends `move_line_vertical` against the case where the
+/// byte-column from the source line lands mid-codepoint on the
+/// destination line (e.g. source "abc" cursor at col 2 → target line
+/// "你好" col 2 → byte 2 is mid-`你`).
+///
+/// The backward direction is deliberate: a byte-column of N means
+/// "after N source bytes". Walking *forward* on a CJK destination
+/// would overshoot — the cursor lands one codepoint to the right of
+/// the visual column the user expects. Walking backward keeps the
+/// caret at-or-before the intended visual column, matching how
+/// most editors (vim, emacs) handle the equivalent navigation.
+fn prev_safe_boundary(text: &str, target: usize) -> usize {
     let mut p = target.min(text.len());
-    while p < text.len() && !text.is_char_boundary(p) {
-        p += 1;
+    while p > 0 && !text.is_char_boundary(p) {
+        p -= 1;
     }
     p
 }
@@ -241,8 +247,10 @@ mod tests {
         let mut c = 2; // column 2 on line "abc"
         dispatch_key_multi(&k(KeyCode::Down, KeyModifiers::NONE), &mut t, &mut c);
         // Column 2 in "你好" would be mid-codepoint of '你' (3-byte);
-        // next_safe_boundary should snap forward to byte 3 (after '你').
-        assert_eq!(c, "abc\n你".len());
+        // prev_safe_boundary snaps BACKWARD to byte 0 (before '你')
+        // so the caret stays at-or-before the source's visual column
+        // instead of overshooting to byte 3 (after '你').
+        assert_eq!(c, "abc\n".len());
         assert!(t.is_char_boundary(c));
     }
 

--- a/src/input_edit_multi.rs
+++ b/src/input_edit_multi.rs
@@ -36,8 +36,15 @@ use crate::input_edit::{self, Outcome};
 ///   behave identically to the single-line path.
 pub fn dispatch_key_multi(key: &KeyEvent, text: &mut String, cursor: &mut usize) -> Outcome {
     let no_mods = key.modifiers.is_empty();
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
     match key.code {
-        KeyCode::Enter if no_mods => {
+        // Enter without Ctrl → newline insert (Shift+Enter, Alt+Enter,
+        // Ctrl+Alt+Enter all count). Ctrl+Enter is left for the caller
+        // to interpret as "submit" — Shift+Enter / Alt+Enter falling
+        // through would land in the outer Git handler's
+        // `Char('e') | Enter` arm and open the selected file in
+        // $EDITOR, which is the opposite of "soft newline".
+        KeyCode::Enter if !ctrl => {
             input_edit::insert_char(text, cursor, '\n');
             Outcome::Edited
         }
@@ -173,6 +180,47 @@ mod tests {
     }
 
     #[test]
+    fn shift_enter_inserts_newline() {
+        // Regression: Shift+Enter is the universal "soft newline"
+        // convention in IM / VSCode / GitHub. Before the gate was
+        // widened from `no_mods` to `!ctrl`, this returned Unhandled
+        // and the outer Git handler interpreted Enter as "open file
+        // in $EDITOR" — a destructive surprise mid-typing.
+        let mut t = "ab".to_string();
+        let mut c = 1;
+        let outcome = dispatch_key_multi(&k(KeyCode::Enter, KeyModifiers::SHIFT), &mut t, &mut c);
+        assert_eq!(outcome, Outcome::Edited);
+        assert_eq!(t, "a\nb");
+        assert_eq!(c, 2);
+    }
+
+    #[test]
+    fn alt_enter_inserts_newline() {
+        // Same regression class as Shift+Enter: Alt+Enter pre-fix
+        // fell through to the outer Git handler.
+        let mut t = "ab".to_string();
+        let mut c = 1;
+        let outcome = dispatch_key_multi(&k(KeyCode::Enter, KeyModifiers::ALT), &mut t, &mut c);
+        assert_eq!(outcome, Outcome::Edited);
+        assert_eq!(t, "a\nb");
+    }
+
+    #[test]
+    fn ctrl_enter_unhandled_so_caller_can_submit() {
+        // The one Enter variant we deliberately don't insert: Ctrl+Enter
+        // is the textarea-submit convention (handled by the caller).
+        let mut t = "msg".to_string();
+        let mut c = 3;
+        let outcome = dispatch_key_multi(
+            &k(KeyCode::Enter, KeyModifiers::CONTROL),
+            &mut t,
+            &mut c,
+        );
+        assert_eq!(outcome, Outcome::Unhandled);
+        assert_eq!(t, "msg", "buffer untouched");
+    }
+
+    #[test]
     fn home_snaps_to_line_start_not_buffer_start() {
         let mut t = "first\nsecond".to_string();
         let mut c = "first\nsecond".len(); // end of second line
@@ -270,9 +318,8 @@ mod tests {
 
     #[test]
     fn ctrl_enter_falls_through_for_caller_to_handle() {
-        // Bare Enter inserts newline; Ctrl+Enter should NOT (caller
-        // intercepts it for "submit"). Verify by checking that
-        // dispatch_key_multi with Ctrl+Enter doesn't mutate the buffer.
+        // Superseded by `ctrl_enter_unhandled_so_caller_can_submit`
+        // above — kept as a docs-style regression sentinel.
         let mut t = "msg".to_string();
         let mut c = 3;
         let outcome = dispatch_key_multi(
@@ -280,9 +327,6 @@ mod tests {
             &mut t,
             &mut c,
         );
-        // Single-line dispatch doesn't know Enter either, so returns
-        // Unhandled. That's what we want — caller layer handles
-        // Ctrl+Enter explicitly before calling us.
         assert_eq!(outcome, Outcome::Unhandled);
         assert_eq!(t, "msg");
         assert_eq!(c, 3);

--- a/src/input_edit_multi.rs
+++ b/src/input_edit_multi.rs
@@ -1,0 +1,302 @@
+//! Multi-line variant of [`crate::input_edit`].
+//!
+//! `dispatch_key_multi` extends the single-line editor vocabulary with
+//! line-aware cursor motion (Up/Down across visual lines, Home/End by
+//! current line) and treats a bare Enter as a newline insert instead of
+//! "submit". Everything else — word-motion, word-delete, paste, char
+//! insert with UTF-8 boundary safety — is delegated to the single-line
+//! primitives so the two layers stay consistent.
+//!
+//! Hard-wrap / soft-wrap awareness is intentionally out of scope: the
+//! buffer model is "flat string with embedded `\n`", which matches how
+//! every multi-line textarea in reef (currently just the Git tab's
+//! commit message) actually stores its content. Callers that want
+//! visual column tracking on top of wrapped lines need to keep their
+//! own "preferred column" state and feed it back here — not yet
+//! exercised, so deliberately left to a future caller.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::input_edit::{self, Outcome};
+
+/// Multi-line variant of [`input_edit::dispatch_key`]. Differences:
+///
+/// - **Bare `Enter`** inserts a literal `\n` (`Outcome::Edited`). Single-line
+///   inputs treat Enter as "commit"; multi-line buffers need a way to
+///   start a new paragraph. Callers that want a submit shortcut should
+///   match `Ctrl+Enter` (or whatever they prefer) BEFORE calling this
+///   dispatcher and `return` early.
+/// - **`Up`/`Down`** move the cursor to the same byte-column on the
+///   previous / next line, clamped to that line's length. Returned as
+///   `Outcome::CursorOnly`.
+/// - **`Home`/`End`** snap to the start / end of the current line
+///   (i.e. between the surrounding `\n`s), not the whole buffer.
+/// - **Everything else** flows into `input_edit::dispatch_key` —
+///   word-motion, delete, Ctrl+A/E, paste, plain-char insert all
+///   behave identically to the single-line path.
+pub fn dispatch_key_multi(key: &KeyEvent, text: &mut String, cursor: &mut usize) -> Outcome {
+    let no_mods = key.modifiers.is_empty();
+    match key.code {
+        KeyCode::Enter if no_mods => {
+            input_edit::insert_char(text, cursor, '\n');
+            Outcome::Edited
+        }
+        KeyCode::Up if no_mods => {
+            move_line_vertical(text, cursor, -1);
+            Outcome::CursorOnly
+        }
+        KeyCode::Down if no_mods => {
+            move_line_vertical(text, cursor, 1);
+            Outcome::CursorOnly
+        }
+        KeyCode::Home if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+            *cursor = line_start_of(text, *cursor);
+            Outcome::CursorOnly
+        }
+        KeyCode::End if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+            *cursor = line_end_of(text, *cursor);
+            Outcome::CursorOnly
+        }
+        _ => input_edit::dispatch_key(key, text, cursor),
+    }
+}
+
+/// Byte offset of the `\n` that starts the line containing `cursor`,
+/// or 0 if `cursor` is on the first line. The returned offset points
+/// AT the first character of the current line (immediately after the
+/// preceding `\n`, or position 0 for the first line).
+pub fn line_start_of(text: &str, cursor: usize) -> usize {
+    let clamped = cursor.min(text.len());
+    text[..clamped].rfind('\n').map(|p| p + 1).unwrap_or(0)
+}
+
+/// Byte offset of the `\n` that ends the line containing `cursor`, or
+/// `text.len()` if `cursor` is on the last (unterminated) line. Points
+/// AT the trailing `\n`, not past it — same convention as
+/// `line_start_of` returning the first char of the next line.
+pub fn line_end_of(text: &str, cursor: usize) -> usize {
+    let clamped = cursor.min(text.len());
+    text[clamped..]
+        .find('\n')
+        .map(|p| clamped + p)
+        .unwrap_or(text.len())
+}
+
+/// Move `cursor` `delta` visual lines (negative = up, positive =
+/// down), preserving the byte-column within the line where possible.
+/// Clamps when the destination line is shorter — Up at the first
+/// line goes to column 0; Down at the last line goes to end of file.
+///
+/// The "byte-column" tracking here is intentionally coarse: a single
+/// CJK / emoji code-point counts as one byte-column unit equal to its
+/// UTF-8 length, not its visual width. That mirrors how every
+/// single-line `input_edit` op already treats byte offsets, and
+/// matches what the textarea renderer sees when laying out lines.
+/// Width-aware column tracking would require a per-line wrap pass —
+/// not worth the complexity until a caller actually needs it.
+pub fn move_line_vertical(text: &str, cursor: &mut usize, delta: i32) {
+    if delta == 0 || text.is_empty() {
+        return;
+    }
+    let clamped = (*cursor).min(text.len());
+    let line_start = line_start_of(text, clamped);
+    let column = clamped - line_start;
+
+    if delta < 0 {
+        // Move to the previous line — `line_start - 1` lands on the
+        // `\n` that ends the previous line; one more `rfind` gives
+        // that line's start.
+        if line_start == 0 {
+            // Already on the first line: snap to start (mirrors how
+            // most editors behave when Up has nowhere to go).
+            *cursor = 0;
+            return;
+        }
+        let prev_line_end = line_start - 1; // position of the '\n'
+        let prev_line_start = line_start_of(text, prev_line_end);
+        let prev_line_len = prev_line_end - prev_line_start;
+        let target = prev_line_start + column.min(prev_line_len);
+        *cursor = next_safe_boundary(text, target);
+    } else {
+        // Move to the next line.
+        let line_end = line_end_of(text, clamped);
+        if line_end == text.len() {
+            // Already on the last line: snap to EOF.
+            *cursor = text.len();
+            return;
+        }
+        let next_line_start = line_end + 1; // skip the '\n'
+        let next_line_end = line_end_of(text, next_line_start);
+        let next_line_len = next_line_end - next_line_start;
+        let target = next_line_start + column.min(next_line_len);
+        *cursor = next_safe_boundary(text, target);
+    }
+}
+
+/// Snap to the nearest valid UTF-8 char boundary at or after `target`.
+/// Defends `move_line_vertical` against the case where the byte-column
+/// from the source line lands mid-codepoint on the destination line
+/// (e.g. source line had "abc" + cursor at 2, destination is "你好"
+/// — byte 2 is mid-`你`). Walks forward to the next boundary to keep
+/// the cursor invariant: always on a char boundary.
+fn next_safe_boundary(text: &str, target: usize) -> usize {
+    let mut p = target.min(text.len());
+    while p < text.len() && !text.is_char_boundary(p) {
+        p += 1;
+    }
+    p
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn k(code: KeyCode, mods: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, mods)
+    }
+
+    #[test]
+    fn enter_inserts_newline() {
+        let mut t = "ab".to_string();
+        let mut c = 1;
+        let outcome = dispatch_key_multi(&k(KeyCode::Enter, KeyModifiers::NONE), &mut t, &mut c);
+        assert_eq!(outcome, Outcome::Edited);
+        assert_eq!(t, "a\nb");
+        assert_eq!(c, 2);
+    }
+
+    #[test]
+    fn home_snaps_to_line_start_not_buffer_start() {
+        let mut t = "first\nsecond".to_string();
+        let mut c = "first\nsecond".len(); // end of second line
+        dispatch_key_multi(&k(KeyCode::Home, KeyModifiers::NONE), &mut t, &mut c);
+        assert_eq!(c, 6, "cursor on start of 'second'");
+    }
+
+    #[test]
+    fn end_snaps_to_line_end_not_buffer_end() {
+        let mut t = "first\nsecond".to_string();
+        let mut c = 0; // start of first line
+        dispatch_key_multi(&k(KeyCode::End, KeyModifiers::NONE), &mut t, &mut c);
+        assert_eq!(c, 5, "cursor on the '\\n' that ends line 1");
+    }
+
+    #[test]
+    fn up_moves_cursor_to_previous_line_same_column() {
+        let mut t = "alpha\nbeta\ngamma".to_string();
+        let mut c = "alpha\nbeta\nga".len(); // column 2 on line "gamma"
+        dispatch_key_multi(&k(KeyCode::Up, KeyModifiers::NONE), &mut t, &mut c);
+        // Should land at column 2 on "beta" — byte offset 6 + 2 = 8.
+        assert_eq!(c, 8);
+    }
+
+    #[test]
+    fn down_moves_cursor_to_next_line_same_column() {
+        let mut t = "alpha\nbeta\ngamma".to_string();
+        let mut c = 2; // column 2 on line "alpha"
+        dispatch_key_multi(&k(KeyCode::Down, KeyModifiers::NONE), &mut t, &mut c);
+        // Should land at column 2 on "beta" — byte offset 6 + 2 = 8.
+        assert_eq!(c, 8);
+    }
+
+    #[test]
+    fn up_clamps_to_shorter_previous_line() {
+        let mut t = "x\nyyyyyy".to_string();
+        let mut c = "x\nyyy".len(); // column 3 on line "yyyyyy"
+        dispatch_key_multi(&k(KeyCode::Up, KeyModifiers::NONE), &mut t, &mut c);
+        // "x" has only 1 char — column clamps to 1 (end of line).
+        assert_eq!(c, 1);
+    }
+
+    #[test]
+    fn up_on_first_line_goes_to_buffer_start() {
+        let mut t = "alpha".to_string();
+        let mut c = 3;
+        dispatch_key_multi(&k(KeyCode::Up, KeyModifiers::NONE), &mut t, &mut c);
+        assert_eq!(c, 0);
+    }
+
+    #[test]
+    fn down_on_last_line_goes_to_buffer_end() {
+        let mut t = "alpha".to_string();
+        let mut c = 1;
+        dispatch_key_multi(&k(KeyCode::Down, KeyModifiers::NONE), &mut t, &mut c);
+        assert_eq!(c, 5);
+    }
+
+    #[test]
+    fn up_lands_on_char_boundary_with_cjk() {
+        let mut t = "abc\n你好".to_string();
+        let mut c = "abc\n你".len(); // 3 + 1 + 3 = 7; column = 3 on line "你好"
+        dispatch_key_multi(&k(KeyCode::Up, KeyModifiers::NONE), &mut t, &mut c);
+        // Source column 3 → on "abc", that's the end of line.
+        assert_eq!(c, 3);
+        assert!(t.is_char_boundary(c));
+    }
+
+    #[test]
+    fn down_lands_on_char_boundary_with_cjk() {
+        let mut t = "abc\n你好".to_string();
+        let mut c = 2; // column 2 on line "abc"
+        dispatch_key_multi(&k(KeyCode::Down, KeyModifiers::NONE), &mut t, &mut c);
+        // Column 2 in "你好" would be mid-codepoint of '你' (3-byte);
+        // next_safe_boundary should snap forward to byte 3 (after '你').
+        assert_eq!(c, "abc\n你".len());
+        assert!(t.is_char_boundary(c));
+    }
+
+    #[test]
+    fn other_keys_fall_through_to_single_line_dispatch() {
+        let mut t = "hello world".to_string();
+        let mut c = 11;
+        // Ctrl+W should still word-delete via the single-line dispatcher.
+        let outcome = dispatch_key_multi(
+            &k(KeyCode::Char('w'), KeyModifiers::CONTROL),
+            &mut t,
+            &mut c,
+        );
+        assert_eq!(outcome, Outcome::Edited);
+        assert_eq!(t, "hello ");
+    }
+
+    #[test]
+    fn ctrl_enter_falls_through_for_caller_to_handle() {
+        // Bare Enter inserts newline; Ctrl+Enter should NOT (caller
+        // intercepts it for "submit"). Verify by checking that
+        // dispatch_key_multi with Ctrl+Enter doesn't mutate the buffer.
+        let mut t = "msg".to_string();
+        let mut c = 3;
+        let outcome = dispatch_key_multi(
+            &k(KeyCode::Enter, KeyModifiers::CONTROL),
+            &mut t,
+            &mut c,
+        );
+        // Single-line dispatch doesn't know Enter either, so returns
+        // Unhandled. That's what we want — caller layer handles
+        // Ctrl+Enter explicitly before calling us.
+        assert_eq!(outcome, Outcome::Unhandled);
+        assert_eq!(t, "msg");
+        assert_eq!(c, 3);
+    }
+
+    #[test]
+    fn line_start_of_first_line() {
+        assert_eq!(line_start_of("foo\nbar", 2), 0);
+    }
+
+    #[test]
+    fn line_start_of_second_line() {
+        assert_eq!(line_start_of("foo\nbar", 5), 4); // 'b' position
+    }
+
+    #[test]
+    fn line_end_of_last_line_unterminated() {
+        assert_eq!(line_end_of("foo\nbar", 5), 7); // text.len()
+    }
+
+    #[test]
+    fn line_end_of_middle_line() {
+        assert_eq!(line_end_of("foo\nbar\nbaz", 5), 7); // the '\n' after "bar"
+    }
+}

--- a/src/input_edit_multi.rs
+++ b/src/input_edit_multi.rs
@@ -217,11 +217,7 @@ mod tests {
         // is the textarea-submit convention (handled by the caller).
         let mut t = "msg".to_string();
         let mut c = 3;
-        let outcome = dispatch_key_multi(
-            &k(KeyCode::Enter, KeyModifiers::CONTROL),
-            &mut t,
-            &mut c,
-        );
+        let outcome = dispatch_key_multi(&k(KeyCode::Enter, KeyModifiers::CONTROL), &mut t, &mut c);
         assert_eq!(outcome, Outcome::Unhandled);
         assert_eq!(t, "msg", "buffer untouched");
     }
@@ -342,11 +338,7 @@ mod tests {
         // above — kept as a docs-style regression sentinel.
         let mut t = "msg".to_string();
         let mut c = 3;
-        let outcome = dispatch_key_multi(
-            &k(KeyCode::Enter, KeyModifiers::CONTROL),
-            &mut t,
-            &mut c,
-        );
+        let outcome = dispatch_key_multi(&k(KeyCode::Enter, KeyModifiers::CONTROL), &mut t, &mut c);
         assert_eq!(outcome, Outcome::Unhandled);
         assert_eq!(t, "msg");
         assert_eq!(c, 3);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod find_widget;
 pub mod fs_watcher;
 pub mod git;
 pub mod global_search;
+pub mod graph_branch_picker;
 pub mod hosts;
 pub mod hosts_picker;
 pub mod i18n;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod images;
 pub mod input;
 pub mod input_edit;
 pub mod paste_conflict;
+pub mod picker_core;
 pub mod place_mode;
 pub mod prefs;
 pub mod quick_open;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod i18n;
 pub mod images;
 pub mod input;
 pub mod input_edit;
+pub mod input_edit_multi;
 pub mod paste_conflict;
 pub mod picker_core;
 pub mod place_mode;

--- a/src/main.rs
+++ b/src/main.rs
@@ -375,9 +375,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         // the full-screen Settings page own every key unconditionally —
                         // 'any key' must not dismiss help while one of them is up — so
                         // route to handle_key first and let it delegate to the page.
-                        if app.quick_open.active
-                            || app.global_search.active
-                            || app.hosts_picker.active
+                        if app.quick_open.core.active
+                            || app.global_search.core.active
+                            || app.hosts_picker.core.active
                             || app.view_mode == ViewMode::Settings
                             || app.view_mode == ViewMode::FocusedPreview
                         {

--- a/src/picker_core.rs
+++ b/src/picker_core.rs
@@ -49,17 +49,27 @@ pub struct PickerCore {
 /// Callers translate these into picker-specific actions:
 ///
 /// ```text
-/// Cancel         → close()         (and possibly extra state cleanup)
+/// Cancel         → close()                   (Esc — close picker only)
+/// Quit           → close() + should_quit     (Ctrl+C — close + app quit)
 /// Confirm        → look up the row at `selected_idx`, act on it
 /// Edited         → recompute the candidate list against `filter`
 /// SelectionMoved → no-op (renderer already sees the new cursor)
 /// CursorMoved    → no-op (filter buffer cursor moved inside text)
-/// Unhandled      → caller's own match arms (e.g. picker-specific
-///                  shortcuts like leader chords / mode toggles)
+/// Unhandled      → the picker fully consumed the key as a no-op; do
+///                  NOT forward it elsewhere. Overlays own keyboard
+///                  while active so unknown keys are intentionally
+///                  swallowed rather than bubbled up to global hotkeys.
 /// ```
+///
+/// `Cancel` and `Quit` are split so callers can wire `should_quit`
+/// in one place — letting them collapse to a single outcome forces
+/// every site to re-derive Ctrl+C by re-matching `key.code`, which
+/// is the kind of duplication that drifts the first time a new
+/// caller forgets to copy the branch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InputOutcome {
     Cancel,
+    Quit,
     Confirm,
     Edited,
     SelectionMoved,
@@ -123,7 +133,7 @@ impl PickerCore {
         // Phase 1: list nav + close + commit.
         match key.code {
             KeyCode::Esc => return InputOutcome::Cancel,
-            KeyCode::Char('c') if ctrl => return InputOutcome::Cancel,
+            KeyCode::Char('c') if ctrl => return InputOutcome::Quit,
             KeyCode::Enter => return InputOutcome::Confirm,
             KeyCode::Up => {
                 self.move_selection(visible_count, -1);
@@ -153,6 +163,11 @@ impl PickerCore {
                 InputOutcome::Edited
             }
             crate::input_edit::Outcome::CursorOnly => InputOutcome::CursorMoved,
+            // PickerCore uses the non-filtered dispatcher so Rejected
+            // can't actually appear here; map it to CursorMoved as a
+            // defensive default if a future variant of dispatch_key
+            // starts emitting Rejected against this code path.
+            crate::input_edit::Outcome::Rejected => InputOutcome::CursorMoved,
             crate::input_edit::Outcome::Unhandled => InputOutcome::Unhandled,
         }
     }
@@ -220,11 +235,11 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_ctrl_c_returns_cancel() {
+    fn dispatch_ctrl_c_returns_quit() {
         let mut c = PickerCore::default();
         assert_eq!(
             c.dispatch_key(&k(KeyCode::Char('c'), KeyModifiers::CONTROL), 5),
-            InputOutcome::Cancel
+            InputOutcome::Quit
         );
     }
 

--- a/src/picker_core.rs
+++ b/src/picker_core.rs
@@ -1,0 +1,293 @@
+//! Shared state + key dispatch for "filter-driven overlay" pickers.
+//!
+//! Four overlays in reef share the same skeleton: filter input on top,
+//! a list of candidate rows below, Esc closes / Enter commits / arrow
+//! keys (plus Ctrl+J/K/N/P readline aliases) navigate the list. Each
+//! one used to hand-roll the input loop on top of
+//! [`crate::input_edit::dispatch_key`]; this module collapses the
+//! shared scaffolding into a single struct + dispatcher so individual
+//! pickers only need to supply their domain-specific bits
+//! (`visible_rows()`, `commit(row)`, leader-chord / extra shortcuts).
+//!
+//! Pickers that consume this:
+//! - `graph_branch_picker` (`b` key on the Graph tab)
+//! - `hosts_picker` (Ctrl+O — note: also owns a secondary `path_buffer`
+//!   that's edited via `input_edit::dispatch_key` directly, not through
+//!   PickerCore, because PickerCore tracks one buffer at a time)
+//! - `quick_open` (Space+P palette)
+//! - `global_search` overlay (Space+F)
+//!
+//! `find_widget` is intentionally NOT a consumer: it has a filter and a
+//! "current match" cursor that walks the underlying text, not a
+//! drop-down list, so it doesn't share PickerCore's selection model.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::layout::Rect;
+
+/// Shared state for a filter-driven picker overlay. Each consuming
+/// picker holds this as a field (e.g. `pub core: PickerCore`) and
+/// keeps its domain-specific data (`all_hosts`, `recent`,
+/// `space_leader_at`, …) alongside.
+#[derive(Debug, Default)]
+pub struct PickerCore {
+    pub active: bool,
+    /// Text in the filter input. Edited via `dispatch_key` / paste.
+    pub filter: String,
+    /// Byte offset into `filter` (UTF-8 char boundary). Maintained
+    /// alongside `filter` by [`crate::input_edit`].
+    pub cursor: usize,
+    /// Index into `visible_rows()` of the row currently highlighted.
+    /// Always reset to 0 on filter edit so the next match lands at the
+    /// top — matches the UX convention every reef picker uses.
+    pub selected_idx: usize,
+    /// Cached popup rect for mouse hit-testing. Set by the panel
+    /// renderer each frame, read by the click/scroll handler.
+    pub last_popup_area: Option<Rect>,
+}
+
+/// Outcome of dispatching a key event to [`PickerCore::dispatch_key`].
+/// Callers translate these into picker-specific actions:
+///
+/// ```text
+/// Cancel         → close()         (and possibly extra state cleanup)
+/// Confirm        → look up the row at `selected_idx`, act on it
+/// Edited         → recompute the candidate list against `filter`
+/// SelectionMoved → no-op (renderer already sees the new cursor)
+/// CursorMoved    → no-op (filter buffer cursor moved inside text)
+/// Unhandled      → caller's own match arms (e.g. picker-specific
+///                  shortcuts like leader chords / mode toggles)
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputOutcome {
+    Cancel,
+    Confirm,
+    Edited,
+    SelectionMoved,
+    CursorMoved,
+    Unhandled,
+}
+
+impl PickerCore {
+    /// Open the overlay, resetting filter / cursor / selection.
+    /// Domain-specific data (cached candidates, recents, etc.) should
+    /// be set by the caller *before* calling this — `open()` is the
+    /// last step that flips `active` to true.
+    pub fn open(&mut self) {
+        self.filter.clear();
+        self.cursor = 0;
+        self.selected_idx = 0;
+        self.active = true;
+    }
+
+    /// Close the overlay and wipe transient state (filter, cursor,
+    /// selection, mouse rect). Caller is responsible for any picker-
+    /// specific cleanup (e.g. clearing `path_buffer` in hosts_picker).
+    pub fn close(&mut self) {
+        self.active = false;
+        self.filter.clear();
+        self.cursor = 0;
+        self.selected_idx = 0;
+        self.last_popup_area = None;
+    }
+
+    /// Clamp `selected_idx` against the current visible row count and
+    /// move it by `delta` (negative = up). Used by the standard
+    /// key/scroll handlers and by callers that need to drive selection
+    /// from outside the key path (mouse wheel, PageUp/PageDown with a
+    /// view_h step).
+    pub fn move_selection(&mut self, visible_count: usize, delta: i32) {
+        if visible_count == 0 {
+            self.selected_idx = 0;
+            return;
+        }
+        let last = visible_count as i32 - 1;
+        let next = (self.selected_idx as i32 + delta).clamp(0, last);
+        self.selected_idx = next as usize;
+    }
+
+    /// Standard picker key dispatch. Two-phase:
+    ///   1. List navigation + close + commit (Esc/Ctrl+C, Enter,
+    ///      Up/Down/Ctrl+J/K/N/P).
+    ///   2. Filter editing via [`crate::input_edit::dispatch_key`].
+    ///
+    /// `visible_count` is the row count caller's `visible_rows()` would
+    /// produce *right now*; needed for selection clamping. Pass 0 when
+    /// the picker has no rows yet (the cursor will just snap to 0).
+    ///
+    /// Callers that own extra shortcuts (leader chords, Alt-modifier
+    /// toggles, Ctrl+P mode-switch in hosts_picker) should match those
+    /// BEFORE calling `dispatch_key` and `return` early; otherwise the
+    /// editor table would consume them as plain inserts.
+    pub fn dispatch_key(&mut self, key: &KeyEvent, visible_count: usize) -> InputOutcome {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        // Phase 1: list nav + close + commit.
+        match key.code {
+            KeyCode::Esc => return InputOutcome::Cancel,
+            KeyCode::Char('c') if ctrl => return InputOutcome::Cancel,
+            KeyCode::Enter => return InputOutcome::Confirm,
+            KeyCode::Up => {
+                self.move_selection(visible_count, -1);
+                return InputOutcome::SelectionMoved;
+            }
+            KeyCode::Down => {
+                self.move_selection(visible_count, 1);
+                return InputOutcome::SelectionMoved;
+            }
+            KeyCode::Char('k' | 'p') if ctrl => {
+                self.move_selection(visible_count, -1);
+                return InputOutcome::SelectionMoved;
+            }
+            KeyCode::Char('j' | 'n') if ctrl => {
+                self.move_selection(visible_count, 1);
+                return InputOutcome::SelectionMoved;
+            }
+            _ => {}
+        }
+
+        // Phase 2: shared editor table. Reset selection on any genuine
+        // edit so the filtered list always opens at row 0.
+        let outcome = crate::input_edit::dispatch_key(key, &mut self.filter, &mut self.cursor);
+        match outcome {
+            crate::input_edit::Outcome::Edited => {
+                self.selected_idx = 0;
+                InputOutcome::Edited
+            }
+            crate::input_edit::Outcome::CursorOnly => InputOutcome::CursorMoved,
+            crate::input_edit::Outcome::Unhandled => InputOutcome::Unhandled,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn k(code: KeyCode, mods: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, mods)
+    }
+
+    #[test]
+    fn open_resets_filter_and_selection() {
+        let mut c = PickerCore {
+            filter: "stale".into(),
+            cursor: 5,
+            selected_idx: 3,
+            ..Default::default()
+        };
+        c.open();
+        assert!(c.active);
+        assert!(c.filter.is_empty());
+        assert_eq!(c.cursor, 0);
+        assert_eq!(c.selected_idx, 0);
+    }
+
+    #[test]
+    fn close_clears_state() {
+        let mut c = PickerCore {
+            active: true,
+            filter: "x".into(),
+            cursor: 1,
+            selected_idx: 2,
+            last_popup_area: Some(Rect::new(0, 0, 1, 1)),
+        };
+        c.close();
+        assert!(!c.active);
+        assert!(c.filter.is_empty());
+        assert_eq!(c.cursor, 0);
+        assert_eq!(c.selected_idx, 0);
+        assert!(c.last_popup_area.is_none());
+    }
+
+    #[test]
+    fn move_selection_clamps() {
+        let mut c = PickerCore::default();
+        c.move_selection(5, 10);
+        assert_eq!(c.selected_idx, 4);
+        c.move_selection(5, -99);
+        assert_eq!(c.selected_idx, 0);
+        c.move_selection(0, 1); // empty rows
+        assert_eq!(c.selected_idx, 0);
+    }
+
+    #[test]
+    fn dispatch_esc_returns_cancel() {
+        let mut c = PickerCore::default();
+        assert_eq!(
+            c.dispatch_key(&k(KeyCode::Esc, KeyModifiers::NONE), 5),
+            InputOutcome::Cancel
+        );
+    }
+
+    #[test]
+    fn dispatch_ctrl_c_returns_cancel() {
+        let mut c = PickerCore::default();
+        assert_eq!(
+            c.dispatch_key(&k(KeyCode::Char('c'), KeyModifiers::CONTROL), 5),
+            InputOutcome::Cancel
+        );
+    }
+
+    #[test]
+    fn dispatch_enter_returns_confirm() {
+        let mut c = PickerCore::default();
+        assert_eq!(
+            c.dispatch_key(&k(KeyCode::Enter, KeyModifiers::NONE), 5),
+            InputOutcome::Confirm
+        );
+    }
+
+    #[test]
+    fn dispatch_arrows_and_readline_aliases_move_selection() {
+        let mut c = PickerCore::default();
+        // Down
+        assert_eq!(
+            c.dispatch_key(&k(KeyCode::Down, KeyModifiers::NONE), 5),
+            InputOutcome::SelectionMoved
+        );
+        assert_eq!(c.selected_idx, 1);
+        // Ctrl+J
+        c.dispatch_key(&k(KeyCode::Char('j'), KeyModifiers::CONTROL), 5);
+        assert_eq!(c.selected_idx, 2);
+        // Ctrl+N
+        c.dispatch_key(&k(KeyCode::Char('n'), KeyModifiers::CONTROL), 5);
+        assert_eq!(c.selected_idx, 3);
+        // Up
+        c.dispatch_key(&k(KeyCode::Up, KeyModifiers::NONE), 5);
+        assert_eq!(c.selected_idx, 2);
+        // Ctrl+K
+        c.dispatch_key(&k(KeyCode::Char('k'), KeyModifiers::CONTROL), 5);
+        assert_eq!(c.selected_idx, 1);
+        // Ctrl+P
+        c.dispatch_key(&k(KeyCode::Char('p'), KeyModifiers::CONTROL), 5);
+        assert_eq!(c.selected_idx, 0);
+    }
+
+    #[test]
+    fn dispatch_char_inserts_into_filter_and_resets_selection() {
+        let mut c = PickerCore {
+            selected_idx: 4,
+            ..Default::default()
+        };
+        let outcome = c.dispatch_key(&k(KeyCode::Char('a'), KeyModifiers::NONE), 10);
+        assert_eq!(outcome, InputOutcome::Edited);
+        assert_eq!(c.filter, "a");
+        assert_eq!(c.cursor, 1);
+        assert_eq!(c.selected_idx, 0, "edit must reset list cursor");
+    }
+
+    #[test]
+    fn dispatch_cursor_motion_does_not_reset_selection() {
+        let mut c = PickerCore {
+            filter: "hello".into(),
+            cursor: 5,
+            selected_idx: 3,
+            active: true,
+            ..Default::default()
+        };
+        let outcome = c.dispatch_key(&k(KeyCode::Left, KeyModifiers::NONE), 10);
+        assert_eq!(outcome, InputOutcome::CursorMoved);
+        assert_eq!(c.cursor, 4);
+        assert_eq!(c.selected_idx, 3, "pure cursor moves preserve selection");
+    }
+}

--- a/src/picker_core.rs
+++ b/src/picker_core.rs
@@ -53,6 +53,13 @@ pub struct PickerCore {
 /// Quit           → close() + should_quit     (Ctrl+C — close + app quit)
 /// Confirm        → look up the row at `selected_idx`, act on it
 /// Edited         → recompute the candidate list against `filter`
+/// Rejected       → a printable char was recognised but a future
+///                  filtered dispatcher refused to insert it. Today
+///                  PickerCore uses the non-filtered backend so this
+///                  is unreachable, but the variant is reserved so
+///                  swapping in `dispatch_key_filtered` later forces
+///                  every caller to update its match (compile-time
+///                  safety net).
 /// SelectionMoved → no-op (renderer already sees the new cursor)
 /// CursorMoved    → no-op (filter buffer cursor moved inside text)
 /// Unhandled      → the picker fully consumed the key as a no-op; do
@@ -72,6 +79,7 @@ pub enum InputOutcome {
     Quit,
     Confirm,
     Edited,
+    Rejected,
     SelectionMoved,
     CursorMoved,
     Unhandled,
@@ -164,10 +172,12 @@ impl PickerCore {
             }
             crate::input_edit::Outcome::CursorOnly => InputOutcome::CursorMoved,
             // PickerCore uses the non-filtered dispatcher so Rejected
-            // can't actually appear here; map it to CursorMoved as a
-            // defensive default if a future variant of dispatch_key
-            // starts emitting Rejected against this code path.
-            crate::input_edit::Outcome::Rejected => InputOutcome::CursorMoved,
+            // can't fire today. Surface it as a distinct outcome
+            // anyway so a future swap to `dispatch_key_filtered`
+            // forces every caller (each currently has a `Rejected =>`
+            // arm) to make an explicit choice instead of folding
+            // rejection into CursorMoved.
+            crate::input_edit::Outcome::Rejected => InputOutcome::Rejected,
             crate::input_edit::Outcome::Unhandled => InputOutcome::Unhandled,
         }
     }

--- a/src/picker_core.rs
+++ b/src/picker_core.rs
@@ -94,6 +94,16 @@ impl PickerCore {
         self.filter.clear();
         self.cursor = 0;
         self.selected_idx = 0;
+        // Also clear the stale popup rect. quick_open and global_search
+        // toggle `core.active = false` directly on close (intentional —
+        // they preserve `filter` for Esc-peek-and-return UX), so they
+        // never go through `close()`. Without invalidating
+        // `last_popup_area` at open time, the first frame after a
+        // terminal resize + reopen sees a stale rect; the mouse
+        // hit-test against `last_popup_area` would misclassify the
+        // first click as outside-the-popup and dismiss the freshly-
+        // opened overlay.
+        self.last_popup_area = None;
         self.active = true;
     }
 
@@ -138,10 +148,14 @@ impl PickerCore {
     /// editor table would consume them as plain inserts.
     pub fn dispatch_key(&mut self, key: &KeyEvent, visible_count: usize) -> InputOutcome {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        // Phase 1: list nav + close + commit.
+        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+        // Phase 1: list nav + close + commit. `Quit` requires `!shift`
+        // so terminals reporting Ctrl+Shift+C as a distinct chord
+        // (kitty / iTerm enhanced keyboard) don't accidentally quit
+        // the app when the user wanted to copy to clipboard.
         match key.code {
             KeyCode::Esc => return InputOutcome::Cancel,
-            KeyCode::Char('c') if ctrl => return InputOutcome::Quit,
+            KeyCode::Char('c') if ctrl && !shift => return InputOutcome::Quit,
             KeyCode::Enter => return InputOutcome::Confirm,
             KeyCode::Up => {
                 self.move_selection(visible_count, -1);

--- a/src/quick_open.rs
+++ b/src/quick_open.rs
@@ -222,7 +222,11 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
     // them inline before delegating the rest to the shared core.
     if matches!(key.code, KeyCode::PageUp | KeyCode::PageDown) {
         let step = app.quick_open.last_view_h.max(1) as i32;
-        let signed = if matches!(key.code, KeyCode::PageUp) { -step } else { step };
+        let signed = if matches!(key.code, KeyCode::PageUp) {
+            -step
+        } else {
+            step
+        };
         move_selection(&mut app.quick_open, signed);
         return;
     }
@@ -259,7 +263,11 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
 /// Called from `input::handle_paste` after the drop-path parser has already
 /// ruled out the payload as a file drop.
 pub fn handle_paste(s: &str, app: &mut App) {
-    input_edit::paste_single_line(s, &mut app.quick_open.core.filter, &mut app.quick_open.core.cursor);
+    input_edit::paste_single_line(
+        s,
+        &mut app.quick_open.core.filter,
+        &mut app.quick_open.core.cursor,
+    );
     filter(&mut app.quick_open);
 }
 
@@ -371,7 +379,11 @@ pub fn filter(state: &mut QuickOpenState) {
         }
     } else {
         let mut matcher = Matcher::new(Config::DEFAULT);
-        let pattern = Pattern::parse(&state.core.filter, CaseMatching::Smart, Normalization::Smart);
+        let pattern = Pattern::parse(
+            &state.core.filter,
+            CaseMatching::Smart,
+            Normalization::Smart,
+        );
         for (idx, cand) in state.index.iter().enumerate() {
             let mut indices: Vec<u32> = Vec::new();
             if let Some(score) = pattern.indices(cand.utf32.slice(..), &mut matcher, &mut indices) {

--- a/src/quick_open.rs
+++ b/src/quick_open.rs
@@ -240,7 +240,11 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         }
         InputOutcome::Confirm => accept(app),
         InputOutcome::Edited => filter(&mut app.quick_open),
-        InputOutcome::SelectionMoved
+        // Rejected unreachable today (PickerCore uses non-filtered
+        // dispatch_key); the arm is here so a future swap forces
+        // an explicit choice.
+        InputOutcome::Rejected
+        | InputOutcome::SelectionMoved
         | InputOutcome::CursorMoved
         | InputOutcome::Unhandled => {}
     }

--- a/src/quick_open.rs
+++ b/src/quick_open.rs
@@ -22,7 +22,6 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
 use nucleo_matcher::{Config, Matcher, Utf32String};
-use ratatui::layout::Rect;
 use std::collections::{HashSet, VecDeque};
 use std::path::PathBuf;
 use std::time::Instant;
@@ -57,11 +56,10 @@ pub struct MatchEntry {
 }
 
 pub struct QuickOpenState {
-    pub active: bool,
-    pub query: String,
-    /// Byte offset into `query`. Always on a char boundary.
-    pub cursor: usize,
-    pub selected: usize,
+    /// Shared overlay scaffolding (`active`, `query` → `core.filter`,
+    /// `cursor`, `selected` → `core.selected_idx`, `last_popup_area`).
+    /// Edits route through `PickerCore::dispatch_key`.
+    pub core: crate::picker_core::PickerCore,
     pub scroll: usize,
     pub index: Vec<Candidate>,
     /// fs-watcher flips this on; `begin()` rebuilds and clears it. Avoids
@@ -72,17 +70,10 @@ pub struct QuickOpenState {
     /// Last-rendered list viewport height in rows; used by PageUp/PageDown
     /// to pick a step size. Mirrors `last_preview_view_h` etc. in `App`.
     pub last_view_h: u16,
-    /// Last-rendered popup bounds. Read by the mouse dispatcher to decide
-    /// whether a click landed inside the palette (stays in palette mode) or
-    /// outside (dismisses). `None` means the popup hasn't been rendered yet —
-    /// any click in that window is treated as "inside" so the first click
-    /// after opening never accidentally dismisses.
-    pub last_popup_area: Option<Rect>,
-
     /// Timestamp of the most recent bare-Space keystroke inside the palette.
     /// Drives the in-palette half of the Space-P chord so the user can
     /// toggle the palette closed without reaching for Esc. Only armed when
-    /// `query.is_empty()` so that Space becomes a literal char once the
+    /// `core.filter.is_empty()` so Space becomes a literal char once the
     /// user is actually searching for something with a space in it.
     pub space_leader_at: Option<Instant>,
 }
@@ -90,17 +81,13 @@ pub struct QuickOpenState {
 impl Default for QuickOpenState {
     fn default() -> Self {
         Self {
-            active: false,
-            query: String::new(),
-            cursor: 0,
-            selected: 0,
+            core: crate::picker_core::PickerCore::default(),
             scroll: 0,
             index: Vec::new(),
             index_stale: true,
             matches: Vec::new(),
             mru: VecDeque::new(),
             last_view_h: 0,
-            last_popup_area: None,
             space_leader_at: None,
         }
     }
@@ -128,12 +115,12 @@ pub fn begin(app: &mut App) {
         app.quick_open.index = rebuild_index_via_backend(app.backend.as_ref());
         app.quick_open.index_stale = false;
     }
-    app.quick_open.active = true;
-    app.quick_open.selected = 0;
+    app.quick_open.core.active = true;
+    app.quick_open.core.selected_idx = 0;
     app.quick_open.scroll = 0;
     // Position cursor at end so the first keystroke continues (not splits)
     // the existing query.
-    app.quick_open.cursor = app.quick_open.query.len();
+    app.quick_open.core.cursor = app.quick_open.core.filter.len();
     // Start with a clean leader slot — a stale timestamp from a previous
     // session would make the first Space-after-open surprisingly close the
     // palette.
@@ -144,12 +131,12 @@ pub fn begin(app: &mut App) {
 /// Commit the current selection: update MRU, close the palette, and jump
 /// the Files tab to the chosen file with a fresh preview loaded.
 pub fn accept(app: &mut App) {
-    let Some(m) = app.quick_open.matches.get(app.quick_open.selected) else {
-        app.quick_open.active = false;
+    let Some(m) = app.quick_open.matches.get(app.quick_open.core.selected_idx) else {
+        app.quick_open.core.active = false;
         return;
     };
     let Some(cand) = app.quick_open.index.get(m.idx) else {
-        app.quick_open.active = false;
+        app.quick_open.core.active = false;
         return;
     };
     let rel = cand.rel_path.clone();
@@ -162,7 +149,7 @@ pub fn accept(app: &mut App) {
     }
     save_mru_to_prefs(&app.quick_open.mru);
 
-    app.quick_open.active = false;
+    app.quick_open.core.active = false;
     app.set_active_tab(Tab::Files);
     app.file_tree.reveal(&rel);
     app.refresh_file_tree_with_target(Some(rel.clone()));
@@ -198,7 +185,7 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
     // characters go straight into the query.
     match crate::input::leader_decision(
         &key,
-        /* allow_arm */ app.quick_open.query.is_empty(),
+        /* allow_arm */ app.quick_open.core.filter.is_empty(),
         app.quick_open.space_leader_at,
         Instant::now(),
         crate::input::LEADER_TIMEOUT,
@@ -218,7 +205,7 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
             // query below.
             app.quick_open.space_leader_at = None;
             if matches!(key.code, KeyCode::Char('p') | KeyCode::Char('P')) {
-                app.quick_open.active = false;
+                app.quick_open.core.active = false;
                 return;
             }
             // Fall through — non-P chord lands in the char-append arm.
@@ -230,60 +217,33 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         crate::input::LeaderVerdict::None => {}
     }
 
-    // Phase 1: palette-specific shortcuts (Esc / Ctrl+C close, Enter
-    // accept, list nav). These must precede `dispatch_key`, which
-    // would otherwise consume e.g. Ctrl+P as a no-op letter.
-    match key.code {
-        KeyCode::Esc => {
-            app.quick_open.active = false;
-            return;
-        }
-        KeyCode::Char('c') if ctrl => {
-            app.quick_open.active = false;
-            app.should_quit = true;
-            return;
-        }
-        KeyCode::Enter => {
-            accept(app);
-            return;
-        }
-        KeyCode::Up => {
-            move_selection(&mut app.quick_open, -1);
-            return;
-        }
-        KeyCode::Down => {
-            move_selection(&mut app.quick_open, 1);
-            return;
-        }
-        KeyCode::Char('p' | 'k') if ctrl => {
-            move_selection(&mut app.quick_open, -1);
-            return;
-        }
-        KeyCode::Char('n' | 'j') if ctrl => {
-            move_selection(&mut app.quick_open, 1);
-            return;
-        }
-        KeyCode::PageUp => {
-            let step = app.quick_open.last_view_h.max(1) as i32;
-            move_selection(&mut app.quick_open, -step);
-            return;
-        }
-        KeyCode::PageDown => {
-            let step = app.quick_open.last_view_h.max(1) as i32;
-            move_selection(&mut app.quick_open, step);
-            return;
-        }
-        _ => {}
+    // PageUp/PageDown depend on the rendered viewport height
+    // (`last_view_h`), which PickerCore doesn't know about — handle
+    // them inline before delegating the rest to the shared core.
+    if matches!(key.code, KeyCode::PageUp | KeyCode::PageDown) {
+        let step = app.quick_open.last_view_h.max(1) as i32;
+        let signed = if matches!(key.code, KeyCode::PageUp) { -step } else { step };
+        move_selection(&mut app.quick_open, signed);
+        return;
     }
-    // Phase 2: shared text-input dispatch. Any edit refilters the
-    // candidate list — same convention every other reef picker uses.
-    let outcome = input_edit::dispatch_key(
-        &key,
-        &mut app.quick_open.query,
-        &mut app.quick_open.cursor,
-    );
-    if outcome == input_edit::Outcome::Edited {
-        filter(&mut app.quick_open);
+
+    // Shared picker dispatch. `Edited` re-runs the fuzzy filter; the
+    // other outcomes are no-ops (PickerCore already updated state).
+    use crate::picker_core::InputOutcome;
+    let visible = app.quick_open.matches.len();
+    match app.quick_open.core.dispatch_key(&key, visible) {
+        InputOutcome::Cancel => {
+            let ctrl_c = matches!(key.code, KeyCode::Char('c')) && ctrl;
+            app.quick_open.core.active = false;
+            if ctrl_c {
+                app.should_quit = true;
+            }
+        }
+        InputOutcome::Confirm => accept(app),
+        InputOutcome::Edited => filter(&mut app.quick_open),
+        InputOutcome::SelectionMoved
+        | InputOutcome::CursorMoved
+        | InputOutcome::Unhandled => {}
     }
 }
 
@@ -296,7 +256,7 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
 /// Called from `input::handle_paste` after the drop-path parser has already
 /// ruled out the payload as a file drop.
 pub fn handle_paste(s: &str, app: &mut App) {
-    input_edit::paste_single_line(s, &mut app.quick_open.query, &mut app.quick_open.cursor);
+    input_edit::paste_single_line(s, &mut app.quick_open.core.filter, &mut app.quick_open.core.cursor);
     filter(&mut app.quick_open);
 }
 
@@ -311,7 +271,7 @@ pub fn handle_paste(s: &str, app: &mut App) {
 /// - Scroll wheel inside popup → move selection (3 rows per tick)
 /// - Everything else (drag, right-click, move) → ignored
 pub fn handle_mouse(mouse: MouseEvent, app: &mut App) {
-    let popup = match app.quick_open.last_popup_area {
+    let popup = match app.quick_open.core.last_popup_area {
         Some(r) => r,
         // No popup rendered yet — swallow the event without side-effects so
         // a spurious click during the first tick can't dismiss the palette.
@@ -328,7 +288,7 @@ pub fn handle_mouse(mouse: MouseEvent, app: &mut App) {
                 // Click-away dismisses the palette, just like clicking
                 // outside a dropdown in a GUI. Keeps the pre-palette state
                 // intact (filter doesn't touch scroll/selection elsewhere).
-                app.quick_open.active = false;
+                app.quick_open.core.active = false;
                 app.last_click = None;
                 return;
             }
@@ -350,7 +310,7 @@ pub fn handle_mouse(mouse: MouseEvent, app: &mut App) {
             if let Some(ClickAction::QuickOpenSelect(idx)) =
                 app.hit_registry.hit_test(mouse.column, mouse.row)
             {
-                app.quick_open.selected = idx;
+                app.quick_open.core.selected_idx = idx;
                 if is_double {
                     accept(app);
                     app.last_click = None;
@@ -385,7 +345,7 @@ pub fn handle_mouse(mouse: MouseEvent, app: &mut App) {
 pub fn filter(state: &mut QuickOpenState) {
     state.matches.clear();
 
-    if state.query.is_empty() {
+    if state.core.filter.is_empty() {
         let mut seen: HashSet<usize> = HashSet::new();
         for path in &state.mru {
             if let Some(idx) = state.index.iter().position(|c| &c.rel_path == path) {
@@ -408,7 +368,7 @@ pub fn filter(state: &mut QuickOpenState) {
         }
     } else {
         let mut matcher = Matcher::new(Config::DEFAULT);
-        let pattern = Pattern::parse(&state.query, CaseMatching::Smart, Normalization::Smart);
+        let pattern = Pattern::parse(&state.core.filter, CaseMatching::Smart, Normalization::Smart);
         for (idx, cand) in state.index.iter().enumerate() {
             let mut indices: Vec<u32> = Vec::new();
             if let Some(score) = pattern.indices(cand.utf32.slice(..), &mut matcher, &mut indices) {
@@ -433,7 +393,7 @@ pub fn filter(state: &mut QuickOpenState) {
     }
 
     // Query change resets the viewport so the top match is visible.
-    state.selected = 0;
+    state.core.selected_idx = 0;
     state.scroll = 0;
 }
 
@@ -541,13 +501,13 @@ fn save_mru_to_prefs(mru: &VecDeque<PathBuf>) {
 
 fn move_selection(state: &mut QuickOpenState, delta: i32) {
     if state.matches.is_empty() {
-        state.selected = 0;
+        state.core.selected_idx = 0;
         return;
     }
     let last = state.matches.len() - 1;
-    let cur = state.selected as i32;
+    let cur = state.core.selected_idx as i32;
     let next = (cur + delta).clamp(0, last as i32) as usize;
-    state.selected = next;
+    state.core.selected_idx = next;
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -599,8 +559,8 @@ mod tests {
     #[test]
     fn subsequence_match_hits_camelcase() {
         let mut s = mk_state(&["src/ui/file_tree_panel.rs", "src/app.rs", "README.md"]);
-        s.query = "uiftp".to_string();
-        s.cursor = s.query.len();
+        s.core.filter = "uiftp".to_string();
+        s.core.cursor = s.core.filter.len();
         filter(&mut s);
         assert!(!s.matches.is_empty());
         // The file_tree_panel path must rank first — it's the only one
@@ -614,8 +574,8 @@ mod tests {
     #[test]
     fn shorter_path_wins_on_score_tie() {
         let mut s = mk_state(&["deep/nested/foo.rs", "foo.rs"]);
-        s.query = "foo".to_string();
-        s.cursor = s.query.len();
+        s.core.filter = "foo".to_string();
+        s.core.cursor = s.core.filter.len();
         filter(&mut s);
         assert_eq!(s.index[s.matches[0].idx].display, "foo.rs");
     }
@@ -623,8 +583,8 @@ mod tests {
     #[test]
     fn non_match_is_excluded_when_query_nonempty() {
         let mut s = mk_state(&["alpha.rs", "beta.rs"]);
-        s.query = "zzz".to_string();
-        s.cursor = s.query.len();
+        s.core.filter = "zzz".to_string();
+        s.core.cursor = s.core.filter.len();
         filter(&mut s);
         assert!(s.matches.is_empty());
     }
@@ -634,9 +594,9 @@ mod tests {
         let mut s = mk_state(&["a.rs", "b.rs", "c.rs"]);
         filter(&mut s);
         move_selection(&mut s, 10);
-        assert_eq!(s.selected, 2);
+        assert_eq!(s.core.selected_idx, 2);
         move_selection(&mut s, -99);
-        assert_eq!(s.selected, 0);
+        assert_eq!(s.core.selected_idx, 0);
     }
 
     #[test]

--- a/src/quick_open.rs
+++ b/src/quick_open.rs
@@ -191,7 +191,6 @@ pub fn accept(app: &mut App) {
 /// keyboard close.
 pub fn handle_key(key: KeyEvent, app: &mut App) {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-    let alt = key.modifiers.contains(KeyModifiers::ALT);
 
     // Space-leader close: mirrors the global open chord. Only armed while
     // `query.is_empty()` so once the user starts typing a path that might
@@ -231,76 +230,60 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
         crate::input::LeaderVerdict::None => {}
     }
 
+    // Phase 1: palette-specific shortcuts (Esc / Ctrl+C close, Enter
+    // accept, list nav). These must precede `dispatch_key`, which
+    // would otherwise consume e.g. Ctrl+P as a no-op letter.
     match key.code {
         KeyCode::Esc => {
             app.quick_open.active = false;
+            return;
         }
         KeyCode::Char('c') if ctrl => {
             app.quick_open.active = false;
             app.should_quit = true;
+            return;
         }
-        KeyCode::Enter => accept(app),
-
-        // ── Deletion ─────────────────────────────────────────────
-        // Alt+Backspace (macOS Option+Backspace) and Ctrl+Backspace
-        // (Windows/Linux) both ask for "delete previous word". Crossterm
-        // only surfaces these modifiers when the terminal uses a kitty /
-        // fixterms-style protocol; older terminals collapse Alt+Backspace
-        // onto plain Backspace, so Ctrl+W stays as the reliable fallback.
-        KeyCode::Backspace if alt || ctrl => {
-            input_edit::delete_word_backward(&mut app.quick_open.query, &mut app.quick_open.cursor);
-            filter(&mut app.quick_open);
+        KeyCode::Enter => {
+            accept(app);
+            return;
         }
-        KeyCode::Char('w') if ctrl => {
-            input_edit::delete_word_backward(&mut app.quick_open.query, &mut app.quick_open.cursor);
-            filter(&mut app.quick_open);
+        KeyCode::Up => {
+            move_selection(&mut app.quick_open, -1);
+            return;
         }
-        KeyCode::Char('u') if ctrl => {
-            input_edit::clear(&mut app.quick_open.query, &mut app.quick_open.cursor);
-            filter(&mut app.quick_open);
+        KeyCode::Down => {
+            move_selection(&mut app.quick_open, 1);
+            return;
         }
-        KeyCode::Backspace => {
-            input_edit::backspace(&mut app.quick_open.query, &mut app.quick_open.cursor);
-            filter(&mut app.quick_open);
+        KeyCode::Char('p' | 'k') if ctrl => {
+            move_selection(&mut app.quick_open, -1);
+            return;
         }
-
-        // ── List navigation ──────────────────────────────────────
-        KeyCode::Up => move_selection(&mut app.quick_open, -1),
-        KeyCode::Char('p') if ctrl => move_selection(&mut app.quick_open, -1),
-        KeyCode::Char('k') if ctrl => move_selection(&mut app.quick_open, -1),
-        KeyCode::Down => move_selection(&mut app.quick_open, 1),
-        KeyCode::Char('n') if ctrl => move_selection(&mut app.quick_open, 1),
-        KeyCode::Char('j') if ctrl => move_selection(&mut app.quick_open, 1),
+        KeyCode::Char('n' | 'j') if ctrl => {
+            move_selection(&mut app.quick_open, 1);
+            return;
+        }
         KeyCode::PageUp => {
             let step = app.quick_open.last_view_h.max(1) as i32;
             move_selection(&mut app.quick_open, -step);
+            return;
         }
         KeyCode::PageDown => {
             let step = app.quick_open.last_view_h.max(1) as i32;
             move_selection(&mut app.quick_open, step);
-        }
-
-        // ── Edit-cursor movement ─────────────────────────────────
-        KeyCode::Left => {
-            input_edit::move_cursor(&app.quick_open.query, &mut app.quick_open.cursor, -1);
-        }
-        KeyCode::Right => {
-            input_edit::move_cursor(&app.quick_open.query, &mut app.quick_open.cursor, 1);
-        }
-        KeyCode::Home => {
-            app.quick_open.cursor = 0;
-        }
-        KeyCode::End => {
-            app.quick_open.cursor = app.quick_open.query.len();
-        }
-
-        // Any other Ctrl-combo is a no-op; we don't want Ctrl+A etc.
-        // landing as a literal 'a' in the query.
-        KeyCode::Char(c) if !ctrl => {
-            input_edit::insert_char(&mut app.quick_open.query, &mut app.quick_open.cursor, c);
-            filter(&mut app.quick_open);
+            return;
         }
         _ => {}
+    }
+    // Phase 2: shared text-input dispatch. Any edit refilters the
+    // candidate list — same convention every other reef picker uses.
+    let outcome = input_edit::dispatch_key(
+        &key,
+        &mut app.quick_open.query,
+        &mut app.quick_open.cursor,
+    );
+    if outcome == input_edit::Outcome::Edited {
+        filter(&mut app.quick_open);
     }
 }
 

--- a/src/quick_open.rs
+++ b/src/quick_open.rs
@@ -230,14 +230,13 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
     // Shared picker dispatch. `Edited` re-runs the fuzzy filter; the
     // other outcomes are no-ops (PickerCore already updated state).
     use crate::picker_core::InputOutcome;
+    let _ = ctrl; // Quit branch handles Ctrl+C; no other ctrl-gating here.
     let visible = app.quick_open.matches.len();
     match app.quick_open.core.dispatch_key(&key, visible) {
-        InputOutcome::Cancel => {
-            let ctrl_c = matches!(key.code, KeyCode::Char('c')) && ctrl;
+        InputOutcome::Cancel => app.quick_open.core.active = false,
+        InputOutcome::Quit => {
             app.quick_open.core.active = false;
-            if ctrl_c {
-                app.should_quit = true;
-            }
+            app.should_quit = true;
         }
         InputOutcome::Confirm => accept(app),
         InputOutcome::Edited => filter(&mut app.quick_open),

--- a/src/search.rs
+++ b/src/search.rs
@@ -161,97 +161,32 @@ pub fn exit_cancel(app: &mut App) {
 /// is up).
 pub fn handle_key_in_search_mode(key: KeyEvent, app: &mut App) {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-    let alt = key.modifiers.contains(KeyModifiers::ALT);
 
-    // Helper: called after any op that mutates `query`. Pure cursor moves
-    // don't need this — they leave matches / wrap_msg untouched.
-    fn after_edit(app: &mut App) {
-        app.search.wrap_msg = None;
-        recompute_and_jump(app, /*from_step=*/ false);
-    }
-
+    // Phase 1: prompt-specific shortcuts. Must precede `dispatch_key`,
+    // which would otherwise treat Enter as Unhandled (no-op) and
+    // Ctrl+C would fall through too.
     match key.code {
-        // ── Exit ────────────────────────────────────────────────
-        KeyCode::Esc => exit_cancel(app),
-        KeyCode::Char('c') if ctrl => exit_cancel(app),
-        KeyCode::Enter => exit_confirm(app),
-
-        // ── Deletion ─────────────────────────────────────────────
-        // Word-delete variants come before plain Backspace so modifier
-        // combos win the match.
-        KeyCode::Backspace if alt || ctrl => {
-            input_edit::delete_word_backward(&mut app.search.query, &mut app.search.cursor);
-            after_edit(app);
+        KeyCode::Esc => {
+            exit_cancel(app);
+            return;
         }
-        KeyCode::Char('w') if ctrl => {
-            input_edit::delete_word_backward(&mut app.search.query, &mut app.search.cursor);
-            after_edit(app);
+        KeyCode::Char('c') if ctrl => {
+            exit_cancel(app);
+            return;
         }
-        KeyCode::Char('u') if ctrl => {
-            input_edit::clear(&mut app.search.query, &mut app.search.cursor);
-            after_edit(app);
-        }
-        KeyCode::Backspace => {
-            input_edit::backspace(&mut app.search.query, &mut app.search.cursor);
-            after_edit(app);
-        }
-
-        // ── Cursor movement ─────────────────────────────────────
-        // Alt/Ctrl + arrow = jump by word; must precede bare-arrow arms.
-        KeyCode::Left if alt || ctrl => {
-            input_edit::move_cursor_word_backward(&app.search.query, &mut app.search.cursor);
-        }
-        KeyCode::Right if alt || ctrl => {
-            input_edit::move_cursor_word_forward(&app.search.query, &mut app.search.cursor);
-        }
-        KeyCode::Left => {
-            input_edit::move_cursor(&app.search.query, &mut app.search.cursor, -1);
-        }
-        KeyCode::Right => {
-            input_edit::move_cursor(&app.search.query, &mut app.search.cursor, 1);
-        }
-        KeyCode::Home => {
-            app.search.cursor = 0;
-        }
-        KeyCode::End => {
-            app.search.cursor = app.search.query.len();
-        }
-
-        // ── Forward-delete ──────────────────────────────────────
-        KeyCode::Delete if alt || ctrl => {
-            input_edit::delete_word_forward(&mut app.search.query, &mut app.search.cursor);
-            after_edit(app);
-        }
-        KeyCode::Delete => {
-            input_edit::delete_char_forward(&mut app.search.query, &mut app.search.cursor);
-            after_edit(app);
-        }
-
-        // ── Readline aliases ────────────────────────────────────
-        // Fallback for terminals that don't forward Alt/Ctrl+Arrow cleanly.
-        KeyCode::Char('b') if alt => {
-            input_edit::move_cursor_word_backward(&app.search.query, &mut app.search.cursor);
-        }
-        KeyCode::Char('f') if alt => {
-            input_edit::move_cursor_word_forward(&app.search.query, &mut app.search.cursor);
-        }
-        KeyCode::Char('d') if alt => {
-            input_edit::delete_word_forward(&mut app.search.query, &mut app.search.cursor);
-            after_edit(app);
-        }
-        KeyCode::Char('a') if ctrl => {
-            app.search.cursor = 0;
-        }
-        KeyCode::Char('e') if ctrl => {
-            app.search.cursor = app.search.query.len();
-        }
-
-        // ── Insertion ───────────────────────────────────────────
-        KeyCode::Char(c) if !ctrl => {
-            input_edit::insert_char(&mut app.search.query, &mut app.search.cursor, c);
-            after_edit(app);
+        KeyCode::Enter => {
+            exit_confirm(app);
+            return;
         }
         _ => {}
+    }
+
+    // Phase 2: shared text-input dispatch. Any edit re-runs
+    // `recompute_and_jump` so the highlight tracks the query.
+    let outcome = input_edit::dispatch_key(&key, &mut app.search.query, &mut app.search.cursor);
+    if outcome == input_edit::Outcome::Edited {
+        app.search.wrap_msg = None;
+        recompute_and_jump(app, /*from_step=*/ false);
     }
 }
 

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1631,9 +1631,7 @@ fn spawn_graph_worker(result_tx: mpsc::Sender<WorkerResult>) -> mpsc::Sender<Gra
                                 && let GraphScope::Branch(target) = &scope
                                 && ref_present_in_map(&ref_map, target)
                             {
-                                return Err(format!(
-                                    "transient walk failure for {target}"
-                                ));
+                                return Err(format!("transient walk failure for {target}"));
                             }
                             Ok(GraphPayload {
                                 rows,
@@ -1778,10 +1776,7 @@ fn build_file_tree_payload(
 /// genuinely-deleted branch (target missing → fallback to AllRefs)
 /// from a transient walk failure (target still present → return Err
 /// so main keeps the previous rows).
-fn ref_present_in_map(
-    ref_map: &HashMap<String, Vec<RefLabel>>,
-    target: &str,
-) -> bool {
+fn ref_present_in_map(ref_map: &HashMap<String, Vec<RefLabel>>, target: &str) -> bool {
     ref_map.values().any(|labels| {
         labels.iter().any(|label| match label {
             RefLabel::Branch(name) => format!("refs/heads/{name}") == target,

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -8,7 +8,7 @@ use crate::app::{CommitFileDiff, DiffHighlighted, HighlightedDiff};
 use crate::backend::Backend;
 use crate::file_tree::{PreviewContent, TreeEntry};
 use crate::git::graph::GraphRow;
-use crate::git::{CommitDetail, DiffContent, FileEntry, RefLabel};
+use crate::git::{CommitDetail, DiffContent, FileEntry, GraphScope, RefLabel};
 use crate::global_search::MatchHit;
 use crate::paste_conflict::Resolution;
 use crate::ui::highlight;
@@ -39,6 +39,24 @@ impl AsyncState {
         self.stale = false;
         self.error = None;
         self.generation
+    }
+
+    /// Cancel any in-flight load and reset the state to "idle" with a
+    /// fresh generation. Use this when the caller's reason for issuing
+    /// the original load no longer holds (e.g. the user changed scope
+    /// so the selected commit is gone) and no follow-up dispatch is
+    /// lined up.
+    ///
+    /// Semantically: "any worker still chewing on the old generation
+    /// will have its result discarded by `complete_ok`'s generation
+    /// check; pretend that already happened." `loading` is forced false
+    /// so the status bar doesn't render a phantom "<label> refreshing…"
+    /// for a load nobody is going to consume.
+    pub fn invalidate(&mut self) {
+        self.generation = self.generation.wrapping_add(1).max(1);
+        self.loading = false;
+        self.stale = false;
+        self.error = None;
     }
 
     pub fn complete_ok(&mut self, generation: u64) -> bool {
@@ -84,7 +102,13 @@ pub struct FileTreePayload {
 pub struct GraphPayload {
     pub rows: Vec<GraphRow>,
     pub ref_map: HashMap<String, Vec<RefLabel>>,
-    pub cache_key: (String, u64),
+    /// `(head_oid, refs_hash, scope_hash)` — see `GitGraphState::cache_key`.
+    pub cache_key: (String, u64, u64),
+    /// The scope this payload was built for. The main thread compares
+    /// against the current `git_graph.scope` to detect a fall-through
+    /// fallback opportunity (`Branch(missing)` → empty rows → revert to
+    /// `AllRefs`).
+    pub scope: GraphScope,
 }
 
 #[derive(Debug)]
@@ -459,6 +483,7 @@ enum GraphTask {
         generation: u64,
         backend: Arc<dyn Backend>,
         limit: usize,
+        scope: GraphScope,
     },
     LoadCommitDetail {
         generation: u64,
@@ -752,11 +777,18 @@ impl TaskCoordinator {
         });
     }
 
-    pub fn refresh_graph(&self, generation: u64, backend: Arc<dyn Backend>, limit: usize) {
+    pub fn refresh_graph(
+        &self,
+        generation: u64,
+        backend: Arc<dyn Backend>,
+        limit: usize,
+        scope: GraphScope,
+    ) {
         let _ = self.graph_tx.send(GraphTask::RefreshGraph {
             generation,
             backend,
             limit,
+            scope,
         });
     }
 
@@ -1567,6 +1599,7 @@ fn spawn_graph_worker(result_tx: mpsc::Sender<WorkerResult>) -> mpsc::Sender<Gra
                         generation,
                         backend,
                         limit,
+                        scope,
                     } => {
                         let result = (|| -> Result<GraphPayload, String> {
                             let head = backend
@@ -1575,12 +1608,38 @@ fn spawn_graph_worker(result_tx: mpsc::Sender<WorkerResult>) -> mpsc::Sender<Gra
                                 .unwrap_or_default();
                             let ref_map = backend.list_refs().map_err(|e| e.to_string())?;
                             let refs_hash = hash_ref_map(&ref_map);
-                            let commits = backend.list_commits(limit).map_err(|e| e.to_string())?;
+                            let scope_hash = hash_graph_scope(&scope);
+                            let commits = backend
+                                .list_commits(&scope, limit)
+                                .map_err(|e| e.to_string())?;
                             let rows = crate::git::graph::build_graph(&commits);
+                            // Transient-walk-failure detector: a
+                            // `Branch(X)` scope where `X` is still in
+                            // ref_map but `list_commits` returned no
+                            // commits is almost certainly a one-off
+                            // libgit2 hiccup (lock contention, fs
+                            // jitter) rather than a real "empty
+                            // branch". Returning Err here keeps the
+                            // previous rows on screen until the next
+                            // 5s revalidate succeeds, instead of
+                            // letting the main thread replace them
+                            // with the empty set. The genuinely-gone
+                            // case (ref missing from ref_map) still
+                            // lands as a normal payload and trips the
+                            // stale-branch fallback in `app.rs`.
+                            if rows.is_empty()
+                                && let GraphScope::Branch(target) = &scope
+                                && ref_present_in_map(&ref_map, target)
+                            {
+                                return Err(format!(
+                                    "transient walk failure for {target}"
+                                ));
+                            }
                             Ok(GraphPayload {
                                 rows,
                                 ref_map,
-                                cache_key: (head, refs_hash),
+                                cache_key: (head, refs_hash, scope_hash),
+                                scope,
                             })
                         })();
                         let _ = result_tx.send(WorkerResult::Graph { generation, result });
@@ -1711,6 +1770,37 @@ fn build_file_tree_payload(
         entries,
         selected_idx,
     })
+}
+
+/// `true` if `target` (a fully-qualified ref like `refs/heads/main`)
+/// is reachable through any `RefLabel::Branch` / `RefLabel::RemoteBranch`
+/// entry in `ref_map`. Used by the graph worker to distinguish a
+/// genuinely-deleted branch (target missing → fallback to AllRefs)
+/// from a transient walk failure (target still present → return Err
+/// so main keeps the previous rows).
+fn ref_present_in_map(
+    ref_map: &HashMap<String, Vec<RefLabel>>,
+    target: &str,
+) -> bool {
+    ref_map.values().any(|labels| {
+        labels.iter().any(|label| match label {
+            RefLabel::Branch(name) => format!("refs/heads/{name}") == target,
+            RefLabel::RemoteBranch(name) => format!("refs/remotes/{name}") == target,
+            _ => false,
+        })
+    })
+}
+
+fn hash_graph_scope(scope: &GraphScope) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    match scope {
+        GraphScope::AllRefs => 0u8.hash(&mut hasher),
+        GraphScope::Branch(s) => {
+            1u8.hash(&mut hasher);
+            s.hash(&mut hasher);
+        }
+    }
+    hasher.finish()
 }
 
 fn hash_ref_map(map: &HashMap<String, Vec<RefLabel>>) -> u64 {
@@ -2931,5 +3021,53 @@ mod preview_panic_guard_tests {
         let result = run_preview_with_panic_guard(Path::new("x.txt"), move || Some(preview));
         let got = result.expect("Ok").expect("Some");
         assert_eq!(got.file_path, "x.txt");
+    }
+}
+
+#[cfg(test)]
+mod graph_worker_helpers_tests {
+    use super::*;
+
+    #[test]
+    fn ref_present_in_map_matches_local_branch() {
+        let mut map: HashMap<String, Vec<RefLabel>> = HashMap::new();
+        map.insert("oid".into(), vec![RefLabel::Branch("main".into())]);
+        assert!(ref_present_in_map(&map, "refs/heads/main"));
+    }
+
+    #[test]
+    fn ref_present_in_map_matches_remote_branch() {
+        let mut map: HashMap<String, Vec<RefLabel>> = HashMap::new();
+        map.insert(
+            "oid".into(),
+            vec![RefLabel::RemoteBranch("origin/main".into())],
+        );
+        assert!(ref_present_in_map(&map, "refs/remotes/origin/main"));
+    }
+
+    #[test]
+    fn ref_present_in_map_rejects_missing_ref() {
+        let mut map: HashMap<String, Vec<RefLabel>> = HashMap::new();
+        map.insert("oid".into(), vec![RefLabel::Branch("main".into())]);
+        assert!(!ref_present_in_map(&map, "refs/heads/feature"));
+    }
+
+    #[test]
+    fn ref_present_in_map_ignores_tags_and_head() {
+        let mut map: HashMap<String, Vec<RefLabel>> = HashMap::new();
+        map.insert(
+            "oid".into(),
+            vec![RefLabel::Head, RefLabel::Tag("v1".into())],
+        );
+        // Even though refs/tags/v1 exists, scope is fully-qualified
+        // refs/heads/ or refs/remotes/ only. Tags / HEAD don't count.
+        assert!(!ref_present_in_map(&map, "refs/heads/v1"));
+        assert!(!ref_present_in_map(&map, "refs/tags/v1"));
+    }
+
+    #[test]
+    fn ref_present_in_map_empty_map_returns_false() {
+        let map: HashMap<String, Vec<RefLabel>> = HashMap::new();
+        assert!(!ref_present_in_map(&map, "refs/heads/anything"));
     }
 }

--- a/src/ui/db_preview.rs
+++ b/src/ui/db_preview.rs
@@ -265,8 +265,9 @@ pub(in crate::ui) fn render(
                     let cursor_byte = app.db_goto_cursor.min(buf.len());
                     let cursor_w =
                         unicode_width::UnicodeWidthStr::width(&buf[..cursor_byte]) as u16;
-                    let caret_x =
-                        prompt_rect.x + prompt_w + cursor_w.min(area.width.saturating_sub(prompt_w));
+                    let caret_x = prompt_rect.x
+                        + prompt_w
+                        + cursor_w.min(area.width.saturating_sub(prompt_w));
                     f.set_cursor_position((caret_x, body_max_y));
                 } else {
                     let footer_idx = position_in_row_bearing(info, o).unwrap_or(0);

--- a/src/ui/db_preview.rs
+++ b/src/ui/db_preview.rs
@@ -240,26 +240,34 @@ pub(in crate::ui) fn render(
             // Pagination footer.
             if body_max_y < max_y {
                 if let Some(buf) = app.db_goto_input.as_ref() {
+                    let prompt_text = format!("{}: ", t(Msg::DbGotoPagePrompt));
+                    let prompt_w =
+                        unicode_width::UnicodeWidthStr::width(prompt_text.as_str()) as u16;
                     let prompt_line = Line::from(vec![
                         Span::styled(
-                            format!("{}: ", t(Msg::DbGotoPagePrompt)),
+                            prompt_text,
                             Style::default()
                                 .fg(th.fg_primary)
                                 .add_modifier(Modifier::BOLD),
                         ),
                         Span::styled(buf.clone(), Style::default().fg(th.fg_primary)),
                         Span::styled(
-                            "▏",
-                            Style::default()
-                                .fg(th.fg_primary)
-                                .add_modifier(Modifier::DIM),
-                        ),
-                        Span::styled(
                             format!("  {}", t(Msg::DbGotoPageHint)),
                             Style::default().fg(th.fg_secondary),
                         ),
                     ]);
-                    f.render_widget(prompt_line, Rect::new(area.x, body_max_y, area.width, 1));
+                    let prompt_rect = Rect::new(area.x, body_max_y, area.width, 1);
+                    f.render_widget(prompt_line, prompt_rect);
+                    // Caret. Cursor is a byte offset into `buf` — same
+                    // convention used by every other input in reef. The
+                    // 18-char cap means this is always a valid char
+                    // boundary on ASCII digits.
+                    let cursor_byte = app.db_goto_cursor.min(buf.len());
+                    let cursor_w =
+                        unicode_width::UnicodeWidthStr::width(&buf[..cursor_byte]) as u16;
+                    let caret_x =
+                        prompt_rect.x + prompt_w + cursor_w.min(area.width.saturating_sub(prompt_w));
+                    f.set_cursor_position((caret_x, body_max_y));
                 } else {
                     let footer_idx = position_in_row_bearing(info, o).unwrap_or(0);
                     render_pagination_footer(

--- a/src/ui/git_graph_panel.rs
+++ b/src/ui/git_graph_panel.rs
@@ -1,8 +1,8 @@
 //! Graph tab's left sidebar — DAG of commits with lane rendering and
 //! ref-label chips.
 
-use crate::app::App;
-use crate::git::RefLabel;
+use crate::app::{App, shorthand_for_full_ref};
+use crate::git::{GraphScope, RefLabel};
 use crate::git::graph::{GraphRow, LaneCell};
 use crate::i18n::{Msg, t};
 use crate::search::SearchTarget;
@@ -17,6 +17,8 @@ use std::ops::Range;
 use unicode_width::UnicodeWidthStr;
 
 pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
+    let area = draw_scope_header_if_any(f, app, area);
+
     if app.git_graph.rows.is_empty() {
         let line = Line::from(Span::styled(
             t(Msg::NoCommits),
@@ -32,7 +34,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
         .git_graph
         .cache_key
         .as_ref()
-        .map(|(head, _)| head.as_str());
+        .map(|(head, _, _)| head.as_str());
 
     // Clamp scroll to a valid range. Auto-scroll into view only when the
     // selection actually moved since the last render — running this every
@@ -97,6 +99,35 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
             },
         );
     }
+}
+
+/// When `git_graph.scope` is restricted to a branch, draw a one-row
+/// "Branch <name>  (press b)" header at the top of the sidebar and
+/// return the remaining `Rect` for the commit rows. With AllRefs (or
+/// a too-short panel) the input rect is returned unchanged so the
+/// rows panel sits flush against the top.
+fn draw_scope_header_if_any(f: &mut Frame, app: &App, area: Rect) -> Rect {
+    let label = match &app.git_graph.scope {
+        GraphScope::AllRefs => return area,
+        GraphScope::Branch(full_ref) => shorthand_for_full_ref(full_ref),
+    };
+    if area.height < 2 {
+        return area;
+    }
+    let header_area = Rect::new(area.x, area.y, area.width, 1);
+    let muted = Style::default().fg(app.theme.chrome_muted_fg);
+    let line = Line::from(vec![
+        Span::styled("Branch ", muted),
+        Span::styled(
+            label.to_string(),
+            Style::default()
+                .fg(app.theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("  (press b)", muted),
+    ]);
+    f.render_widget(line, header_area);
+    Rect::new(area.x, area.y + 1, area.width, area.height - 1)
 }
 
 pub fn handle_key(app: &mut App, key: &str) -> bool {

--- a/src/ui/git_graph_panel.rs
+++ b/src/ui/git_graph_panel.rs
@@ -2,8 +2,8 @@
 //! ref-label chips.
 
 use crate::app::{App, shorthand_for_full_ref};
-use crate::git::{GraphScope, RefLabel};
 use crate::git::graph::{GraphRow, LaneCell};
+use crate::git::{GraphScope, RefLabel};
 use crate::i18n::{Msg, t};
 use crate::search::SearchTarget;
 use crate::ui::mouse::ClickAction;

--- a/src/ui/global_search_panel.rs
+++ b/src/ui/global_search_panel.rs
@@ -152,7 +152,8 @@ pub fn render_body(f: &mut Frame, app: &mut App, inner: Rect, input_focused: boo
     );
     if find_focused {
         let cursor_w =
-            UnicodeWidthStr::width(&app.global_search.core.filter[..app.global_search.core.cursor]) as u16;
+            UnicodeWidthStr::width(&app.global_search.core.filter[..app.global_search.core.cursor])
+                as u16;
         let cursor_x = inner.x + PROMPT_COL_W + cursor_w.min(inner.width.saturating_sub(3));
         f.set_cursor_position((cursor_x, find_y));
     }

--- a/src/ui/global_search_panel.rs
+++ b/src/ui/global_search_panel.rs
@@ -47,7 +47,7 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
     let y = screen.y + screen.height.saturating_sub(popup_h) / 2;
     let area = Rect::new(x, y, popup_w, popup_h);
 
-    app.global_search.last_popup_area = Some(area);
+    app.global_search.core.last_popup_area = Some(area);
 
     f.render_widget(Clear, area);
 
@@ -95,7 +95,7 @@ pub fn render_body(f: &mut Frame, app: &mut App, inner: Rect, input_focused: boo
     // so its prompt is just a prompt; Tab::Search makes the prompt
     // clickable.
     let replace_open = app.global_search.replace_open;
-    let toggle_in_use = !app.global_search.active; // overlay sets `active=true`
+    let toggle_in_use = !app.global_search.core.active; // overlay sets `active=true`
     let header_rows: u16 = if replace_open { 2 } else { 1 };
 
     let find_y = inner.y;
@@ -146,13 +146,13 @@ pub fn render_body(f: &mut Frame, app: &mut App, inner: Rect, input_focused: boo
     f.render_widget(
         Line::from(vec![
             Span::styled(prompt_glyph.to_string(), prompt_style),
-            Span::styled(app.global_search.query.clone(), query_style),
+            Span::styled(app.global_search.core.filter.clone(), query_style),
         ]),
         Rect::new(inner.x, find_y, inner.width, 1),
     );
     if find_focused {
         let cursor_w =
-            UnicodeWidthStr::width(&app.global_search.query[..app.global_search.cursor]) as u16;
+            UnicodeWidthStr::width(&app.global_search.core.filter[..app.global_search.core.cursor]) as u16;
         let cursor_x = inner.x + PROMPT_COL_W + cursor_w.min(inner.width.saturating_sub(3));
         f.set_cursor_position((cursor_x, find_y));
     }
@@ -231,7 +231,7 @@ pub fn render_body(f: &mut Frame, app: &mut App, inner: Rect, input_focused: boo
     // ── List ───────────────────────────────────────────────────────────
     let loading = app.global_search_load.loading;
     if app.global_search.results.is_empty() {
-        let msg = if app.global_search.query.is_empty() {
+        let msg = if app.global_search.core.filter.is_empty() {
             if input_focused {
                 "Type to search file contents…"
             } else {
@@ -252,7 +252,7 @@ pub fn render_body(f: &mut Frame, app: &mut App, inner: Rect, input_focused: boo
             Rect::new(inner.x, list_y, inner.width, 1),
         );
     } else {
-        let sel = app.global_search.selected;
+        let sel = app.global_search.core.selected_idx;
         if sel < app.global_search.scroll {
             app.global_search.scroll = sel;
         } else if list_h > 0 && sel >= app.global_search.scroll + list_h as usize {
@@ -396,7 +396,7 @@ fn render_footer_text(state: &crate::global_search::GlobalSearchState, loading: 
     let cur = if state.results.is_empty() {
         0
     } else {
-        state.selected + 1
+        state.core.selected_idx + 1
     };
     let total = state.results.len();
     let mut s = format!("{cur} / {total}");

--- a/src/ui/graph_branch_picker_panel.rs
+++ b/src/ui/graph_branch_picker_panel.rs
@@ -74,8 +74,7 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
         .graph_branch_picker
         .cursor
         .min(app.graph_branch_picker.filter.len());
-    let cursor_w =
-        UnicodeWidthStr::width(&app.graph_branch_picker.filter[..cursor_byte]) as u16;
+    let cursor_w = UnicodeWidthStr::width(&app.graph_branch_picker.filter[..cursor_byte]) as u16;
     let max_caret_offset = inner.width.saturating_sub(prompt_w + 1);
     let caret_x = inner.x + prompt_w + cursor_w.min(max_caret_offset);
     f.set_cursor_position((caret_x, input_y));
@@ -92,11 +91,7 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
         let is_selected = row_idx == app.graph_branch_picker.selected_idx;
 
         let (left, right, accent) = match row {
-            BranchPickerRow::AllRefs => (
-                "[ All refs ]".to_string(),
-                "default".to_string(),
-                true,
-            ),
+            BranchPickerRow::AllRefs => ("[ All refs ]".to_string(), "default".to_string(), true),
             BranchPickerRow::Recent(b) => {
                 let prefix = if b.is_head { "* " } else { "  " };
                 let kind = match b.kind {

--- a/src/ui/graph_branch_picker_panel.rs
+++ b/src/ui/graph_branch_picker_panel.rs
@@ -87,8 +87,24 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
 
     let rows = app.graph_branch_picker.visible_rows();
 
-    for (row_idx, row) in rows.iter().enumerate().take(list_h as usize) {
-        let y = list_y + row_idx as u16;
+    // Auto-scroll so `selected_idx` stays in the visible window.
+    // Same pattern as `quick_open_panel`: only adjust scroll when the
+    // selection moves outside the window, so the user can scroll
+    // independently (mouse wheel etc.) without snapping back. Without
+    // this, monorepos with hundreds of branches push the highlight
+    // off-screen on Down-key autorepeat.
+    let sel = app.graph_branch_picker.core.selected_idx;
+    let list_h_usize = list_h as usize;
+    if sel < app.graph_branch_picker.scroll {
+        app.graph_branch_picker.scroll = sel;
+    } else if list_h_usize > 0 && sel >= app.graph_branch_picker.scroll + list_h_usize {
+        app.graph_branch_picker.scroll = sel + 1 - list_h_usize;
+    }
+    let scroll = app.graph_branch_picker.scroll.min(rows.len().saturating_sub(1));
+
+    for (visible_row, row) in rows.iter().skip(scroll).take(list_h_usize).enumerate() {
+        let row_idx = scroll + visible_row;
+        let y = list_y + visible_row as u16;
         let is_selected = row_idx == app.graph_branch_picker.core.selected_idx;
 
         let (left, right, accent) = match row {

--- a/src/ui/graph_branch_picker_panel.rs
+++ b/src/ui/graph_branch_picker_panel.rs
@@ -1,0 +1,161 @@
+//! Overlay renderer for the Graph tab's branch picker (`b` key).
+//!
+//! Mirrors `hosts_picker_panel` — bordered popup with a filter row up
+//! top, a list of rows in the middle, and a footer. Click zones are
+//! registered as `ClickAction::GraphBranchPickerSelect(idx)` so mouse
+//! drives the same commit path as Enter.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Padding};
+use unicode_width::UnicodeWidthStr;
+
+use crate::app::App;
+use crate::graph_branch_picker::{BranchKind, BranchPickerRow};
+use crate::ui::mouse::ClickAction;
+
+pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
+    let th = app.theme;
+
+    let popup_w = 68u16.min(screen.width.saturating_sub(4).max(20));
+    let popup_h = 22u16.min(screen.height.saturating_sub(4).max(8));
+    let x = screen.x + screen.width.saturating_sub(popup_w) / 2;
+    let y = screen.y + screen.height.saturating_sub(popup_h) / 2;
+    let area = Rect::new(x, y, popup_w, popup_h);
+
+    app.graph_branch_picker.last_popup_area = Some(area);
+
+    f.render_widget(Clear, area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(th.accent))
+        .title(Span::styled(
+            " Graph · branch ",
+            Style::default()
+                .fg(th.fg_primary)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .padding(Padding::new(1, 1, 0, 0));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    if inner.height < 3 {
+        return;
+    }
+
+    let input_y = inner.y;
+    let sep_y = inner.y + 1;
+    let list_y = inner.y + 2;
+    let has_footer = inner.height >= 5;
+    let list_h = if has_footer {
+        inner.height.saturating_sub(3)
+    } else {
+        inner.height.saturating_sub(2)
+    };
+
+    // Input row.
+    let prompt = "› ";
+    let prompt_w = UnicodeWidthStr::width(prompt) as u16;
+    let input_line = Line::from(vec![
+        Span::styled(prompt, Style::default().fg(th.accent)),
+        Span::styled(
+            app.graph_branch_picker.filter.clone(),
+            Style::default().fg(th.fg_primary),
+        ),
+    ]);
+    f.render_widget(input_line, Rect::new(inner.x, input_y, inner.width, 1));
+    // Visible caret — same trick `quick_open_panel` uses. Width-aware
+    // so it lands between CJK / wide chars correctly, and clamped to
+    // the popup's interior so a very long filter doesn't park the
+    // caret past the border.
+    let cursor_byte = app
+        .graph_branch_picker
+        .cursor
+        .min(app.graph_branch_picker.filter.len());
+    let cursor_w =
+        UnicodeWidthStr::width(&app.graph_branch_picker.filter[..cursor_byte]) as u16;
+    let max_caret_offset = inner.width.saturating_sub(prompt_w + 1);
+    let caret_x = inner.x + prompt_w + cursor_w.min(max_caret_offset);
+    f.set_cursor_position((caret_x, input_y));
+
+    // Separator.
+    let sep = "─".repeat(inner.width as usize);
+    let sep_line = Line::from(Span::styled(sep, Style::default().fg(th.border)));
+    f.render_widget(sep_line, Rect::new(inner.x, sep_y, inner.width, 1));
+
+    let rows = app.graph_branch_picker.visible_rows();
+
+    for (row_idx, row) in rows.iter().enumerate().take(list_h as usize) {
+        let y = list_y + row_idx as u16;
+        let is_selected = row_idx == app.graph_branch_picker.selected_idx;
+
+        let (left, right, accent) = match row {
+            BranchPickerRow::AllRefs => (
+                "[ All refs ]".to_string(),
+                "default".to_string(),
+                true,
+            ),
+            BranchPickerRow::Recent(b) => {
+                let prefix = if b.is_head { "* " } else { "  " };
+                let kind = match b.kind {
+                    BranchKind::Local => "recent · local",
+                    BranchKind::Remote => "recent · remote",
+                };
+                (format!("{prefix}{}", b.display), kind.to_string(), true)
+            }
+            BranchPickerRow::Branch(b) => {
+                let prefix = if b.is_head { "* " } else { "  " };
+                let kind = match b.kind {
+                    BranchKind::Local => "local",
+                    BranchKind::Remote => "remote",
+                };
+                (format!("{prefix}{}", b.display), kind.to_string(), false)
+            }
+        };
+
+        let left_style = if is_selected {
+            Style::default()
+                .fg(th.chrome_bg)
+                .bg(th.accent)
+                .add_modifier(Modifier::BOLD)
+        } else if accent {
+            Style::default().fg(th.accent)
+        } else {
+            Style::default().fg(th.fg_primary)
+        };
+        let right_style = if is_selected {
+            Style::default().fg(th.chrome_bg).bg(th.accent)
+        } else {
+            Style::default().fg(th.chrome_muted_fg)
+        };
+
+        let line = Line::from(vec![
+            Span::styled(format!(" {left} "), left_style),
+            Span::styled(format!(" {right} "), right_style),
+        ]);
+        let row_rect = Rect::new(inner.x, y, inner.width, 1);
+        f.render_widget(line, row_rect);
+
+        app.hit_registry
+            .register(row_rect, ClickAction::GraphBranchPickerSelect(row_idx));
+    }
+
+    if rows.is_empty() {
+        let empty = Line::from(Span::styled(
+            "  no branches match — clear the filter or press Esc",
+            Style::default()
+                .fg(th.chrome_muted_fg)
+                .add_modifier(Modifier::ITALIC),
+        ));
+        f.render_widget(empty, Rect::new(inner.x, list_y, inner.width, 1));
+    }
+
+    if has_footer {
+        let footer_y = inner.y + inner.height - 1;
+        let footer = "  Enter select · Esc cancel";
+        let footer_line = Line::from(Span::styled(footer, Style::default().fg(Color::DarkGray)));
+        f.render_widget(footer_line, Rect::new(inner.x, footer_y, inner.width, 1));
+    }
+}

--- a/src/ui/graph_branch_picker_panel.rs
+++ b/src/ui/graph_branch_picker_panel.rs
@@ -75,7 +75,8 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
         .core
         .cursor
         .min(app.graph_branch_picker.core.filter.len());
-    let cursor_w = UnicodeWidthStr::width(&app.graph_branch_picker.core.filter[..cursor_byte]) as u16;
+    let cursor_w =
+        UnicodeWidthStr::width(&app.graph_branch_picker.core.filter[..cursor_byte]) as u16;
     let max_caret_offset = inner.width.saturating_sub(prompt_w + 1);
     let caret_x = inner.x + prompt_w + cursor_w.min(max_caret_offset);
     f.set_cursor_position((caret_x, input_y));
@@ -100,7 +101,10 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
     } else if list_h_usize > 0 && sel >= app.graph_branch_picker.scroll + list_h_usize {
         app.graph_branch_picker.scroll = sel + 1 - list_h_usize;
     }
-    let scroll = app.graph_branch_picker.scroll.min(rows.len().saturating_sub(1));
+    let scroll = app
+        .graph_branch_picker
+        .scroll
+        .min(rows.len().saturating_sub(1));
 
     for (visible_row, row) in rows.iter().skip(scroll).take(list_h_usize).enumerate() {
         let row_idx = scroll + visible_row;

--- a/src/ui/graph_branch_picker_panel.rs
+++ b/src/ui/graph_branch_picker_panel.rs
@@ -25,7 +25,7 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
     let y = screen.y + screen.height.saturating_sub(popup_h) / 2;
     let area = Rect::new(x, y, popup_w, popup_h);
 
-    app.graph_branch_picker.last_popup_area = Some(area);
+    app.graph_branch_picker.core.last_popup_area = Some(area);
 
     f.render_widget(Clear, area);
 
@@ -61,7 +61,7 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
     let input_line = Line::from(vec![
         Span::styled(prompt, Style::default().fg(th.accent)),
         Span::styled(
-            app.graph_branch_picker.filter.clone(),
+            app.graph_branch_picker.core.filter.clone(),
             Style::default().fg(th.fg_primary),
         ),
     ]);
@@ -72,9 +72,10 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
     // caret past the border.
     let cursor_byte = app
         .graph_branch_picker
+        .core
         .cursor
-        .min(app.graph_branch_picker.filter.len());
-    let cursor_w = UnicodeWidthStr::width(&app.graph_branch_picker.filter[..cursor_byte]) as u16;
+        .min(app.graph_branch_picker.core.filter.len());
+    let cursor_w = UnicodeWidthStr::width(&app.graph_branch_picker.core.filter[..cursor_byte]) as u16;
     let max_caret_offset = inner.width.saturating_sub(prompt_w + 1);
     let caret_x = inner.x + prompt_w + cursor_w.min(max_caret_offset);
     f.set_cursor_position((caret_x, input_y));
@@ -88,7 +89,7 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
 
     for (row_idx, row) in rows.iter().enumerate().take(list_h as usize) {
         let y = list_y + row_idx as u16;
-        let is_selected = row_idx == app.graph_branch_picker.selected_idx;
+        let is_selected = row_idx == app.graph_branch_picker.core.selected_idx;
 
         let (left, right, accent) = match row {
             BranchPickerRow::AllRefs => ("[ All refs ]".to_string(), "default".to_string(), true),

--- a/src/ui/hosts_picker_panel.rs
+++ b/src/ui/hosts_picker_panel.rs
@@ -1,6 +1,6 @@
 //! Hosts picker overlay (bound to Ctrl+O; see `crate::hosts_picker`).
 //!
-//! Renders on top of the normal UI when `app.hosts_picker.active` is true.
+//! Renders on top of the normal UI when `app.hosts_picker.core.active` is true.
 //! Three regions inside the popup: a single-row input line (filter or
 //! literal path), the visible-row list (recent targets + parsed
 //! `~/.ssh/config` entries), and a help footer. Registers a `ClickAction`
@@ -26,7 +26,7 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
     let y = screen.y + screen.height.saturating_sub(popup_h) / 2;
     let area = Rect::new(x, y, popup_w, popup_h);
 
-    app.hosts_picker.last_popup_area = Some(area);
+    app.hosts_picker.core.last_popup_area = Some(area);
 
     f.render_widget(Clear, area);
 
@@ -64,8 +64,8 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
     // Input row.
     let (input_text, cursor_byte) = match app.hosts_picker.input_mode {
         InputMode::Search => (
-            app.hosts_picker.filter.as_str(),
-            app.hosts_picker.filter_cursor,
+            app.hosts_picker.core.filter.as_str(),
+            app.hosts_picker.core.cursor,
         ),
         InputMode::Path => (
             app.hosts_picker.path_buffer.as_str(),
@@ -104,7 +104,7 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
 
     for (row_idx, row) in rows.iter().enumerate().take(list_h as usize) {
         let y = list_y + row_idx as u16;
-        let is_selected = row_idx == app.hosts_picker.selected_idx;
+        let is_selected = row_idx == app.hosts_picker.core.selected_idx;
         let (left, right, is_recent) = match row {
             PickerRow::Recent(t) => (t.to_arg(), "recent".to_string(), true),
             PickerRow::Entry(h) => {

--- a/src/ui/hosts_picker_panel.rs
+++ b/src/ui/hosts_picker_panel.rs
@@ -62,20 +62,36 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
     };
 
     // Input row.
-    let input_text = match app.hosts_picker.input_mode {
-        InputMode::Search => app.hosts_picker.filter.clone(),
-        InputMode::Path => app.hosts_picker.path_buffer.clone(),
+    let (input_text, cursor_byte) = match app.hosts_picker.input_mode {
+        InputMode::Search => (
+            app.hosts_picker.filter.as_str(),
+            app.hosts_picker.filter_cursor,
+        ),
+        InputMode::Path => (
+            app.hosts_picker.path_buffer.as_str(),
+            app.hosts_picker.path_cursor,
+        ),
     };
     let prompt = match app.hosts_picker.input_mode {
         InputMode::Search => "› ",
         InputMode::Path => "➜ ",
     };
+    let prompt_w = unicode_width::UnicodeWidthStr::width(prompt) as u16;
     let input_line = Line::from(vec![
         Span::styled(prompt, Style::default().fg(th.accent)),
-        Span::styled(input_text, Style::default().fg(th.fg_primary)),
+        Span::styled(input_text.to_string(), Style::default().fg(th.fg_primary)),
     ]);
     let input_rect = Rect::new(inner.x, input_y, inner.width, 1);
     f.render_widget(input_line, input_rect);
+    // Visible caret. Width-aware so multi-byte chars don't desync,
+    // clamped so a very long buffer doesn't park the caret past the
+    // popup's right border.
+    let cursor_clamped = cursor_byte.min(input_text.len());
+    let cursor_w =
+        unicode_width::UnicodeWidthStr::width(&input_text[..cursor_clamped]) as u16;
+    let max_caret_offset = inner.width.saturating_sub(prompt_w + 1);
+    let caret_x = inner.x + prompt_w + cursor_w.min(max_caret_offset);
+    f.set_cursor_position((caret_x, input_y));
 
     // Separator line between input and list.
     let sep = "─".repeat(inner.width as usize);

--- a/src/ui/hosts_picker_panel.rs
+++ b/src/ui/hosts_picker_panel.rs
@@ -87,8 +87,7 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
     // clamped so a very long buffer doesn't park the caret past the
     // popup's right border.
     let cursor_clamped = cursor_byte.min(input_text.len());
-    let cursor_w =
-        unicode_width::UnicodeWidthStr::width(&input_text[..cursor_clamped]) as u16;
+    let cursor_w = unicode_width::UnicodeWidthStr::width(&input_text[..cursor_clamped]) as u16;
     let max_caret_offset = inner.width.saturating_sub(prompt_w + 1);
     let caret_x = inner.x + prompt_w + cursor_w.min(max_caret_offset);
     f.set_cursor_position((caret_x, input_y));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -220,16 +220,16 @@ pub fn render(f: &mut Frame, app: &mut App) {
     // Global-search after quick-open: if both flags were somehow true the
     // later render wins on overlap, and having global-search on top matches
     // its priority in input dispatch.
-    if app.quick_open.active {
+    if app.quick_open.core.active {
         quick_open_panel::render(f, app, size);
     }
-    if app.global_search.active {
+    if app.global_search.core.active {
         global_search_panel::render(f, app, size);
     }
-    if app.hosts_picker.active {
+    if app.hosts_picker.core.active {
         hosts_picker_panel::render(f, app, size);
     }
-    if app.graph_branch_picker.active {
+    if app.graph_branch_picker.core.active {
         graph_branch_picker_panel::render(f, app, size);
     }
     // Context menu overlay renders last so it sits above the help

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -11,6 +11,7 @@ pub mod focused_preview_panel;
 pub mod git_graph_panel;
 pub mod git_status_panel;
 pub mod global_search_panel;
+pub mod graph_branch_picker_panel;
 pub mod highlight;
 pub mod hosts_picker_panel;
 pub mod hover;
@@ -227,6 +228,9 @@ pub fn render(f: &mut Frame, app: &mut App) {
     }
     if app.hosts_picker.active {
         hosts_picker_panel::render(f, app, size);
+    }
+    if app.graph_branch_picker.active {
+        graph_branch_picker_panel::render(f, app, size);
     }
     // Context menu overlay renders last so it sits above the help
     // popup and any other in-panel chrome. The menu itself is scoped

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -41,6 +41,13 @@ pub enum ClickAction {
     /// into `HostsPickerState::visible_rows()`. Handled in
     /// `input::handle_mouse` while the picker owns mouse input.
     HostsPickerSelect(usize),
+    /// Click on a row in the Graph tab's branch picker (`b`). The
+    /// `usize` indexes into
+    /// `GraphBranchPickerState::visible_rows()`. Dispatched inside
+    /// `input::handle_mouse_graph_branch_picker`, not via
+    /// `App::handle_action` — the picker owns mouse exclusively while
+    /// open.
+    GraphBranchPickerSelect(usize),
     /// Click on the input row of the Search tab's left panel while in
     /// list mode. Sets `focus = FindInput` so the user can mouse-drive
     /// the mode switch instead of hunting for `/` or `i`. Only registered

--- a/src/ui/quick_open_panel.rs
+++ b/src/ui/quick_open_panel.rs
@@ -101,7 +101,8 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
     );
     // Blinking cursor — same trick `render_search_prompt` uses. Using
     // UnicodeWidthStr so cursor lands between CJK/wide chars correctly.
-    let cursor_w = UnicodeWidthStr::width(&app.quick_open.core.filter[..app.quick_open.core.cursor]) as u16;
+    let cursor_w =
+        UnicodeWidthStr::width(&app.quick_open.core.filter[..app.quick_open.core.cursor]) as u16;
     let cursor_x = inner.x + 2 + cursor_w.min(inner.width.saturating_sub(3));
     f.set_cursor_position((cursor_x, input_y));
 

--- a/src/ui/quick_open_panel.rs
+++ b/src/ui/quick_open_panel.rs
@@ -1,6 +1,6 @@
 //! Quick-open palette overlay (bound to Space-P; see `crate::quick_open`).
 //!
-//! Rendered on top of the normal UI when `app.quick_open.active` is true.
+//! Rendered on top of the normal UI when `app.quick_open.core.active` is true.
 //! Three regions inside the popup: a single-row input line, a list of
 //! matches, and a right-aligned counter footer. The only state this panel
 //! writes back to `App` is `quick_open.last_view_h` (used by PageUp/PageDown
@@ -39,11 +39,11 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
     // Stash bounds so `quick_open::handle_mouse` can decide "inside popup
     // vs. click-away dismiss". Overwritten every frame so it stays in sync
     // with terminal resizes.
-    app.quick_open.last_popup_area = Some(area);
+    app.quick_open.core.last_popup_area = Some(area);
 
     f.render_widget(Clear, area);
 
-    let recent = app.quick_open.query.is_empty() && !app.quick_open.mru.is_empty();
+    let recent = app.quick_open.core.filter.is_empty() && !app.quick_open.mru.is_empty();
     let title = if recent {
         " Quick Open · recent "
     } else {
@@ -91,7 +91,7 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
             Style::default().fg(th.accent).add_modifier(Modifier::BOLD),
         ),
         Span::styled(
-            app.quick_open.query.clone(),
+            app.quick_open.core.filter.clone(),
             Style::default().fg(th.fg_primary),
         ),
     ];
@@ -101,7 +101,7 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
     );
     // Blinking cursor — same trick `render_search_prompt` uses. Using
     // UnicodeWidthStr so cursor lands between CJK/wide chars correctly.
-    let cursor_w = UnicodeWidthStr::width(&app.quick_open.query[..app.quick_open.cursor]) as u16;
+    let cursor_w = UnicodeWidthStr::width(&app.quick_open.core.filter[..app.quick_open.core.cursor]) as u16;
     let cursor_x = inner.x + 2 + cursor_w.min(inner.width.saturating_sub(3));
     f.set_cursor_position((cursor_x, input_y));
 
@@ -116,7 +116,7 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
 
     // ── List ───────────────────────────────────────────────────────────
     if app.quick_open.matches.is_empty() {
-        let msg = if app.quick_open.query.is_empty() {
+        let msg = if app.quick_open.core.filter.is_empty() {
             "Type to search files…"
         } else {
             "No matching files"
@@ -134,7 +134,7 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
         // Keep the selection in view. Same pattern as file_tree_panel — only
         // adjust scroll when selection moved outside the window, so the user
         // can scroll independently (Future: wire mouse wheel on popup).
-        let sel = app.quick_open.selected;
+        let sel = app.quick_open.core.selected_idx;
         if sel < app.quick_open.scroll {
             app.quick_open.scroll = sel;
         } else if list_h > 0 && sel >= app.quick_open.scroll + list_h as usize {
@@ -171,7 +171,7 @@ pub fn render(f: &mut Frame, app: &mut App, screen: Rect) {
         let cur = if app.quick_open.matches.is_empty() {
             0
         } else {
-            app.quick_open.selected + 1
+            app.quick_open.core.selected_idx + 1
         };
         let text = format!("{} / {}", cur, app.quick_open.matches.len());
         let w = UnicodeWidthStr::width(text.as_str()) as u16;

--- a/tests/backend_loopback.rs
+++ b/tests/backend_loopback.rs
@@ -92,8 +92,9 @@ fn remote_list_commits_matches_local() {
     let local = LocalBackend::open_at(tmp.path().to_path_buf());
     let remote = spawn_remote(tmp.path());
 
-    let l = local.list_commits(10).expect("local commits");
-    let r = remote.list_commits(10).expect("remote commits");
+    let scope = reef::git::GraphScope::AllRefs;
+    let l = local.list_commits(&scope, 10).expect("local commits");
+    let r = remote.list_commits(&scope, 10).expect("remote commits");
 
     assert_eq!(l.len(), r.len());
     for (a, b) in l.iter().zip(r.iter()) {

--- a/tests/focused_preview_scroll.rs
+++ b/tests/focused_preview_scroll.rs
@@ -761,8 +761,8 @@ fn quick_open_keeps_v_keystroke_after_leader() {
 
     let mut app = App::new(Theme::dark(), None);
     reef::quick_open::begin(&mut app);
-    assert!(app.quick_open.active);
-    assert!(app.quick_open.query.is_empty());
+    assert!(app.quick_open.core.active);
+    assert!(app.quick_open.core.filter.is_empty());
 
     // Space arms the leader (allowed because query is empty).
     input::handle_key(key(KeyCode::Char(' ')), &mut app);
@@ -772,12 +772,12 @@ fn quick_open_keeps_v_keystroke_after_leader() {
     // leader is cleared and `v` falls through to the char-append arm.
     input::handle_key(key(KeyCode::Char('v')), &mut app);
     assert!(
-        app.quick_open.active,
+        app.quick_open.core.active,
         "Space+V must not close quick_open — it's not the palette's own chord"
     );
     assert!(app.quick_open.space_leader_at.is_none());
     assert_eq!(
-        app.quick_open.query, "v",
+        app.quick_open.core.filter, "v",
         "the 'v' keystroke should land in the query buffer"
     );
 
@@ -788,12 +788,12 @@ fn quick_open_keeps_v_keystroke_after_leader() {
     // again, which it isn't (we typed 'v'). With 'v' in query, the
     // leader isn't armed by Space, so Space appends to query.
     // Reset for a clean P-toggle check:
-    app.quick_open.query.clear();
-    app.quick_open.cursor = 0;
+    app.quick_open.core.filter.clear();
+    app.quick_open.core.cursor = 0;
     input::handle_key(key(KeyCode::Char(' ')), &mut app);
     input::handle_key(key(KeyCode::Char('p')), &mut app);
     assert!(
-        !app.quick_open.active,
+        !app.quick_open.core.active,
         "Space+P with empty query should close quick_open"
     );
 }

--- a/tests/git_repo_integration.rs
+++ b/tests/git_repo_integration.rs
@@ -184,10 +184,68 @@ fn list_commits_returns_topological_order() {
     commit_file(&raw, "a.txt", "v3", "third");
 
     let (_g, repo) = open_in(tmp.path());
-    let commits = repo.list_commits(10);
+    let commits = repo.list_commits(&reef::git::GraphScope::AllRefs, 10);
     assert_eq!(commits.len(), 3);
     assert_eq!(commits[0].subject, "third");
     assert_eq!(commits[2].subject, "first");
+}
+
+#[test]
+fn list_commits_branch_scope_only_walks_named_ref() {
+    // Build two divergent branches off of the initial commit. The default
+    // branch (`main`/`master`) holds A→B; a feature branch points at A→C.
+    // Scoping to the feature branch must surface C but never B; scoping
+    // to the default must surface B but never C.
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, raw) = tempdir_repo();
+    commit_file(&raw, "a.txt", "v1", "A: shared root");
+    let after_a = raw.head().unwrap().target().unwrap();
+    let head_name = raw.head().unwrap().shorthand().map(String::from).unwrap();
+
+    // Create + check out a feature branch off A, commit C.
+    raw.branch("feature", &raw.find_commit(after_a).unwrap(), false)
+        .unwrap();
+    raw.set_head("refs/heads/feature").unwrap();
+    raw.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+        .unwrap();
+    commit_file(&raw, "feature.txt", "vC", "C: on feature");
+
+    // Back to the default branch and commit B.
+    raw.set_head(&format!("refs/heads/{head_name}")).unwrap();
+    raw.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+        .unwrap();
+    commit_file(&raw, "b.txt", "vB", "B: on default");
+
+    let (_g, repo) = open_in(tmp.path());
+    let default_ref = format!("refs/heads/{head_name}");
+    let default_commits =
+        repo.list_commits(&reef::git::GraphScope::Branch(default_ref.clone()), 50);
+    let default_subjects: Vec<&str> = default_commits.iter().map(|c| c.subject.as_str()).collect();
+    assert!(default_subjects.contains(&"A: shared root"));
+    assert!(default_subjects.contains(&"B: on default"));
+    assert!(!default_subjects.contains(&"C: on feature"));
+
+    let feature_commits = repo.list_commits(
+        &reef::git::GraphScope::Branch("refs/heads/feature".into()),
+        50,
+    );
+    let feature_subjects: Vec<&str> = feature_commits.iter().map(|c| c.subject.as_str()).collect();
+    assert!(feature_subjects.contains(&"A: shared root"));
+    assert!(feature_subjects.contains(&"C: on feature"));
+    assert!(!feature_subjects.contains(&"B: on default"));
+
+    // Missing ref → empty Vec, no panic.
+    let none = repo.list_commits(
+        &reef::git::GraphScope::Branch("refs/heads/does-not-exist".into()),
+        50,
+    );
+    assert!(none.is_empty());
+
+    // AllRefs still surfaces both branches' tips.
+    let all = repo.list_commits(&reef::git::GraphScope::AllRefs, 50);
+    let all_subjects: Vec<&str> = all.iter().map(|c| c.subject.as_str()).collect();
+    assert!(all_subjects.contains(&"B: on default"));
+    assert!(all_subjects.contains(&"C: on feature"));
 }
 
 #[test]
@@ -270,7 +328,7 @@ fn get_range_files_multi_commit_is_union() {
 
     let (_g, repo) = open_in(tmp.path());
     // list_commits is newest-first, so oldest = first commit, newest = third.
-    let commits = repo.list_commits(10);
+    let commits = repo.list_commits(&reef::git::GraphScope::AllRefs, 10);
     let oldest = &commits[2].oid;
     let newest = &commits[0].oid;
     let files = repo.get_range_files(oldest, newest);
@@ -290,7 +348,7 @@ fn get_range_file_diff_collapses_multiple_edits() {
     let _c3 = commit_file(&raw, "a.txt", "v3\n", "third");
 
     let (_g, repo) = open_in(tmp.path());
-    let commits = repo.list_commits(10);
+    let commits = repo.list_commits(&reef::git::GraphScope::AllRefs, 10);
     let oldest = &commits[2].oid;
     let newest = &commits[0].oid;
     let diff = repo

--- a/tests/global_search_seed.rs
+++ b/tests/global_search_seed.rs
@@ -47,14 +47,14 @@ fn select_byte_range(app: &mut App, start: (usize, usize), end: (usize, usize)) 
 fn begin_without_selection_preserves_existing_query() {
     let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let (mut app, _tmp, _g) = fresh_app();
-    app.global_search.query = "previous".to_string();
-    app.global_search.cursor = "previous".len();
+    app.global_search.core.filter = "previous".to_string();
+    app.global_search.core.cursor = "previous".len();
 
     global_search::begin(&mut app);
 
-    assert!(app.global_search.active);
-    assert_eq!(app.global_search.query, "previous");
-    assert_eq!(app.global_search.cursor, "previous".len());
+    assert!(app.global_search.core.active);
+    assert_eq!(app.global_search.core.filter, "previous");
+    assert_eq!(app.global_search.core.cursor, "previous".len());
 }
 
 #[test]
@@ -67,9 +67,9 @@ fn begin_seeds_query_from_preview_selection() {
 
     global_search::begin(&mut app);
 
-    assert_eq!(app.global_search.query, "bar();");
-    assert_eq!(app.global_search.cursor, "bar();".len());
-    assert!(app.global_search.active);
+    assert_eq!(app.global_search.core.filter, "bar();");
+    assert_eq!(app.global_search.core.cursor, "bar();".len());
+    assert!(app.global_search.core.active);
 }
 
 #[test]
@@ -83,7 +83,7 @@ fn begin_seeds_first_nonempty_line_when_selection_spans_multiple_rows() {
     global_search::begin(&mut app);
 
     assert_eq!(
-        app.global_search.query, "hello",
+        app.global_search.core.filter, "hello",
         "leading blank row must be skipped, indent must be trimmed",
     );
 }
@@ -96,7 +96,7 @@ fn begin_with_seed_equal_to_existing_query_keeps_excluded_set() {
     // Guard: `begin()` skips `mark_query_edited` when the seed matches.
     let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let (mut app, _tmp, _g) = fresh_app();
-    app.global_search.query = "bar".to_string();
+    app.global_search.core.filter = "bar".to_string();
     app.global_search
         .excluded
         .insert((PathBuf::from("a.rs"), 1));
@@ -105,7 +105,7 @@ fn begin_with_seed_equal_to_existing_query_keeps_excluded_set() {
 
     global_search::begin(&mut app);
 
-    assert_eq!(app.global_search.query, "bar");
+    assert_eq!(app.global_search.core.filter, "bar");
     assert!(
         !app.global_search.excluded.is_empty(),
         "no-op seed must not wipe per-match opt-outs",
@@ -119,11 +119,11 @@ fn begin_with_empty_selection_keeps_existing_query() {
     // seed with, so the existing query stays.
     let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let (mut app, _tmp, _g) = fresh_app();
-    app.global_search.query = "kept".to_string();
+    app.global_search.core.filter = "kept".to_string();
     install_text_preview(&mut app, &["foo bar"]);
     select_byte_range(&mut app, (0, 2), (0, 2));
 
     global_search::begin(&mut app);
 
-    assert_eq!(app.global_search.query, "kept");
+    assert_eq!(app.global_search.core.filter, "kept");
 }

--- a/tests/space_leader_input.rs
+++ b/tests/space_leader_input.rs
@@ -154,7 +154,7 @@ fn space_does_not_arm_while_typing_in_search_query() {
     app.set_active_tab(Tab::Search);
     app.active_panel = Panel::Files;
     app.global_search.focus = reef::global_search::SearchPanelFocus::FindInput;
-    app.global_search.query = "foo".to_string();
+    app.global_search.core.filter = "foo".to_string();
 
     input::handle_key(space_key(), &mut app);
     assert!(

--- a/tests/ui_snapshots.rs
+++ b/tests/ui_snapshots.rs
@@ -599,8 +599,8 @@ fn snapshot_search_tab_replace_open_with_excluded_row() {
     let mut app = App::new(Theme::dark(), None);
     wait_for_file_tree(&mut app);
     app.set_active_tab(reef::app::Tab::Search);
-    app.global_search.query = "needle".to_string();
-    app.global_search.cursor = "needle".len();
+    app.global_search.core.filter = "needle".to_string();
+    app.global_search.core.cursor = "needle".len();
     app.global_search.replace_text = "thread".to_string();
     app.global_search.replace_cursor = "thread".len();
     app.global_search.replace_open = true;


### PR DESCRIPTION
## Summary

8 commits、+3272 / -793 across 35 files。两件事：

### 1. Graph 单分支视图（原始需求）

按 `b` 弹出 overlay picker，把 commit graph 收敛到选中的本地或远端分支。walk 作用域、recents、当前激活分支均通过 prefs 跨会话持久化。

- `GraphScope { AllRefs | Branch(full_ref) }` 贯穿 Backend / TaskCoordinator / graph worker；scope 进入 cache key
- branch picker overlay：filter 输入 + recents 段 + `[ All refs ]` 哨兵 + 鼠标 / 双击确认
- 冷启动保护：`ref_map` 未填充时拒绝打开 picker（避免误 Enter 覆盖持久化 scope）
- 过期分支 fallback：active scope 的 ref 消失时，worker 对 transient walk 失败返回 Err 保留旧行；只有 ref 真删时才回退到 AllRefs + i18n toast
- Wire protocol bumped v9 → v10：`Request::ListCommits` 加必填 `scope`，混版本握手立即失败而非静默退化
- 侧栏顶部显示 `Branch <name>  (press b)` 指示当前 scope

### 2. 统一所有文本输入框（用户后续要求"彻底统一"）

reef 此前散落 12 处输入实现（5 个 picker + 1 个多行 commit textarea + 6 个零散）。本 PR 收敛到三层共享原语：

| 层 | 模块 | 服务于 |
|---|---|---|
| L0 | `input_edit` | 单行编辑原语 + `dispatch_key` + `dispatch_key_filtered` |
| L1 | `input_edit_multi` | 多行 textarea（跨行 Up/Down、行内 Home/End、Enter 插 `\n`） |
| L2 | `picker_core` | overlay picker scaffold（filter + cursor + selected_idx + dispatch） |

迁移后所有输入框统一支持 Alt/Ctrl+方向键、Ctrl+W/U、Alt+B/F/D、Ctrl+J/K/N/P 列表导航、UTF-8 boundary 安全。`commit textarea` 用 L1（多行），4 个 picker（quick_open / global_search overlay / hosts_picker / graph_branch_picker）用 L2，其余 7 处零散单行输入用 L0。

收敛带来净减约 700 行重复的 key-table 代码。

## Commit 列表

- `3012407` feat(graph): scope graph to a single branch via `b` picker
- `f343e09` refactor(input): unify single-line editors on input_edit::dispatch_key
- `9e0f881` feat(input): add dispatch_key_filtered for content-restricted inputs
- `acc9186` refactor(picker): extract PickerCore + migrate all 4 filter overlays
- `fe1ac3c` feat(input): add input_edit_multi for textarea-style buffers
- `77da87b` fix(input): address review findings on the picker refactor
- `edd93df` fix(input): plug regressions introduced by the picker-refactor fix-up
- `a6c12a8` fix(input): address 15 findings from the max-effort review

经历 4 轮 code-review，累计修了 31 个 finding（其中 6 个是 review 修复自己引入的回归 — 都已修干净）。

## Test plan

- [x] 49 个新单元 / 集成测试，覆盖 worker、fallback、picker filter / cursor、scope 持久化、`input_edit_multi` 多行行为、PickerCore dispatch、cache 失效、stale-branch toast
- [x] \`cargo check --tests\` 通过（前几个 commit 阶段不通过，最后修齐了）
- [x] \`cargo test --workspace\` lib 639 passed + 所有集成测试 ok（`fs_watcher_integration` 3 个 fail 是 main 上 pre-existing flake）
- [x] \`cargo clippy --workspace --no-deps\` 无 warning
- [x] 手动：`b` 打开 picker → 选分支 → graph 收敛；选 `[ All refs ]` 恢复全量
- [x] 手动：删掉持久化分支后重启，graph 自动回落到 AllRefs 并出 toast
- [x] 手动：mixed-protocol 握手立即失败而不是静默退化
- [x] 手动：commit textarea 内 Shift+Enter / Alt+Enter 软换行；Ctrl+Enter 提交；Ctrl+S 不再误 stage
- [x] 手动：所有 4 个 picker overlay 的编辑器快捷键统一（Alt/Ctrl+箭头、Ctrl+W、Ctrl+U 等）