### PR TITLE
perf(diff/preview): cache display rows, share via Arc, add LRU + bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,10 @@ harness = false
 name = "graph"
 harness = false
 
+[[bench]]
+name = "diff_perf"
+harness = false
+
 # ─── Workspace ─────────────────────────────────────────────────────────────
 # Root is the `reef` crate itself; `crates/test-support` is a dev-only helper
 # lib used by this crate's integration tests. `fuzz/` is excluded and runs as

--- a/benches/diff_perf.rs
+++ b/benches/diff_perf.rs
@@ -1,0 +1,178 @@
+//! Micro-benchmarks for the diff/preview hot paths the recent refactor
+//! touched. Run with `cargo bench --bench diff_perf`. Each bench is sized
+//! to be representative of "non-trivial PR diff" — 1k content lines split
+//! across 20 hunks of 50 lines each.
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use reef::app::HighlightedDiff;
+use reef::git::{DiffContent, DiffHunk, DiffLine, LineTag};
+use reef::search::{MatchLoc, SearchState, SearchTarget};
+use std::sync::Arc;
+
+/// Generates a diff with `hunks` hunks of `lines_per_hunk` lines each.
+/// Mix of Context (60%), Added (25%), Removed (15%) to approximate a
+/// realistic edit pattern.
+fn synth_diff(hunks: usize, lines_per_hunk: usize) -> DiffContent {
+    let mk_hunks: Vec<DiffHunk> = (0..hunks)
+        .map(|h| {
+            let lines: Vec<DiffLine> = (0..lines_per_hunk)
+                .map(|i| {
+                    let tag = match i % 20 {
+                        0..=11 => LineTag::Context,
+                        12..=16 => LineTag::Added,
+                        _ => LineTag::Removed,
+                    };
+                    let content_str = format!(
+                        "    let value_{h}_{i} = compute({}, {});",
+                        h * 100 + i,
+                        i * 7
+                    );
+                    DiffLine {
+                        tag,
+                        content: Arc::from(content_str),
+                        old_lineno: Some((h * lines_per_hunk + i) as u32 + 1),
+                        new_lineno: Some((h * lines_per_hunk + i) as u32 + 1),
+                    }
+                })
+                .collect();
+            DiffHunk {
+                header: Arc::from(
+                    format!(
+                        "@@ -{0},{1} +{0},{1} @@",
+                        h * lines_per_hunk + 1,
+                        lines_per_hunk
+                    )
+                    .as_str(),
+                ),
+                lines,
+            }
+        })
+        .collect();
+    DiffContent {
+        file_path: "src/lib.rs".to_string(),
+        hunks: mk_hunks,
+    }
+}
+
+/// Build HighlightedDiff (which builds DiffDisplay both layouts).
+fn bench_diff_display_build(c: &mut Criterion) {
+    let diff = synth_diff(20, 50); // 1000 lines / 20 hunks
+    c.bench_function("DiffDisplay::build/1k_lines_20_hunks", |b| {
+        b.iter(|| {
+            let d = HighlightedDiff::new(black_box(diff.clone()), None);
+            black_box(d);
+        });
+    });
+}
+
+/// `search::unified_display_rows` flattens a DiffContent into
+/// `Vec<Arc<str>>` (post-Arc<str> migration — used to be `Vec<String>`)
+/// for the match-finding stage. Called per keystroke in find widget.
+fn bench_unified_display_rows(c: &mut Criterion) {
+    let diff = synth_diff(20, 50);
+    c.bench_function("unified_display_rows/1k_lines", |b| {
+        b.iter(|| {
+            let rows = reef::search::unified_display_rows(black_box(&diff));
+            black_box(rows);
+        });
+    });
+}
+
+/// `SearchState::ranges_on_row` lookup on a 1000-row search result.
+/// Simulates per-row overlay lookup during render of a long diff.
+fn bench_ranges_on_row(c: &mut Criterion) {
+    let mut state = SearchState {
+        target: Some(SearchTarget::Diff),
+        ..SearchState::default()
+    };
+    // 1000 matches scattered across 500 rows (avg 2 matches/row).
+    let matches: Vec<MatchLoc> = (0..1000)
+        .map(|i| MatchLoc {
+            row: i / 2,
+            byte_range: (i % 50)..(i % 50 + 3),
+        })
+        .collect();
+    state.set_matches(matches);
+
+    c.bench_function("ranges_on_row/lookup_50_rows_of_1k_matches", |b| {
+        b.iter(|| {
+            for row in 0..50 {
+                let (ranges, _cur) = state.ranges_on_row(SearchTarget::Diff, black_box(row));
+                black_box(ranges);
+            }
+        });
+    });
+}
+
+/// Simulate one find-widget keystroke against a Unified diff: flatten
+/// the diff via `unified_display_rows` + run the matcher. Pre-fix the
+/// `to_string()` storm dominated; post-fix the Arc-clone path is the
+/// hot work.
+fn bench_find_widget_keystroke(c: &mut Criterion) {
+    use reef::search::find_all;
+    let diff = synth_diff(20, 50);
+    c.bench_function("find_keystroke/unified_1k_lines_smallcase", |b| {
+        b.iter(|| {
+            let rows = reef::search::unified_display_rows(black_box(&diff));
+            let mut total = 0usize;
+            for r in &rows {
+                // `&Arc<str>` derefs to `&str`.
+                total += find_all(r, black_box("compute"), true).len();
+            }
+            black_box(total);
+        });
+    });
+}
+
+/// `highlight_diff` on a brand-new key — pays the full hash, flat build
+/// and syntect cost. First-time-loaded diff baseline. Resets the cache
+/// upfront so the bench's numbers don't depend on which other benches
+/// ran first in this binary.
+fn bench_highlight_diff_miss(c: &mut Criterion) {
+    let diff = synth_diff(20, 50);
+    let mut iter_count = 0u64;
+    reef::tasks::_reset_highlight_cache();
+    c.bench_function("highlight_diff/miss_1k_lines", |b| {
+        b.iter(|| {
+            // Mutate path each iteration so the cache misses every time —
+            // otherwise we'd be measuring the in-flight wait or the cache
+            // hit, not actual syntect cost.
+            iter_count += 1;
+            let path = format!("src/bench_{}.rs", iter_count);
+            let r = reef::tasks::highlight_diff(black_box(&path), black_box(&diff), true);
+            black_box(r);
+        });
+    });
+}
+
+/// `highlight_diff` on a warm cache key — should short-circuit on the
+/// LRU lookup and return an `Arc<DiffHighlighted>` clone (refcount bump).
+/// Resets first then warms exactly one key, so the measured short-circuit
+/// is reproducible regardless of prior bench state.
+fn bench_highlight_diff_hit(c: &mut Criterion) {
+    let diff = synth_diff(20, 50);
+    reef::tasks::_reset_highlight_cache();
+    // Warm the cache once outside the timing loop.
+    let _ = reef::tasks::highlight_diff("src/cached.rs", &diff, true);
+    c.bench_function("highlight_diff/cache_hit_1k_lines", |b| {
+        b.iter(|| {
+            let r = reef::tasks::highlight_diff(
+                black_box("src/cached.rs"),
+                black_box(&diff),
+                black_box(true),
+            );
+            black_box(r);
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_diff_display_build,
+    bench_unified_display_rows,
+    bench_ranges_on_row,
+    bench_find_widget_keystroke,
+    bench_highlight_diff_miss,
+    bench_highlight_diff_hit,
+);
+criterion_main!(benches);

--- a/crates/reef-agent/src/main.rs
+++ b/crates/reef-agent/src/main.rs
@@ -716,7 +716,7 @@ fn diff_to_dto(d: reef::git::DiffContent) -> DiffContentDto {
 
 fn diff_hunk_to_dto(h: reef::git::DiffHunk) -> DiffHunkDto {
     DiffHunkDto {
-        header: h.header,
+        header: h.header.to_string(),
         lines: h.lines.into_iter().map(diff_line_to_dto).collect(),
     }
 }
@@ -724,7 +724,7 @@ fn diff_hunk_to_dto(h: reef::git::DiffHunk) -> DiffHunkDto {
 fn diff_line_to_dto(l: reef::git::DiffLine) -> DiffLineDto {
     DiffLineDto {
         tag: line_tag_to_dto(l.tag),
-        content: l.content,
+        content: l.content.to_string(),
         old_lineno: l.old_lineno,
         new_lineno: l.new_lineno,
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -420,10 +420,47 @@ pub type DiffHighlighted = Vec<Vec<LineTokens>>;
 /// A diff plus its optional syntax-highlighted tokens. Used for the Git-tab
 /// working/staged diff (no path needed — the selected file is tracked
 /// elsewhere) where `CommitFileDiff` would be overkill.
+///
+/// `display` is the worker-built render cache (per-frame display rows +
+/// mouse-hit row_texts for both unified and SBS layouts). Wrapped in `Arc` so
+/// cloning the struct doesn't clone the cache, and so the renderer's
+/// `hit_slot` can share the same Vec without per-frame copy.
+///
+/// **Invariant**: `display` must be built from `diff` + `highlighted` via
+/// `HighlightedDiff::new`. Mutating `diff` or `highlighted` in place (both
+/// fields are pub for ergonomics) without rebuilding `display` desyncs
+/// the render-time row vectors from the underlying data — render shows
+/// stale text while `ranges_on_row` indexes into the new content. Always
+/// reassign the whole struct via `::new(...)` for content-changing
+/// updates.
 #[derive(Debug, Clone)]
 pub struct HighlightedDiff {
     pub diff: DiffContent,
-    pub highlighted: Option<DiffHighlighted>,
+    /// Syntax-highlighted tokens, shared as `Arc<DiffHighlighted>` so the
+    /// process-wide highlight cache can hand the same allocation to every
+    /// caller without cloning the deep `Vec<Vec<Arc<...>>>` structure.
+    /// `None` means the file's extension didn't resolve a syntax (or we
+    /// skipped highlighting due to size guards).
+    pub highlighted: Option<Arc<DiffHighlighted>>,
+    pub display: Arc<crate::ui::diff_panel::DiffDisplay>,
+}
+
+impl HighlightedDiff {
+    /// Build a `HighlightedDiff` and its render-cache (`DiffDisplay`) in one
+    /// step. Worker callers use this so tests don't have to know about the
+    /// cache wiring; pass the highlight result (or `None` if no syntax
+    /// resolved / highlighting was skipped).
+    pub fn new(diff: DiffContent, highlighted: Option<Arc<DiffHighlighted>>) -> Self {
+        let display = Arc::new(crate::ui::diff_panel::DiffDisplay::build(
+            &diff,
+            highlighted.as_deref(),
+        ));
+        Self {
+            diff,
+            highlighted,
+            display,
+        }
+    }
 }
 
 /// A loaded commit-file diff plus its optional syntax-highlighted tokens.
@@ -433,7 +470,23 @@ pub struct HighlightedDiff {
 pub struct CommitFileDiff {
     pub path: String,
     pub diff: DiffContent,
-    pub highlighted: Option<DiffHighlighted>,
+    pub highlighted: Option<Arc<DiffHighlighted>>,
+    pub display: Arc<crate::ui::diff_panel::DiffDisplay>,
+}
+
+impl CommitFileDiff {
+    pub fn new(path: String, diff: DiffContent, highlighted: Option<Arc<DiffHighlighted>>) -> Self {
+        let display = Arc::new(crate::ui::diff_panel::DiffDisplay::build(
+            &diff,
+            highlighted.as_deref(),
+        ));
+        Self {
+            path,
+            diff,
+            highlighted,
+            display,
+        }
+    }
 }
 
 /// Range-mode summary for the Graph tab's right panel. Shown instead of
@@ -6024,17 +6077,19 @@ mod tests {
         // without resetting search would leave `n`/`N` jumping to
         // rows that no longer correspond to anything visible.
         let mut fx = make_scope_fixture();
-        // Synthesize an active CommitGraph search.
+        // Synthesize an active CommitGraph search via `set_matches` so the
+        // `row_index` invariant holds (set_matches resets `current`, so
+        // assign it on the next line).
         fx.app.search = crate::search::SearchState {
             target: Some(crate::search::SearchTarget::CommitGraph),
-            matches: vec![crate::search::MatchLoc {
-                row: 0,
-                byte_range: 0..3,
-            }],
-            current: Some(0),
             query: "foo".into(),
             ..crate::search::SearchState::default()
         };
+        fx.app.search.set_matches(vec![crate::search::MatchLoc {
+            row: 0,
+            byte_range: 0..3,
+        }]);
+        fx.app.search.current = Some(0);
 
         fx.app
             .set_graph_scope(GraphScope::Branch("refs/heads/main".into()));
@@ -6053,14 +6108,14 @@ mod tests {
         let mut fx = make_scope_fixture();
         fx.app.search = crate::search::SearchState {
             target: Some(crate::search::SearchTarget::FilePreview),
-            matches: vec![crate::search::MatchLoc {
-                row: 5,
-                byte_range: 0..3,
-            }],
-            current: Some(0),
             query: "foo".into(),
             ..crate::search::SearchState::default()
         };
+        fx.app.search.set_matches(vec![crate::search::MatchLoc {
+            row: 5,
+            byte_range: 0..3,
+        }]);
+        fx.app.search.current = Some(0);
 
         fx.app
             .set_graph_scope(GraphScope::Branch("refs/heads/main".into()));

--- a/src/backend/remote.rs
+++ b/src/backend/remote.rs
@@ -1194,7 +1194,7 @@ impl From<reef_proto::DiffContentDto> for DiffContent {
 impl From<reef_proto::DiffHunkDto> for crate::git::DiffHunk {
     fn from(v: reef_proto::DiffHunkDto) -> Self {
         crate::git::DiffHunk {
-            header: v.header,
+            header: std::sync::Arc::from(v.header),
             lines: v.lines.into_iter().map(Into::into).collect(),
         }
     }
@@ -1204,7 +1204,7 @@ impl From<reef_proto::DiffLineDto> for crate::git::DiffLine {
     fn from(v: reef_proto::DiffLineDto) -> Self {
         crate::git::DiffLine {
             tag: v.tag.into(),
-            content: v.content,
+            content: std::sync::Arc::from(v.content),
             old_lineno: v.old_lineno,
             new_lineno: v.new_lineno,
         }

--- a/src/find_widget.rs
+++ b/src/find_widget.rs
@@ -12,9 +12,7 @@
 use crate::app::App;
 use crate::input;
 use crate::input_edit;
-use crate::search::{
-    self, MatchLoc, Snapshot, center_scroll, find_all, restore_snapshot, take_snapshot,
-};
+use crate::search::{MatchLoc, Snapshot, center_scroll, find_all, restore_snapshot, take_snapshot};
 use crate::ui::selection::{DiffRowText, DiffSide};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use std::ops::Range;
@@ -36,9 +34,24 @@ pub struct FindWidgetState {
     pub regex: bool,
 
     pub target: Option<FindTarget>,
+    /// Match locations. **Invariant**: must agree with `row_index` —
+    /// mutate ONLY through `set_matches` / `clear_matches`. Direct
+    /// `matches.push(...)` or `matches = vec![...]` leaves `row_index`
+    /// stale and `ranges_on_row` will silently return empty results
+    /// for the desynced rows.
     pub matches: Vec<MatchLoc>,
     pub current: Option<usize>,
     pub snapshot: Option<Snapshot>,
+
+    /// `row → indices into matches`. Rebuilt by `set_matches` /
+    /// `clear_matches`. Mirrors `SearchState::row_index` so per-row
+    /// overlay lookup stays O(1+k) instead of O(matches.len()).
+    ///
+    /// **Invariant:** kept in sync via `set_matches` / `clear_matches`.
+    /// External code (tests etc.) using the struct-literal form should
+    /// pass `Default::default()` here; mutating after construction is
+    /// not supported.
+    pub row_index: std::collections::HashMap<usize, Vec<usize>>,
 
     /// Cached widget rect for mouse hit-testing.
     pub last_widget_rect: Option<ratatui::layout::Rect>,
@@ -63,9 +76,37 @@ pub enum FindTarget {
 }
 
 impl FindWidgetState {
+    /// Replace `matches` and rebuild the per-row lookup. Also resets
+    /// `current` to `None` — callers picking a fresh "current" must
+    /// assign it right after this call. Mirrors `SearchState::set_matches`'s
+    /// invariant so a future caller can't accidentally carry a stale
+    /// `current >= matches.len()` past the swap.
+    ///
+    /// Panic-safe: see `SearchState::set_matches` for the rationale on
+    /// the assign-before-index ordering.
+    pub fn set_matches(&mut self, matches: Vec<MatchLoc>) {
+        self.matches = matches;
+        self.current = None;
+        self.row_index.clear();
+        for (i, m) in self.matches.iter().enumerate() {
+            self.row_index.entry(m.row).or_default().push(i);
+        }
+    }
+
+    /// Empty `matches` + reset associated fields (index, current,
+    /// regex_error). Also clears `regex_error` so a panel-blur / Esc /
+    /// mode-swap path doesn't leak a stale error string into the
+    /// prompt render.
+    pub fn clear_matches(&mut self) {
+        self.matches.clear();
+        self.row_index.clear();
+        self.current = None;
+        self.regex_error = None;
+    }
+
     /// Ranges of matches on `row` for `target` plus the current-match
     /// range if it lives on this row. Render-time helper, mirrors
-    /// `SearchState::ranges_on_row`.
+    /// `SearchState::ranges_on_row` — O(1+k) via `row_index`.
     pub fn ranges_on_row(
         &self,
         target: FindTarget,
@@ -74,12 +115,13 @@ impl FindWidgetState {
         if self.target != Some(target) || self.matches.is_empty() {
             return (Vec::new(), None);
         }
-        let mut all = Vec::new();
+        let Some(idxs) = self.row_index.get(&row) else {
+            return (Vec::new(), None);
+        };
+        let mut all = Vec::with_capacity(idxs.len());
         let mut cur = None;
-        for (i, m) in self.matches.iter().enumerate() {
-            if m.row != row {
-                continue;
-            }
+        for &i in idxs {
+            let m = &self.matches[i];
             if Some(i) == self.current {
                 cur = Some(m.byte_range.clone());
             }
@@ -343,53 +385,74 @@ fn diff_target_from_layout(
     }
 }
 
-fn collect_rows(app: &App, target: FindTarget) -> Vec<String> {
+/// Returns a row vec where each entry borrows from `app` (`Cow::Borrowed(&str)`)
+/// when possible — the diff paths read directly from the precomputed
+/// `display.unified_row_texts` / `display.sbs_row_texts` rather than
+/// re-flattening the diff on every keystroke.
+fn collect_rows(app: &App, target: FindTarget) -> Vec<std::borrow::Cow<'_, str>> {
+    use std::borrow::Cow;
     match target {
         FindTarget::FilePreview => match app.preview_content.as_ref().map(|p| &p.body) {
-            Some(crate::file_tree::PreviewBody::Text { lines, .. }) => lines.clone(),
+            Some(crate::file_tree::PreviewBody::Text { lines, .. }) => {
+                lines.iter().map(|l| Cow::Borrowed(l.as_str())).collect()
+            }
             _ => Vec::new(),
         },
         FindTarget::DiffUnified => match &app.diff_content {
-            Some(d) => search::unified_display_rows(&d.diff),
+            Some(d) => row_texts_to_cows(&d.display.unified_row_texts),
             None => Vec::new(),
         },
         FindTarget::GraphDiffUnified => match &app.commit_detail.file_diff {
-            Some(d) => search::unified_display_rows(&d.diff),
+            Some(d) => row_texts_to_cows(&d.display.unified_row_texts),
             None => Vec::new(),
         },
         FindTarget::DiffSbsLeft => match &app.diff_content {
-            Some(d) => sbs_side_rows(&d.diff, DiffSide::SbsLeft),
+            Some(d) => sbs_side_cows(&d.display.sbs_row_texts, DiffSide::SbsLeft),
             None => Vec::new(),
         },
         FindTarget::DiffSbsRight => match &app.diff_content {
-            Some(d) => sbs_side_rows(&d.diff, DiffSide::SbsRight),
+            Some(d) => sbs_side_cows(&d.display.sbs_row_texts, DiffSide::SbsRight),
             None => Vec::new(),
         },
         FindTarget::GraphDiffSbsLeft => match &app.commit_detail.file_diff {
-            Some(d) => sbs_side_rows(&d.diff, DiffSide::SbsLeft),
+            Some(d) => sbs_side_cows(&d.display.sbs_row_texts, DiffSide::SbsLeft),
             None => Vec::new(),
         },
         FindTarget::GraphDiffSbsRight => match &app.commit_detail.file_diff {
-            Some(d) => sbs_side_rows(&d.diff, DiffSide::SbsRight),
+            Some(d) => sbs_side_cows(&d.display.sbs_row_texts, DiffSide::SbsRight),
             None => Vec::new(),
         },
     }
 }
 
-fn sbs_side_rows(diff: &crate::git::DiffContent, side: DiffSide) -> Vec<String> {
-    crate::ui::diff_panel::build_sbs_row_texts(diff)
-        .into_iter()
+fn row_texts_to_cows(rows: &[DiffRowText]) -> Vec<std::borrow::Cow<'_, str>> {
+    use std::borrow::Cow;
+    rows.iter()
         .map(|r| match r {
-            DiffRowText::Separator => String::new(),
-            DiffRowText::Header(h) => h,
-            // `build_sbs_row_texts` only ever emits Separator / Header /
-            // Sbs (paired rows), never `Unified` — exhaustive match keeps
-            // the compiler honest if the row enum grows new variants.
-            DiffRowText::Unified(s) => s,
+            DiffRowText::Separator => Cow::Borrowed(""),
+            DiffRowText::Header(s) => Cow::Borrowed(s.as_ref()),
+            DiffRowText::Unified(s) => Cow::Borrowed(s.as_ref()),
+            DiffRowText::Sbs { .. } => Cow::Borrowed(""),
+        })
+        .collect()
+}
+
+/// Project the precomputed `Arc<Vec<DiffRowText>>` from `DiffDisplay::build`
+/// onto the requested SBS side. Previously this re-ran the SBS pairing state
+/// machine on every keystroke; now it's an O(N) walk over already-shared
+/// `Arc<str>` rows, with zero per-row allocation (each output `Cow::Borrowed`
+/// points into the cached Arc).
+fn sbs_side_cows(rows: &[DiffRowText], side: DiffSide) -> Vec<std::borrow::Cow<'_, str>> {
+    use std::borrow::Cow;
+    rows.iter()
+        .map(|r| match r {
+            DiffRowText::Separator => Cow::Borrowed(""),
+            DiffRowText::Header(h) => Cow::Borrowed(h.as_ref()),
+            DiffRowText::Unified(s) => Cow::Borrowed(s.as_ref()),
             DiffRowText::Sbs { left, right } => match side {
-                DiffSide::SbsLeft => left,
-                DiffSide::SbsRight => right,
-                DiffSide::Unified => String::new(),
+                DiffSide::SbsLeft => Cow::Borrowed(left.as_ref()),
+                DiffSide::SbsRight => Cow::Borrowed(right.as_ref()),
+                DiffSide::Unified => Cow::Borrowed(""),
             },
         })
         .collect()
@@ -448,9 +511,8 @@ pub fn recompute(app: &mut App) {
     let query = app.find_widget.query.clone();
 
     if query.is_empty() {
-        app.find_widget.matches.clear();
-        app.find_widget.current = None;
-        app.find_widget.regex_error = None;
+        // `clear_matches` already nulls `regex_error` — see its doc.
+        app.find_widget.clear_matches();
         // Re-apply snapshot scroll so the view rests at the starting
         // position while the user is mid-edit. Matches the legacy
         // `/`-prompt feel where deleting back to empty undoes the jump.
@@ -489,7 +551,7 @@ pub fn recompute(app: &mut App) {
         }
     }
 
-    app.find_widget.matches = matches;
+    app.find_widget.set_matches(matches);
     app.find_widget.regex_error = regex_error;
     app.find_widget.current = pick_current(app, target);
     jump_to_current(app);

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -4,6 +4,7 @@ pub mod tree;
 use git2::{DiffOptions, Repository, Sort, StatusOptions};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct FileEntry {
@@ -114,16 +115,27 @@ pub struct DiffContent {
     pub hunks: Vec<DiffHunk>,
 }
 
+/// One hunk of a diff. `header` is the `@@ -.. +.. @@` line plus optional
+/// section context (e.g. `@@ -1,5 +1,5 @@ fn foo`). Stored as `Arc<str>`
+/// so cloning a hunk for the SBS pairing / display cache is a refcount
+/// bump rather than a String allocation — the rendered display vector
+/// hands the same Arc through to the spans on every frame.
 #[derive(Debug, Clone)]
 pub struct DiffHunk {
-    pub header: String,
+    pub header: Arc<str>,
     pub lines: Vec<DiffLine>,
 }
 
+/// One line within a hunk. `content` is the raw text without the leading
+/// `+`/`-`/` ` marker (the marker is reconstructed from `tag` at render
+/// time). `Arc<str>` so `.clone()` is a refcount bump — the per-frame
+/// `pair_hunk_lines` and `DiffDisplay::build` paths rely on this being
+/// O(1); a `String` field would re-introduce per-line heap copies
+/// across every render.
 #[derive(Debug, Clone)]
 pub struct DiffLine {
     pub tag: LineTag,
-    pub content: String,
+    pub content: Arc<str>,
     pub old_lineno: Option<u32>,
     pub new_lineno: Option<u32>,
 }
@@ -433,7 +445,7 @@ impl GitRepo {
             .enumerate()
             .map(|(i, line)| DiffLine {
                 tag: LineTag::Added,
-                content: line.to_string(),
+                content: Arc::from(line),
                 old_lineno: None,
                 new_lineno: Some(i as u32 + 1),
             })
@@ -442,7 +454,7 @@ impl GitRepo {
         Some(DiffContent {
             file_path: path.to_string(),
             hunks: vec![DiffHunk {
-                header: format!("@@ -0,0 +1,{} @@ (new file)", lines.len()),
+                header: Arc::from(format!("@@ -0,0 +1,{} @@ (new file)", lines.len())),
                 lines,
             }],
         })
@@ -470,9 +482,12 @@ impl GitRepo {
                         '-' => LineTag::Removed,
                         _ => LineTag::Context,
                     };
-                    let content = String::from_utf8_lossy(line.content()).to_string();
-                    // Trim trailing newline
-                    let content = content.trim_end_matches('\n').to_string();
+                    // `from_utf8_lossy` returns `Cow::Borrowed` for ASCII (the common
+                    // case) — going straight from that slice into `Arc::from` is one
+                    // allocation; the earlier `.to_string().trim_end_matches(..)`
+                    // path paid two (the lossy String AND the Arc<str> buffer).
+                    let cow = String::from_utf8_lossy(line.content());
+                    let content: Arc<str> = Arc::from(cow.trim_end_matches('\n'));
 
                     let diff_line = DiffLine {
                         tag,
@@ -487,10 +502,11 @@ impl GitRepo {
                     }
                 }
                 'H' => {
-                    // Hunk header
-                    let header = String::from_utf8_lossy(line.content()).trim().to_string();
+                    // Hunk header. Same one-alloc pattern as the content branch
+                    // above — `from_utf8_lossy` → trim → `Arc::from(&str)`.
+                    let cow = String::from_utf8_lossy(line.content());
                     hunks.push(DiffHunk {
-                        header,
+                        header: Arc::from(cow.trim()),
                         lines: Vec::new(),
                     });
                 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -13,6 +13,7 @@
 use crate::app::{App, Panel, SelectedFile, Tab};
 use crate::input_edit;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::collections::HashMap;
 use std::ops::Range;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -24,9 +25,10 @@ pub enum SearchTarget {
     Diff,
     CommitDetail,
     /// Graph tab 三列布局下右侧 diff 栏的 `/` 搜索目标。行索引对齐
-    /// `unified_display_rows(&file_diff.diff)`——和 Git tab 的
-    /// `SearchTarget::Diff` 同款 —— 这样渲染层的 `ranges_on_row` 直接拿
-    /// 到匹配区间,跟 `diff_panel::render_diff` 的行号系统无缝对接。
+    /// `commit_detail.file_diff.display.unified_row_texts`——和 Git tab 的
+    /// `SearchTarget::Diff` 同款(共享同一份 worker-built `DiffDisplay` 缓存)
+    /// —— 这样渲染层的 `ranges_on_row` 直接拿到匹配区间,跟
+    /// `diff_panel::render_diff` 的行号系统无缝对接。
     GraphDiff,
 }
 
@@ -71,10 +73,27 @@ pub struct SearchState {
     /// Byte offset into `query`. Always on a char boundary.
     pub cursor: usize,
     pub target: Option<SearchTarget>,
+    /// Match locations. **Invariant**: must agree with `row_index` —
+    /// mutate ONLY through `set_matches` / `clear_matches`. Direct
+    /// `matches.push(...)` or `matches = vec![...]` leaves `row_index`
+    /// stale and `ranges_on_row` will silently return empty results
+    /// for the desynced rows.
     pub matches: Vec<MatchLoc>,
     pub current: Option<usize>,
     pub snapshot: Option<Snapshot>,
     pub wrap_msg: Option<WrapMsg>,
+    /// `row → indices into `matches`` index. Rebuilt whenever `matches`
+    /// changes via [`set_matches`] / [`clear_matches`]. Lets per-row
+    /// renderers look up overlays in O(1+k) (k = matches on that row)
+    /// instead of scanning all matches every frame — at 10k+ hits the
+    /// linear scan was the dominant render cost for global-search
+    /// previews.
+    ///
+    /// **Invariant:** kept in sync via `set_matches` / `clear_matches`.
+    /// External code (tests etc.) using the struct-literal form should
+    /// pass `Default::default()` here; mutating after construction is
+    /// not supported.
+    pub row_index: HashMap<usize, Vec<usize>>,
 }
 
 impl SearchState {
@@ -84,8 +103,39 @@ impl SearchState {
         !self.active && !self.matches.is_empty() && self.target.is_some()
     }
 
+    /// Replace `matches` and rebuild the per-row lookup. Also resets
+    /// `current` to `None` — callers picking a fresh "current" must
+    /// assign it right after this call. (Pre-fix, leaving the stale
+    /// `current` index hanging past the new `matches.len()` made
+    /// `step` / `jump_to_current` silently no-op; the asymmetry with
+    /// `clear_matches` (which always wiped `current`) was a footgun.)
+    ///
+    /// Panic-safe: `self.matches` is assigned BEFORE we build the
+    /// `row_index` over it. If a HashMap rehash inside the loop panics
+    /// (OOM), we leave `row_index` partial — but the indices it holds
+    /// still point into `self.matches`, so `ranges_on_row` returns a
+    /// truncated but consistent view rather than reading past
+    /// stale-vec bounds.
+    pub fn set_matches(&mut self, matches: Vec<MatchLoc>) {
+        self.matches = matches;
+        self.current = None;
+        self.row_index.clear();
+        for (i, m) in self.matches.iter().enumerate() {
+            self.row_index.entry(m.row).or_default().push(i);
+        }
+    }
+
+    /// Empty `matches` + clear the index. Cheaper than building a fresh
+    /// `SearchState` when only matches need to drop.
+    pub fn clear_matches(&mut self) {
+        self.matches.clear();
+        self.row_index.clear();
+        self.current = None;
+    }
+
     /// Ranges of matches falling on a given row, plus the current-match
     /// range if it lives on this row. Consumed by the overlay renderer.
+    /// O(1+k) where k = match count on `row` — backed by `row_index`.
     pub fn ranges_on_row(
         &self,
         target: SearchTarget,
@@ -94,12 +144,13 @@ impl SearchState {
         if self.target != Some(target) || self.matches.is_empty() {
             return (Vec::new(), None);
         }
-        let mut all = Vec::new();
+        let Some(idxs) = self.row_index.get(&row) else {
+            return (Vec::new(), None);
+        };
+        let mut all = Vec::with_capacity(idxs.len());
         let mut cur = None;
-        for (i, m) in self.matches.iter().enumerate() {
-            if m.row != row {
-                continue;
-            }
+        for &i in idxs {
+            let m = &self.matches[i];
             if Some(i) == self.current {
                 cur = Some(m.byte_range.clone());
             }
@@ -133,6 +184,7 @@ pub fn begin(app: &mut App, backwards: bool) {
         current: None,
         snapshot: Some(snap),
         wrap_msg: None,
+        row_index: HashMap::new(),
     };
 }
 
@@ -275,24 +327,30 @@ pub(crate) fn resolve_target(app: &App) -> Option<SearchTarget> {
 
 /// Build the searchable row list for a target. Row indices returned in match
 /// locations are into this vec.
-fn collect_rows(app: &App, target: SearchTarget) -> Vec<String> {
+/// Returns a row vec where each entry is borrowed from `app` when possible
+/// (`Cow::Borrowed(&str)`) and only allocates for the synthesized empty
+/// separator rows in diffs. Saves the per-keystroke `to_string()` storm
+/// over Arc<str>-backed diff lines.
+fn collect_rows(app: &App, target: SearchTarget) -> Vec<std::borrow::Cow<'_, str>> {
+    use std::borrow::Cow;
     match target {
         SearchTarget::FileTree => app
             .file_tree
             .entries
             .iter()
-            .map(|e| e.name.clone())
+            .map(|e| Cow::Borrowed(e.name.as_str()))
             .collect(),
         SearchTarget::GitStatus => {
             // Unified staged-then-unstaged path list — matches the order of
             // selectable rows in the panel. Search in git_status is file-only
             // (banners and section headers are skipped).
-            let mut rows = Vec::with_capacity(app.staged_files.len() + app.unstaged_files.len());
+            let mut rows: Vec<Cow<'_, str>> =
+                Vec::with_capacity(app.staged_files.len() + app.unstaged_files.len());
             for f in &app.staged_files {
-                rows.push(f.path.clone());
+                rows.push(Cow::Borrowed(f.path.as_str()));
             }
             for f in &app.unstaged_files {
-                rows.push(f.path.clone());
+                rows.push(Cow::Borrowed(f.path.as_str()));
             }
             rows
         }
@@ -300,28 +358,30 @@ fn collect_rows(app: &App, target: SearchTarget) -> Vec<String> {
             .git_graph
             .rows
             .iter()
-            .map(|r| r.commit.subject.clone())
+            .map(|r| Cow::Borrowed(r.commit.subject.as_str()))
             .collect(),
         SearchTarget::FilePreview => match &app.preview_content {
             Some(p) => match &p.body {
-                crate::file_tree::PreviewBody::Text { lines, .. } => lines.clone(),
+                crate::file_tree::PreviewBody::Text { lines, .. } => {
+                    lines.iter().map(|l| Cow::Borrowed(l.as_str())).collect()
+                }
                 _ => Vec::new(),
             },
             _ => Vec::new(),
         },
         SearchTarget::Diff => match &app.diff_content {
-            // Row layout matches the Unified diff panel's `all_lines`:
-            // separator rows between hunks, then hunk header + per-line rows.
-            // `diff_scroll` is an offset into that vec, so our row index is
-            // directly usable as a scroll target.
-            Some(d) => unified_display_rows(&d.diff),
+            // Read directly from the pre-built `display.unified_row_texts`
+            // (Arc<Vec<DiffRowText>> built once at diff load) instead of
+            // re-flattening the diff on every keystroke. Each row borrows
+            // from the Arc<str> inside the DiffRowText — zero per-row alloc.
+            Some(d) => row_texts_to_cows(&d.display.unified_row_texts),
             None => Vec::new(),
         },
         SearchTarget::GraphDiff => match &app.commit_detail.file_diff {
             // Graph tab 3-col diff column — same row layout as the Git tab's
             // diff panel, just sourced from `commit_detail.file_diff` instead
             // of `app.diff_content`.
-            Some(d) => unified_display_rows(&d.diff),
+            Some(d) => row_texts_to_cows(&d.display.unified_row_texts),
             None => Vec::new(),
         },
         SearchTarget::CommitDetail => {
@@ -332,21 +392,45 @@ fn collect_rows(app: &App, target: SearchTarget) -> Vec<String> {
             // inline diff rows in 3-col mode so match coordinates stay
             // aligned with what's actually rendered under Panel::Commit.
             crate::ui::commit_detail_panel::searchable_rows(app)
+                .into_iter()
+                .map(Cow::Owned)
+                .collect()
         }
     }
 }
 
+/// Project a slice of `DiffRowText` into the `Cow<&str>` shape `collect_rows`
+/// returns. Each row borrows directly from the underlying `Arc<str>` —
+/// zero per-row allocation, mirroring the find_widget SBS path.
+fn row_texts_to_cows(rows: &[crate::ui::selection::DiffRowText]) -> Vec<std::borrow::Cow<'_, str>> {
+    use crate::ui::selection::DiffRowText;
+    use std::borrow::Cow;
+    rows.iter()
+        .map(|r| match r {
+            DiffRowText::Separator => Cow::Borrowed(""),
+            DiffRowText::Header(s) => Cow::Borrowed(s.as_ref()),
+            DiffRowText::Unified(s) => Cow::Borrowed(s.as_ref()),
+            // Sbs variants don't appear in `unified_row_texts`; defensive.
+            DiffRowText::Sbs { .. } => Cow::Borrowed(""),
+        })
+        .collect()
+}
+
 /// Flatten a diff into searchable rows that line up with the Unified diff
 /// panel's `all_lines` layout (separator between hunks → header → body).
-pub(crate) fn unified_display_rows(diff: &crate::git::DiffContent) -> Vec<String> {
-    let mut rows = Vec::new();
+/// Returns `Vec<Arc<str>>` (refcount bumps, no heap copies) since the
+/// underlying `DiffLine.content` / `DiffHunk.header` are already `Arc<str>`
+/// — the matcher only reads `&str` via deref coercion.
+pub fn unified_display_rows(diff: &crate::git::DiffContent) -> Vec<std::sync::Arc<str>> {
+    let empty = crate::ui::text::empty_arc_str();
+    let mut rows: Vec<std::sync::Arc<str>> = Vec::new();
     for (i, hunk) in diff.hunks.iter().enumerate() {
         if i > 0 {
-            rows.push(String::new()); // Separator row — never matches.
+            rows.push(std::sync::Arc::clone(&empty)); // Separator row — never matches.
         }
-        rows.push(hunk.header.clone());
+        rows.push(std::sync::Arc::clone(&hunk.header));
         for line in &hunk.lines {
-            rows.push(line.content.clone());
+            rows.push(std::sync::Arc::clone(&line.content));
         }
     }
     rows
@@ -360,7 +444,7 @@ pub(crate) fn smart_case(query: &str) -> bool {
 
 /// All byte-range matches of `needle` in `haystack`, non-overlapping, with
 /// smart-case folding. Needle must be non-empty.
-pub(crate) fn find_all(haystack: &str, needle: &str, case_insensitive: bool) -> Vec<Range<usize>> {
+pub fn find_all(haystack: &str, needle: &str, case_insensitive: bool) -> Vec<Range<usize>> {
     if needle.is_empty() {
         return Vec::new();
     }
@@ -395,8 +479,7 @@ fn recompute_and_jump(app: &mut App, from_step: bool) {
     let query = app.search.query.clone();
 
     if query.is_empty() {
-        app.search.matches.clear();
-        app.search.current = None;
+        app.search.clear_matches();
         // Re-apply the snapshot so the view shows the starting position while
         // the user is still editing.
         if let Some(snap) = app.search.snapshot.clone() {
@@ -417,7 +500,7 @@ fn recompute_and_jump(app: &mut App, from_step: bool) {
         }
     }
 
-    app.search.matches = matches;
+    app.search.set_matches(matches);
     app.search.current = pick_current(app, target, from_step);
     jump_to_current(app);
 }
@@ -667,25 +750,27 @@ mod tests {
 
     #[test]
     fn ranges_on_row_filters_correctly() {
-        let s = SearchState {
+        let mut s = SearchState {
             target: Some(SearchTarget::FilePreview),
-            matches: vec![
-                MatchLoc {
-                    row: 1,
-                    byte_range: 0..3,
-                },
-                MatchLoc {
-                    row: 1,
-                    byte_range: 5..8,
-                },
-                MatchLoc {
-                    row: 2,
-                    byte_range: 0..3,
-                },
-            ],
-            current: Some(1),
             ..SearchState::default()
         };
+        s.set_matches(vec![
+            MatchLoc {
+                row: 1,
+                byte_range: 0..3,
+            },
+            MatchLoc {
+                row: 1,
+                byte_range: 5..8,
+            },
+            MatchLoc {
+                row: 2,
+                byte_range: 0..3,
+            },
+        ]);
+        // `set_matches` resets `current` — assign it after so the test still
+        // exercises the `Some(idx)` branch of `ranges_on_row`.
+        s.current = Some(1);
         let (all, cur) = s.ranges_on_row(SearchTarget::FilePreview, 1);
         assert_eq!(all, vec![0..3, 5..8]);
         assert_eq!(cur, Some(5..8));
@@ -695,14 +780,14 @@ mod tests {
 
     #[test]
     fn ranges_on_row_target_mismatch_returns_empty() {
-        let s = SearchState {
+        let mut s = SearchState {
             target: Some(SearchTarget::FilePreview),
-            matches: vec![MatchLoc {
-                row: 0,
-                byte_range: 0..1,
-            }],
             ..SearchState::default()
         };
+        s.set_matches(vec![MatchLoc {
+            row: 0,
+            byte_range: 0..1,
+        }]);
         let (all, _) = s.ranges_on_row(SearchTarget::Diff, 0);
         assert!(all.is_empty());
     }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1696,27 +1696,436 @@ fn spawn_graph_worker(result_tx: mpsc::Sender<WorkerResult>) -> mpsc::Sender<Gra
     tx
 }
 
+/// Skip highlighting when a diff exceeds this many content lines. Mirrors
+/// the preview path's `lines.len() <= 5_000` cap (see `file_tree::load_preview`)
+/// but lets diffs go further because the typical diff has way fewer lines than
+/// the file it came from. Past this point syntect's per-line cost stops being
+/// negligible (50k+ lines of generated code can stall the worker for
+/// seconds — bad even off the render path).
+const HIGHLIGHT_DIFF_LINE_CAP: usize = 10_000;
+
+/// Skip highlighting when the diff's total content byte size exceeds this.
+/// Matches `file_tree::load_preview`'s `raw.len() <= 512 * 1024` byte gate,
+/// scaled up since diffs are usually a subset of the file. A 2 MB diff is
+/// already in "regenerated file" territory and not interesting to colorize.
+const HIGHLIGHT_DIFF_BYTE_CAP: usize = 2 * 1024 * 1024;
+
+/// Max entries in the shared highlight cache. Each entry is one
+/// `Arc<DiffHighlighted>` (deep structure of `Vec<Vec<Arc<...>>>`); 32
+/// covers the typical "flip between 5-10 files in a working tree"
+/// pattern without unbounded growth. Eviction is true LRU (oldest entry
+/// pops when full) so a 33rd insert doesn't nuke the warm working set.
+const HIGHLIGHT_CACHE_MAX: usize = 32;
+
+/// Cell state with named variants (vs. the original `Option<Option<Arc<…>>>`
+/// where the outer Option was "Pending vs Done" and the inner was
+/// "highlight succeeded vs no syntax"). The double-Option encoding was
+/// reader-hostile and brittle to refactors — a future flatten would
+/// silently break the `while pending` loop in `wait`.
+enum CellState {
+    Pending,
+    Done(Option<Arc<DiffHighlighted>>),
+}
+
+/// Filled-once cell that lets late callers wait on an in-flight syntect
+/// computation instead of starting their own. First miss installs the
+/// cell into the LRU; concurrent misses for the same key grab the same
+/// `Arc<InFlightCell>` and `wait` on the Condvar until the first caller
+/// stores the result and `notify_all`s.
+struct InFlightCell {
+    state: std::sync::Mutex<CellState>,
+    cv: std::sync::Condvar,
+}
+
+impl InFlightCell {
+    fn new() -> Self {
+        Self {
+            state: std::sync::Mutex::new(CellState::Pending),
+            cv: std::sync::Condvar::new(),
+        }
+    }
+
+    /// Publish the result and wake all waiters. Idempotent — late
+    /// `PublishGuard::drop` calls after the worker already published
+    /// are silent no-ops (the second `Done` write would just overwrite
+    /// itself with the same value).
+    fn publish(&self, result: Option<Arc<DiffHighlighted>>) {
+        let mut g = self.state.lock().unwrap_or_else(|p| {
+            self.state.clear_poison();
+            p.into_inner()
+        });
+        // Skip if already published — protects against the Drop guard
+        // running after the explicit publish (cell.publish(result) then
+        // PublishGuard::drop tries to publish(None)).
+        if matches!(*g, CellState::Done(_)) {
+            return;
+        }
+        *g = CellState::Done(result);
+        self.cv.notify_all();
+    }
+
+    /// Block until `publish` runs. Poison-tolerant.
+    ///
+    /// The `v.clone()` happens while still holding the state mutex —
+    /// `Arc::clone` on the `Option<Arc<DiffHighlighted>>` is a single
+    /// atomic refcount bump so there's no real win in trying to hoist
+    /// it out (and structurally we can't — the borrow is anchored to
+    /// the guard). The explicit `drop(g)` makes the lock-release point
+    /// obvious and ensures subsequent woken waiters serialize only on
+    /// the cheap clone, not on whatever the caller does with `value`.
+    fn wait(&self) -> Option<Arc<DiffHighlighted>> {
+        let mut g = self.state.lock().unwrap_or_else(|p| {
+            self.state.clear_poison();
+            p.into_inner()
+        });
+        while matches!(*g, CellState::Pending) {
+            g = self.cv.wait(g).unwrap_or_else(|p| {
+                self.state.clear_poison();
+                p.into_inner()
+            });
+        }
+        let value = match &*g {
+            CellState::Done(v) => v.clone(),
+            CellState::Pending => unreachable!("loop only exits on Done"),
+        };
+        drop(g);
+        value
+    }
+}
+
+/// RAII guard that ensures `publish` runs on every exit from the
+/// syntect-compute window, including panic unwind. Without this, a
+/// panic between `Slot::InFlight(cell)` insertion and the explicit
+/// `cell.publish(result)` would strand every future caller for the
+/// same cache key on the Condvar forever — the cell would stay
+/// `Pending` and `wait()` would block indefinitely.
+struct PublishGuard {
+    cell: Arc<InFlightCell>,
+    key: u64,
+    armed: bool,
+}
+
+impl PublishGuard {
+    fn new(cell: Arc<InFlightCell>, key: u64) -> Self {
+        Self {
+            cell,
+            key,
+            armed: true,
+        }
+    }
+
+    /// Disarm the guard — call this after the explicit `cell.publish(result)`
+    /// so the subsequent `Drop` is a cheap no-op (it still runs, but the
+    /// early-`return` on `!self.armed` skips the `publish`/`lock_cache`
+    /// work). Use `std::mem::forget(self)` if you want to skip `Drop`
+    /// entirely; we deliberately don't, because Drop's branch is one
+    /// load + jump and panicking through `defuse` would still need the
+    /// safety net.
+    fn defuse(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PublishGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // Panic path: publish None so waiters return cleanly (render falls
+        // back to plain colors). Then evict the InFlight slot from the
+        // cache so the next caller re-misses instead of re-waiting on a
+        // dead cell.
+        self.cell.publish(None);
+        let mut cache = lock_cache();
+        // Only drop the slot if it's still our cell — a concurrent
+        // worker may have already replaced it.
+        if let Some(Slot::InFlight(c)) = cache.map.get(&self.key) {
+            if Arc::ptr_eq(c, &self.cell) {
+                cache.remove(&self.key);
+            }
+        }
+    }
+}
+
+/// LRU slot. `Ready` is a finished entry (highlight result or `None` for
+/// "we decided not to highlight"); `InFlight` is a syntect job currently
+/// running on some worker — late callers grab the Arc and `wait()`.
+enum Slot {
+    Ready(Option<Arc<DiffHighlighted>>),
+    InFlight(Arc<InFlightCell>),
+}
+
+/// Tiny hand-rolled LRU. 32 entries → linear scan is faster than a
+/// proper linked-list LRU's allocator overhead, and avoids a 3rd-party
+/// dep. `order` lists keys oldest→newest; on access, we move the touched
+/// key to the back.
+struct HighlightLru {
+    map: std::collections::HashMap<u64, Slot>,
+    order: std::collections::VecDeque<u64>,
+}
+
+impl HighlightLru {
+    fn new() -> Self {
+        Self {
+            map: std::collections::HashMap::with_capacity(HIGHLIGHT_CACHE_MAX),
+            order: std::collections::VecDeque::with_capacity(HIGHLIGHT_CACHE_MAX),
+        }
+    }
+
+    /// Cheap structural-invariant guard. The map and order deque must
+    /// agree on which keys are live; both insert/touch/promote/remove
+    /// maintain this. Centralising the assert here surfaces any future
+    /// helper that drifts.
+    ///
+    /// The whole body is gated behind `cfg(debug_assertions)`:
+    ///   * release builds get a true no-op (no TLS read, no len calls),
+    ///   * debug builds run the panic-skip + `debug_assert_eq`. The
+    ///     skip is necessary because `PublishGuard::drop` calls into
+    ///     this method during unwind — a debug-only mismatch there
+    ///     would otherwise trigger Rust's panic-while-panicking abort.
+    #[cfg_attr(debug_assertions, inline)]
+    #[cfg_attr(not(debug_assertions), inline(always))]
+    fn assert_invariant(&self) {
+        #[cfg(debug_assertions)]
+        {
+            if std::thread::panicking() {
+                return;
+            }
+            debug_assert_eq!(
+                self.map.len(),
+                self.order.len(),
+                "HighlightLru: map.len() must equal order.len()"
+            );
+        }
+    }
+
+    /// Peek the slot for `key` *without* taking ownership. Updates LRU
+    /// access order on hit. The two Slot variants return different shapes
+    /// so the caller (`highlight_diff`) can branch:
+    ///   * `Ready(v)` → clone the inner Option<Arc> and return immediately
+    ///   * `InFlight(cell)` → Arc::clone the cell, drop the cache lock,
+    ///     wait on the cell
+    fn touch(&mut self, key: &u64) -> Option<SlotView> {
+        self.assert_invariant();
+        let slot = self.map.get(key)?;
+        let view = match slot {
+            Slot::Ready(v) => SlotView::Ready(v.clone()),
+            Slot::InFlight(c) => SlotView::InFlight(Arc::clone(c)),
+        };
+        if let Some(pos) = self.order.iter().position(|k| k == key) {
+            self.order.remove(pos);
+            self.order.push_back(*key);
+        }
+        Some(view)
+    }
+
+    fn insert(&mut self, key: u64, slot: Slot) {
+        self.assert_invariant();
+        if self.map.contains_key(&key) {
+            if let Some(pos) = self.order.iter().position(|k| k == &key) {
+                self.order.remove(pos);
+            }
+        } else if self.order.len() >= HIGHLIGHT_CACHE_MAX {
+            if let Some(oldest) = self.order.pop_front() {
+                self.map.remove(&oldest);
+            }
+        }
+        // Map insert first, order push second. Panic-safety analysis:
+        //   * New-key, non-full: neither pre-branch fires; on `map.insert`
+        //     rehash-panic both halves stay at old len → invariant holds.
+        //   * New-key, full: eviction popped front of order AND removed
+        //     from map (both decremented in lockstep above); on rehash
+        //     panic both stay at old-1 → invariant holds.
+        //   * Existing-key: `order.remove(pos)` ran above (order = old-1);
+        //     `map.insert` here is a *replace* which never rehashes,
+        //     so no panic window. If it did panic, order would be
+        //     old-1 vs map old → DESYNC. Currently unreachable because
+        //     all call sites guarantee key absence via `touch()`+None,
+        //     but a future caller adding `insert(existing_key, _)`
+        //     would re-open the bug — keep the eviction symmetry and
+        //     existing-key replace semantics in mind when extending.
+        self.map.insert(key, slot);
+        self.order.push_back(key);
+    }
+
+    /// Remove `key` from both halves of the LRU. Used by `PublishGuard`
+    /// to evict a dead InFlight slot on the panic-unwind path.
+    fn remove(&mut self, key: &u64) {
+        self.assert_invariant();
+        if self.map.remove(key).is_some() {
+            if let Some(pos) = self.order.iter().position(|k| k == key) {
+                self.order.remove(pos);
+            }
+        }
+    }
+
+    /// Promote an `InFlight(our_cell)` slot to `Ready(value)`, but ONLY
+    /// if the slot still holds `our_cell` — a concurrent worker may
+    /// have evicted us and installed its own InFlight, and overwriting
+    /// that slot would corrupt the second worker's cache view. Also
+    /// rotates the key to the back of the LRU order so a freshly-
+    /// computed result isn't immediately evictable just because the
+    /// InFlight slot sat near the front during the syntect window.
+    fn promote_if_owner(
+        &mut self,
+        key: u64,
+        our_cell: &Arc<InFlightCell>,
+        value: Option<Arc<DiffHighlighted>>,
+    ) {
+        self.assert_invariant();
+        match self.map.get(&key) {
+            Some(Slot::InFlight(c)) if Arc::ptr_eq(c, our_cell) => {
+                self.map.insert(key, Slot::Ready(value));
+                if let Some(pos) = self.order.iter().position(|k| k == &key) {
+                    self.order.remove(pos);
+                    self.order.push_back(key);
+                }
+            }
+            _ => {
+                // Either evicted (None) or replaced by a concurrent
+                // worker's InFlight (Slot::InFlight with a different
+                // cell pointer). Either way, don't touch the slot —
+                // the other worker's promote will handle it.
+            }
+        }
+    }
+
+    /// Clear the entire cache. Test/bench-only helper exposed via the
+    /// public reset hook so a unit test calling `highlight_diff` directly
+    /// can flush process-global state between tests.
+    fn clear(&mut self) {
+        self.map.clear();
+        self.order.clear();
+    }
+}
+
+enum SlotView {
+    Ready(Option<Arc<DiffHighlighted>>),
+    InFlight(Arc<InFlightCell>),
+}
+
+type HighlightCache = std::sync::Mutex<HighlightLru>;
+
+fn highlight_cache() -> &'static HighlightCache {
+    use std::sync::OnceLock;
+    static CACHE: OnceLock<HighlightCache> = OnceLock::new();
+    CACHE.get_or_init(|| std::sync::Mutex::new(HighlightLru::new()))
+}
+
+/// Poison-tolerant lock: if a previous holder panicked, recover the
+/// inner state (it's just a cache — discarding the panic-time write is
+/// fine) and clear the poison flag so subsequent callers see a clean
+/// Mutex. Without this, one panic anywhere in any worker silently
+/// deadlocks the cache for the rest of the process lifetime.
+fn lock_cache() -> std::sync::MutexGuard<'static, HighlightLru> {
+    let m = highlight_cache();
+    match m.lock() {
+        Ok(g) => g,
+        Err(poisoned) => {
+            m.clear_poison();
+            poisoned.into_inner()
+        }
+    }
+}
+
+/// Compute the per-diff cache key. Hashed inputs:
+///   - `dark` flag (1 byte) so theme toggle is its own lookup
+///   - path length prefix + path bytes (so `foo.rs`+`bar` and `foo`+`.rsbar`
+///     don't collide — without the length-prefix their byte streams match)
+///   - per-hunk: hunk_lens, header length + bytes (so two diffs with
+///     identical flat content but different hunk groupings produce
+///     different keys — without this the cached `Vec<Vec<...>>` shape
+///     can mismatch the requesting diff and silently mis-render)
+///   - per-line: length prefix + bytes
+fn highlight_cache_key(path: &str, diff: &DiffContent, dark: bool) -> u64 {
+    use std::hash::Hasher;
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    h.write_u8(u8::from(dark));
+    h.write_usize(path.len());
+    h.write(path.as_bytes());
+    h.write_usize(diff.hunks.len());
+    for hunk in &diff.hunks {
+        h.write_usize(hunk.header.len());
+        h.write(hunk.header.as_bytes());
+        h.write_usize(hunk.lines.len());
+        for line in &hunk.lines {
+            h.write_usize(line.content.len());
+            h.write(line.content.as_bytes());
+        }
+    }
+    h.finish()
+}
+
 /// Run syntect over the diff's content lines once per file and split the
 /// flat result into per-hunk slices so the renderer can index by
 /// `(hunk, line)`. Runs in worker threads — keeps the UI smooth on large
-/// diffs (a 10k-line diff takes ~50ms). Lines are fed through a single
-/// `HighlightLines` instance so state (e.g. open block comments) persists
-/// across hunks; this matches delta/bat's pragmatic approach of treating
-/// the hunk stream as a pseudo-file when the full file isn't available.
-/// Added/removed/context lines are mixed together — accepted imprecision
-/// for the 90% case. Returns `None` when no syntax resolves (unknown
-/// extension, binary, etc.), letting the renderer fall back to plain
-/// per-tag colors.
-fn highlight_diff(path: &str, diff: &DiffContent, dark: bool) -> Option<DiffHighlighted> {
-    let mut flat: Vec<String> = Vec::new();
+/// diffs (a 10k-line diff takes ~50ms).
+///
+/// Returns an `Arc<DiffHighlighted>` so cache hits and downstream sharing
+/// are O(1) refcount bumps instead of a deep clone of `Vec<Vec<Arc<...>>>`.
+/// `None` means we deliberately didn't highlight (no syntax resolves,
+/// or exceeds the size guards) — render falls back to plain per-tag colors.
+pub fn highlight_diff(path: &str, diff: &DiffContent, dark: bool) -> Option<Arc<DiffHighlighted>> {
+    let key = highlight_cache_key(path, diff, dark);
+
+    // First lookup: hit → return immediately; in-flight → wait on the cell;
+    // miss → install an `InFlight` cell and commit to running syntect ourselves.
+    let cell = {
+        let mut cache = lock_cache();
+        match cache.touch(&key) {
+            Some(SlotView::Ready(v)) => return v,
+            Some(SlotView::InFlight(c)) => {
+                drop(cache);
+                return c.wait();
+            }
+            None => {
+                // Size guards run on the FIRST caller's path only — concurrent
+                // callers with the same (path, diff, dark) key see Slot::InFlight
+                // and `wait()` on the cell, inheriting whatever decision this
+                // worker makes. That's safe today because the guards depend
+                // only on `diff` (which is part of the cache key, so equal-
+                // keyed callers see equal guards); if the guards ever grow a
+                // caller-dependent dimension (theme-conditional thresholds,
+                // viewport-dependent caps) this dedup needs to re-evaluate
+                // on each path.
+                let total_lines: usize = diff.hunks.iter().map(|h| h.lines.len()).sum();
+                if total_lines > HIGHLIGHT_DIFF_LINE_CAP {
+                    cache.insert(key, Slot::Ready(None));
+                    return None;
+                }
+                let total_bytes: usize = diff
+                    .hunks
+                    .iter()
+                    .flat_map(|h| h.lines.iter().map(|l| l.content.len()))
+                    .sum();
+                if total_bytes > HIGHLIGHT_DIFF_BYTE_CAP {
+                    cache.insert(key, Slot::Ready(None));
+                    return None;
+                }
+                // Claim — concurrent callers from here on `wait()` on this cell.
+                let cell = Arc::new(InFlightCell::new());
+                cache.insert(key, Slot::InFlight(Arc::clone(&cell)));
+                cell
+            }
+        }
+    };
+
+    // RAII guard: on panic between here and `defuse()` below, the Drop
+    // impl publishes `None` so any waiters return cleanly (no permanent
+    // deadlock) and evicts the dead InFlight slot from the LRU.
+    let guard = PublishGuard::new(Arc::clone(&cell), key);
+
+    // Hold no lock during syntect.
+    let total_lines: usize = diff.hunks.iter().map(|h| h.lines.len()).sum();
+    let mut flat: Vec<String> = Vec::with_capacity(total_lines);
     let mut hunk_lens: Vec<usize> = Vec::with_capacity(diff.hunks.len());
     for hunk in &diff.hunks {
         hunk_lens.push(hunk.lines.len());
         for line in &hunk.lines {
-            flat.push(line.content.clone());
+            flat.push(line.content.to_string());
         }
     }
-    highlight::highlight_file(path, &flat, dark).map(|flat_tokens| {
+    let result = highlight::highlight_file(path, &flat, dark).map(|flat_tokens| {
         // Wrap each line's tokens in `Arc` so downstream `tokens_for(li)`
         // clones are O(1). The iterator-based split hands each Arc to its
         // owning hunk without re-bumping refcounts.
@@ -1734,21 +2143,61 @@ fn highlight_diff(path: &str, diff: &DiffContent, dark: bool) -> Option<DiffHigh
             out.push(hunk);
         }
         out
-    })
+    });
+    let result = result.map(Arc::new);
+
+    // Publish to waiters first (releases anyone blocked on the cell).
+    cell.publish(result.clone());
+
+    // Promote the cache slot from `InFlight` to `Ready` — but only if we
+    // still own the slot. A concurrent worker may have evicted us and
+    // installed its own InFlight cell; overwriting that would orphan
+    // the other worker's waiters from the cache (they still get woken
+    // via their own cell's publish, but new callers would see Ready
+    // instead of InFlight and miss the deduplication). Also rotates
+    // the key to the back of the LRU order so a long syntect job's
+    // result isn't immediately evictable.
+    {
+        let mut cache = lock_cache();
+        cache.promote_if_owner(key, &cell, result.clone());
+    }
+
+    // Success path — disarm the guard so its Drop doesn't fire a
+    // redundant `publish(None)` (idempotent thanks to the early-return
+    // in `publish`, but still cheaper to skip the lock).
+    guard.defuse();
+
+    result
+}
+
+/// Drop every entry from the process-global highlight cache. Exposed
+/// for tests / benches that call `highlight_diff` directly — without
+/// this the cache state leaks across tests within the same binary,
+/// making "is this a hit or miss?" assertions non-deterministic.
+///
+/// **Caller responsibility**: only call when no worker thread is mid-
+/// `highlight_diff` for any key you care about. Clearing the LRU drops
+/// any live `Slot::InFlight(cell)` entries without notifying the cell;
+/// the worker's later `cell.publish` still wakes any waiters it had
+/// (they got the cell Arc before the clear), but new callers post-clear
+/// will miss and may run syntect again concurrently for the same key.
+/// Functionally correct (no deadlock, deterministic syntect output),
+/// but means the next two calls for that key duplicate the syntect run.
+///
+/// Marked `#[doc(hidden)]` since it's not part of the supported API.
+#[doc(hidden)]
+pub fn _reset_highlight_cache() {
+    lock_cache().clear();
 }
 
 fn build_commit_file_diff(path: String, diff: DiffContent, dark: bool) -> CommitFileDiff {
     let highlighted = highlight_diff(&path, &diff, dark);
-    CommitFileDiff {
-        path,
-        diff,
-        highlighted,
-    }
+    CommitFileDiff::new(path, diff, highlighted)
 }
 
 fn build_highlighted_diff(path: &str, diff: DiffContent, dark: bool) -> HighlightedDiff {
     let highlighted = highlight_diff(path, &diff, dark);
-    HighlightedDiff { diff, highlighted }
+    HighlightedDiff::new(diff, highlighted)
 }
 
 fn build_file_tree_payload(

--- a/src/ui/commit_detail_panel.rs
+++ b/src/ui/commit_detail_panel.rs
@@ -7,9 +7,8 @@ use crate::git::{DiffContent, FileEntry, FileStatus, LineTag};
 use crate::i18n::{Msg, t};
 use crate::search::SearchTarget;
 use crate::ui::git_graph_panel;
-use crate::ui::highlight::StyledToken;
 use crate::ui::mouse::ClickAction;
-use crate::ui::text::{clip_spans, overlay_match_highlight};
+use crate::ui::text::{clip_spans, empty_arc_str, overlay_match_highlight, spaces};
 use crate::ui::theme::Theme;
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -71,8 +70,8 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
                 .filter_map(|r| r.sbs.as_ref())
                 .fold((0usize, 0usize), |(l, r), p| {
                     (
-                        l.max(UnicodeWidthStr::width(p.left_text.as_str())),
-                        r.max(UnicodeWidthStr::width(p.right_text.as_str())),
+                        l.max(UnicodeWidthStr::width(p.left_text.as_ref())),
+                        r.max(UnicodeWidthStr::width(p.right_text.as_ref())),
                     )
                 });
         let max_left_h = max_left_tw.saturating_sub(left_body_w);
@@ -133,17 +132,17 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, _focused: bool) {
             .search
             .ranges_on_row(SearchTarget::CommitDetail, row_idx);
 
-        let base: Vec<(Style, String)> = row
+        let base: Vec<(Style, std::borrow::Cow<'_, str>)> = row
             .spans
             .iter()
-            .map(|s| (s.style, s.text.clone()))
+            .map(|s| (s.style, std::borrow::Cow::Borrowed(s.text.as_str())))
             .collect();
         let overlaid = if ranges.is_empty() {
             base
         } else {
             overlay_match_highlight(base, &ranges, cur, theme.search_match, theme.search_current)
         };
-        let final_tokens: Vec<(Style, String)> = overlaid
+        let final_tokens: Vec<(Style, std::borrow::Cow<'_, str>)> = overlaid
             .into_iter()
             .map(|(style, text)| {
                 (
@@ -268,12 +267,20 @@ fn render_sbs_row_live(
     // When syntax tokens exist, use them with the row's bg overlaid per-token
     // so added/removed shading still fills the half. Falls back to a single
     // plain-fg span otherwise. Arc-wrapped tokens deref transparently here.
-    let left_base_tokens: Vec<(Style, String)> = match &sbs.left_tokens {
+    let left_base_tokens: Vec<(Style, std::borrow::Cow<'_, str>)> = match &sbs.left_tokens {
         Some(toks) if !toks.is_empty() => toks
             .iter()
-            .map(|(s, t)| (style_with_bg(*s, left_bg), t.clone()))
+            .map(|(s, t)| {
+                (
+                    style_with_bg(*s, left_bg),
+                    std::borrow::Cow::Borrowed(t.as_str()),
+                )
+            })
             .collect(),
-        _ => vec![(l_body_base, sbs.left_text.clone())],
+        _ => vec![(
+            l_body_base,
+            std::borrow::Cow::Borrowed(sbs.left_text.as_ref()),
+        )],
     };
     let left_overlaid = if left_ranges.is_empty() {
         left_base_tokens
@@ -286,7 +293,7 @@ fn render_sbs_row_live(
             theme.search_current,
         )
     };
-    let left_hovered: Vec<(Style, String)> = left_overlaid
+    let left_hovered: Vec<(Style, std::borrow::Cow<'_, str>)> = left_overlaid
         .into_iter()
         .map(|(s, t)| (apply_hover(s), t))
         .collect();
@@ -298,12 +305,20 @@ fn render_sbs_row_live(
     let left_pad_w = left_body_w.saturating_sub(left_clipped_w);
 
     // Right body: mirror of left.
-    let right_base_tokens: Vec<(Style, String)> = match &sbs.right_tokens {
+    let right_base_tokens: Vec<(Style, std::borrow::Cow<'_, str>)> = match &sbs.right_tokens {
         Some(toks) if !toks.is_empty() => toks
             .iter()
-            .map(|(s, t)| (style_with_bg(*s, right_bg), t.clone()))
+            .map(|(s, t)| {
+                (
+                    style_with_bg(*s, right_bg),
+                    std::borrow::Cow::Borrowed(t.as_str()),
+                )
+            })
             .collect(),
-        _ => vec![(r_body_base, sbs.right_text.clone())],
+        _ => vec![(
+            r_body_base,
+            std::borrow::Cow::Borrowed(sbs.right_text.as_ref()),
+        )],
     };
     let right_overlaid = if right_ranges.is_empty() {
         right_base_tokens
@@ -316,7 +331,7 @@ fn render_sbs_row_live(
             theme.search_current,
         )
     };
-    let right_hovered: Vec<(Style, String)> = right_overlaid
+    let right_hovered: Vec<(Style, std::borrow::Cow<'_, str>)> = right_overlaid
         .into_iter()
         .map(|(s, t)| (apply_hover(s), t))
         .collect();
@@ -333,14 +348,14 @@ fn render_sbs_row_live(
         l_gutter_style,
     ));
     out.extend(left_clipped);
-    out.push(Span::styled(" ".repeat(left_pad_w), l_pad_style));
+    out.push(Span::styled(spaces(left_pad_w), l_pad_style));
     out.push(Span::styled("│".to_string(), sep_style));
     out.push(Span::styled(
         format!(" {} ", fmt_diff_lineno(sbs.right_no)),
         r_gutter_style,
     ));
     out.extend(right_clipped);
-    out.push(Span::styled(" ".repeat(right_pad_w), r_pad_style));
+    out.push(Span::styled(spaces(right_pad_w), r_pad_style));
 
     f.render_widget(Line::from(out), Rect::new(area.x, y, area.width, 1));
 }
@@ -476,11 +491,68 @@ pub fn scroll(app: &mut App, delta: i32) {
 
 // ─── Row model ────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Default)]
+/// Lazy/tagged span text. The original `String` field forced every
+/// `format!(…)` callsite to a single allocation but cost an extra heap
+/// copy on `Arc<str>` SBS body text; the intermediate `Arc<str>` field
+/// flipped that — SBS got zero-copy, but `format!()`-built gutter and
+/// header spans paid a redundant Arc reallocation per row per frame.
+/// This enum keeps every caller at exactly one allocation:
+///   * `&'static str` literals → no allocation, no refcount.
+///   * `format!()` / owned `String` → one alloc, moved into the variant.
+///   * `Arc<str>` from SBS body text → refcount bump only.
+#[derive(Debug, Clone)]
+enum SpanText {
+    Static(&'static str),
+    Owned(String),
+    Shared(std::sync::Arc<str>),
+}
+
+impl SpanText {
+    fn as_str(&self) -> &str {
+        match self {
+            SpanText::Static(s) => s,
+            SpanText::Owned(s) => s.as_str(),
+            SpanText::Shared(a) => a.as_ref(),
+        }
+    }
+    fn len(&self) -> usize {
+        self.as_str().len()
+    }
+}
+
+impl From<&'static str> for SpanText {
+    fn from(s: &'static str) -> Self {
+        SpanText::Static(s)
+    }
+}
+
+impl From<String> for SpanText {
+    fn from(s: String) -> Self {
+        SpanText::Owned(s)
+    }
+}
+
+impl From<std::sync::Arc<str>> for SpanText {
+    fn from(a: std::sync::Arc<str>) -> Self {
+        SpanText::Shared(a)
+    }
+}
+
+#[derive(Debug, Clone)]
 struct RowSpan {
-    text: String,
+    text: SpanText,
     style: Style,
     click: Option<(String, Value)>,
+}
+
+impl Default for RowSpan {
+    fn default() -> Self {
+        Self {
+            text: SpanText::Static(""),
+            style: Style::default(),
+            click: None,
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -504,7 +576,12 @@ struct Row {
 struct SbsParts {
     left_tag: LineTag,
     left_no: Option<u32>,
-    left_text: String,
+    /// Per-half text — `Arc<str>` shared with the underlying `DiffLine.content`
+    /// so the per-frame `pair_hunk_lines` rebuild costs one refcount bump per
+    /// line, not a `String::clone` heap copy. (Pre-fix, the 2-col commit-detail
+    /// path was still doing `line.content.to_string()` per line per frame even
+    /// though `DiffLine.content` is now `Arc<str>`.)
+    left_text: std::sync::Arc<str>,
     /// Syntect-colored tokens for `left_text` — populated when syntax
     /// highlighting is available for the file. Concatenating token texts
     /// must yield exactly `left_text` (search byte offsets rely on this).
@@ -513,19 +590,19 @@ struct SbsParts {
     left_tokens: Option<LineTokens>,
     right_tag: LineTag,
     right_no: Option<u32>,
-    right_text: String,
+    right_text: std::sync::Arc<str>,
     right_tokens: Option<LineTokens>,
 }
 
 impl RowSpan {
-    fn plain(text: impl Into<String>) -> Self {
+    fn plain(text: impl Into<SpanText>) -> Self {
         Self {
             text: text.into(),
             style: Style::default(),
             click: None,
         }
     }
-    fn styled(text: impl Into<String>, style: Style) -> Self {
+    fn styled(text: impl Into<SpanText>, style: Style) -> Self {
         Self {
             text: text.into(),
             style,
@@ -569,8 +646,16 @@ impl Row {
 }
 
 fn from_ratatui_span(span: Span<'static>) -> RowSpan {
+    // Match on the Cow variant directly so a Borrowed `&'static str` stays
+    // Static (zero allocation), and an Owned `String` moves into Owned
+    // (no rebox into an Arc<str> like the previous `into_owned()` +
+    // `Arc::from` chain).
+    let text = match span.content {
+        std::borrow::Cow::Borrowed(s) => SpanText::Static(s),
+        std::borrow::Cow::Owned(s) => SpanText::Owned(s),
+    };
     RowSpan {
-        text: span.content.into_owned(),
+        text,
         style: span.style,
         click: None,
     }
@@ -666,7 +751,7 @@ fn build_rows(app: &App, width: u16, display_w: u16, theme: &Theme) -> Vec<Row> 
         append_diff_rows(
             &mut rows,
             &file_diff.diff,
-            file_diff.highlighted.as_ref(),
+            file_diff.highlighted.as_deref(),
             cd.diff_layout,
             width,
             display_w,
@@ -1055,7 +1140,7 @@ fn append_unified_diff(
             // and contributed to right-edge misalignment.
             let line_content_w = DIFF_GUTTER_WIDTH
                 .saturating_add(2)
-                .saturating_add(UnicodeWidthStr::width(line.content.as_str()));
+                .saturating_add(UnicodeWidthStr::width(line.content.as_ref()));
 
             let mut spans: Vec<RowSpan> = Vec::with_capacity(2 + clipped.len() + 1);
             spans.push(RowSpan::styled(format!(" {}  {}  ", old_no, new_no), g));
@@ -1076,20 +1161,20 @@ fn append_unified_diff(
 /// Otherwise falls back to a single plain-fg token. Takes the line's tokens
 /// directly (not the nested `DiffHighlighted`) so callers can hoist the
 /// per-hunk lookup out of the inner loop.
-fn content_tokens_for_line(
-    content: &str,
-    line_tokens: Option<&LineTokens>,
+fn content_tokens_for_line<'a>(
+    content: &'a str,
+    line_tokens: Option<&'a LineTokens>,
     fallback_fg: Color,
     bg: Option<Color>,
-) -> Vec<StyledToken> {
+) -> Vec<(Style, std::borrow::Cow<'a, str>)> {
     match line_tokens {
         Some(toks) if !toks.is_empty() => toks
             .iter()
-            .map(|(s, t)| (apply_bg(*s, bg), t.clone()))
+            .map(|(s, t)| (apply_bg(*s, bg), std::borrow::Cow::Borrowed(t.as_str())))
             .collect(),
         _ => {
             let style = apply_bg(Style::default().fg(fallback_fg), bg);
-            vec![(style, content.to_string())]
+            vec![(style, std::borrow::Cow::Borrowed(content))]
         }
     }
 }
@@ -1139,18 +1224,22 @@ fn build_sbs_row(parts: SbsParts, theme: &Theme) -> Row {
     let right_gutter_style = style_with_bg(Style::default().fg(theme.fg_secondary), right_bg);
     let right_body_style = style_with_bg(Style::default().fg(right_fg), right_bg);
 
+    // SBS row content. The left/right body spans pass `Arc::clone(&parts.{l,r}_text)`
+    // straight into `RowSpan` — zero heap copy on the per-frame render path.
+    // The gutter / divider spans still allocate (formatted strings / "│") but
+    // those are O(1) per row, not O(text-length).
     let spans = vec![
         RowSpan::styled(
             format!(" {} ", fmt_diff_lineno(parts.left_no)),
             left_gutter_style,
         ),
-        RowSpan::styled(parts.left_text.clone(), left_body_style),
-        RowSpan::styled("│".to_string(), Style::default().fg(theme.fg_secondary)),
+        RowSpan::styled(std::sync::Arc::clone(&parts.left_text), left_body_style),
+        RowSpan::styled("│", Style::default().fg(theme.fg_secondary)),
         RowSpan::styled(
             format!(" {} ", fmt_diff_lineno(parts.right_no)),
             right_gutter_style,
         ),
-        RowSpan::styled(parts.right_text.clone(), right_body_style),
+        RowSpan::styled(std::sync::Arc::clone(&parts.right_text), right_body_style),
     ];
     Row::new(spans).with_sbs(parts)
 }
@@ -1174,17 +1263,19 @@ fn pair_hunk_lines(
     hunk: &crate::git::DiffHunk,
     hunk_tokens: Option<&Vec<LineTokens>>,
 ) -> Vec<SbsParts> {
+    use std::sync::Arc;
     let mut rows = Vec::new();
     // Pending removed entries carry their per-line tokens so the left half
     // keeps its syntax highlighting when paired with a later Added line.
-    let mut pending_removed: Vec<(Option<u32>, String, Option<LineTokens>)> = Vec::new();
+    let mut pending_removed: Vec<(Option<u32>, Arc<str>, Option<LineTokens>)> = Vec::new();
     let tokens_for =
         |li: usize| -> Option<LineTokens> { hunk_tokens.and_then(|t| t.get(li)).cloned() };
+    let empty = empty_arc_str();
 
     for (li, line) in hunk.lines.iter().enumerate() {
         match line.tag {
             LineTag::Removed => {
-                pending_removed.push((line.old_lineno, line.content.clone(), tokens_for(li)));
+                pending_removed.push((line.old_lineno, Arc::clone(&line.content), tokens_for(li)));
             }
             LineTag::Added => {
                 let added_tokens = tokens_for(li);
@@ -1198,18 +1289,18 @@ fn pair_hunk_lines(
                         left_tokens: old_tokens,
                         right_tag: LineTag::Added,
                         right_no: line.new_lineno,
-                        right_text: line.content.clone(),
+                        right_text: Arc::clone(&line.content),
                         right_tokens: added_tokens,
                     });
                 } else {
                     rows.push(SbsParts {
                         left_tag: LineTag::Context,
                         left_no: None,
-                        left_text: String::new(),
+                        left_text: Arc::clone(&empty),
                         left_tokens: None,
                         right_tag: LineTag::Added,
                         right_no: line.new_lineno,
-                        right_text: line.content.clone(),
+                        right_text: Arc::clone(&line.content),
                         right_tokens: added_tokens,
                     });
                 }
@@ -1223,7 +1314,7 @@ fn pair_hunk_lines(
                         left_tokens: old_tokens,
                         right_tag: LineTag::Context,
                         right_no: None,
-                        right_text: String::new(),
+                        right_text: Arc::clone(&empty),
                         right_tokens: None,
                     });
                 }
@@ -1231,11 +1322,11 @@ fn pair_hunk_lines(
                 rows.push(SbsParts {
                     left_tag: LineTag::Context,
                     left_no: line.old_lineno,
-                    left_text: line.content.clone(),
+                    left_text: Arc::clone(&line.content),
                     left_tokens: ctx_tokens.clone(),
                     right_tag: LineTag::Context,
                     right_no: line.new_lineno,
-                    right_text: line.content.clone(),
+                    right_text: Arc::clone(&line.content),
                     right_tokens: ctx_tokens,
                 });
             }
@@ -1250,7 +1341,7 @@ fn pair_hunk_lines(
             left_tokens: old_tokens,
             right_tag: LineTag::Context,
             right_no: None,
-            right_text: String::new(),
+            right_text: Arc::clone(&empty),
             right_tokens: None,
         });
     }
@@ -1318,11 +1409,16 @@ pub fn searchable_rows(app: &App) -> Vec<String> {
     let rows = build_rows(app, u16::MAX, u16::MAX, &app.theme);
     rows.into_iter()
         .map(|r| {
-            r.spans
-                .into_iter()
-                .map(|s| s.text)
-                .collect::<Vec<_>>()
-                .join("")
+            // `RowSpan.text` is `SpanText` (Static / Owned / Shared) —
+            // push each span's bytes into one owned String per row.
+            // Matches the old `Vec<String>.join("")` behavior without
+            // going through an intermediate `Vec<&str>` allocation.
+            let total: usize = r.spans.iter().map(|s| s.text.len()).sum();
+            let mut out = String::with_capacity(total);
+            for s in &r.spans {
+                out.push_str(s.text.as_str());
+            }
+            out
         })
         .collect()
 }
@@ -1386,17 +1482,17 @@ mod tests {
     fn pair_hunk_lines_threads_tokens_through_pairing() {
         use crate::git::{DiffHunk, DiffLine};
         let hunk = DiffHunk {
-            header: "@@ -1,1 +1,1 @@".to_string(),
+            header: "@@ -1,1 +1,1 @@".into(),
             lines: vec![
                 DiffLine {
                     tag: LineTag::Removed,
-                    content: "old".to_string(),
+                    content: "old".into(),
                     old_lineno: Some(1),
                     new_lineno: None,
                 },
                 DiffLine {
                     tag: LineTag::Added,
-                    content: "new".to_string(),
+                    content: "new".into(),
                     old_lineno: None,
                     new_lineno: Some(1),
                 },
@@ -1420,10 +1516,10 @@ mod tests {
     fn pair_hunk_lines_end_of_hunk_flush_preserves_tokens() {
         use crate::git::{DiffHunk, DiffLine};
         let hunk = DiffHunk {
-            header: "@@ -1,1 +1,0 @@".to_string(),
+            header: "@@ -1,1 +1,0 @@".into(),
             lines: vec![DiffLine {
                 tag: LineTag::Removed,
-                content: "gone".to_string(),
+                content: "gone".into(),
                 old_lineno: Some(1),
                 new_lineno: None,
             }],
@@ -1497,17 +1593,17 @@ mod tests {
         let parts = SbsParts {
             left_tag: LineTag::Context,
             left_no: Some(1),
-            left_text: "old".to_string(),
+            left_text: "old".into(),
             left_tokens: None,
             right_tag: LineTag::Context,
             right_no: Some(2),
-            right_text: "new".to_string(),
+            right_text: "new".into(),
             right_tokens: None,
         };
         let row = build_sbs_row(parts.clone(), &theme);
         let marker = row.sbs.as_ref().expect("SBS row must carry sbs marker");
-        assert_eq!(marker.left_text, "old");
-        assert_eq!(marker.right_text, "new");
+        assert_eq!(marker.left_text.as_ref(), "old");
+        assert_eq!(marker.right_text.as_ref(), "new");
     }
 
     /// SBS search highlight regression test: ranges in a flat row string
@@ -1570,29 +1666,29 @@ mod tests {
             SbsParts {
                 left_tag: LineTag::Context,
                 left_no: Some(1),
-                left_text: "x".repeat(100), // long left
+                left_text: "x".repeat(100).into(), // long left
                 left_tokens: None,
                 right_tag: LineTag::Context,
                 right_no: Some(1),
-                right_text: "y".repeat(50), // shorter right
+                right_text: "y".repeat(50).into(), // shorter right
                 right_tokens: None,
             },
             SbsParts {
                 left_tag: LineTag::Context,
                 left_no: Some(2),
-                left_text: "z".repeat(10), // short left
+                left_text: "z".repeat(10).into(), // short left
                 left_tokens: None,
                 right_tag: LineTag::Context,
                 right_no: Some(2),
-                right_text: "w".repeat(200), // very long right
+                right_text: "w".repeat(200).into(), // very long right
                 right_tokens: None,
             },
         ];
 
         let (max_left_tw, max_right_tw) = parts.iter().fold((0usize, 0usize), |(l, r), p| {
             (
-                l.max(UnicodeWidthStr::width(p.left_text.as_str())),
-                r.max(UnicodeWidthStr::width(p.right_text.as_str())),
+                l.max(UnicodeWidthStr::width(p.left_text.as_ref())),
+                r.max(UnicodeWidthStr::width(p.right_text.as_ref())),
             )
         });
         let max_left_h = max_left_tw.saturating_sub(left_body_w);

--- a/src/ui/db_preview.rs
+++ b/src/ui/db_preview.rs
@@ -1167,17 +1167,18 @@ fn render_data_pane(
     // blue for INT, etc.). Bold to keep the name as the primary
     // emphasis; the chip below uses the same hue but unbolded so the
     // hierarchy reads as "name (bold) / type (lighter)".
-    let mut name_tokens: Vec<(Style, String)> = Vec::with_capacity(columns.len() * 2);
+    let mut name_tokens: Vec<(Style, std::borrow::Cow<'_, str>)> =
+        Vec::with_capacity(columns.len() * 2);
     for (i, col) in columns.iter().enumerate() {
         if i > 0 {
-            name_tokens.push((sep_bg_default, COL_SEP.to_string()));
+            name_tokens.push((sep_bg_default, std::borrow::Cow::Borrowed(COL_SEP)));
         }
         let w = col_widths.get(i).copied().unwrap_or(0);
         let aff = affinity_of(&col.decl_type);
         let style = Style::default()
             .fg(affinity_header_color(aff, theme))
             .add_modifier(Modifier::BOLD);
-        name_tokens.push((style, pad_to_width(&col.name, w)));
+        name_tokens.push((style, std::borrow::Cow::Owned(pad_to_width(&col.name, w))));
     }
     let name_spans = clip_spans(&name_tokens, h_scroll, area.width as usize);
     f.render_widget(
@@ -1190,15 +1191,19 @@ fn render_data_pane(
     // annotation. Empty for Affinity::None columns (rendered as
     // spaces) since there's no useful tag to show.
     if area.height >= 2 {
-        let mut type_tokens: Vec<(Style, String)> = Vec::with_capacity(columns.len() * 2);
+        let mut type_tokens: Vec<(Style, std::borrow::Cow<'_, str>)> =
+            Vec::with_capacity(columns.len() * 2);
         for (i, col) in columns.iter().enumerate() {
             if i > 0 {
-                type_tokens.push((sep_bg_default, COL_SEP.to_string()));
+                type_tokens.push((sep_bg_default, std::borrow::Cow::Borrowed(COL_SEP)));
             }
             let w = col_widths.get(i).copied().unwrap_or(0);
             let aff = affinity_of(&col.decl_type);
             let style = Style::default().fg(affinity_color(aff, theme));
-            type_tokens.push((style, pad_to_width(affinity_short(aff), w)));
+            type_tokens.push((
+                style,
+                std::borrow::Cow::Owned(pad_to_width(affinity_short(aff), w)),
+            ));
         }
         let type_spans = clip_spans(&type_tokens, h_scroll, area.width as usize);
         f.render_widget(
@@ -1256,10 +1261,10 @@ fn render_data_pane(
             );
         }
 
-        let mut tokens: Vec<(Style, String)> = Vec::with_capacity(row.len() * 2);
+        let mut tokens: Vec<(Style, std::borrow::Cow<'_, str>)> = Vec::with_capacity(row.len() * 2);
         for (c_idx, value) in row.iter().enumerate() {
             if c_idx > 0 {
-                tokens.push((bg_style, COL_SEP.to_string()));
+                tokens.push((bg_style, std::borrow::Cow::Borrowed(COL_SEP)));
             }
             let w = col_widths.get(c_idx).copied().unwrap_or(0);
             let mut cell_style_v = cell_style(value, theme);
@@ -1273,7 +1278,7 @@ fn render_data_pane(
             } else {
                 pad_to_width(&value.to_string(), w)
             };
-            tokens.push((cell_style_v, padded));
+            tokens.push((cell_style_v, std::borrow::Cow::Owned(padded)));
         }
         let spans = clip_spans(&tokens, h_scroll, area.width as usize);
         f.render_widget(

--- a/src/ui/diff_panel.rs
+++ b/src/ui/diff_panel.rs
@@ -3,10 +3,10 @@ use crate::find_widget::{FindTarget, FindWidgetState};
 use crate::git::{DiffContent, DiffHunk, LineTag};
 use crate::i18n::{Msg, t};
 use crate::search::{SearchState, SearchTarget};
-use crate::ui::highlight::StyledToken;
 use crate::ui::selection::{DiffHit, DiffRowText, DiffSelection, DiffSide};
 use crate::ui::text::{
-    clip_spans, overlay_match_highlight, overlay_selection_highlight, truncate_to_width,
+    clip_spans, empty_arc_str, overlay_match_highlight, overlay_selection_highlight, spaces,
+    truncate_to_width,
 };
 use crate::ui::theme::Theme;
 use ratatui::Frame;
@@ -14,7 +14,9 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Padding};
+use std::borrow::Cow;
 use std::ops::Range;
+use std::sync::Arc;
 use unicode_width::UnicodeWidthStr;
 
 /// Scroll + viewport state held by whichever layer owns a diff panel
@@ -44,16 +46,40 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
     // both since at most one tab renders Diff at a time.
     app.last_diff_rect = Some(inner);
 
-    let Some(d) = app.diff_content.take() else {
+    // RAII guard around the `take()`+restore pattern: the diff is moved
+    // out for the duration of `render_diff` (to break the aliasing with
+    // `&mut app.diff_scroll` etc), and put back from `Drop` so a panic
+    // inside `render_diff` doesn't permanently strand the loaded diff.
+    // Pre-fix, an unwind skipped the restore and the panel rendered
+    // empty until the user re-triggered a load.
+    struct DiffSlotGuard<'a> {
+        slot: &'a mut Option<crate::app::HighlightedDiff>,
+        held: Option<crate::app::HighlightedDiff>,
+    }
+    impl<'a> Drop for DiffSlotGuard<'a> {
+        fn drop(&mut self) {
+            if let Some(d) = self.held.take() {
+                *self.slot = Some(d);
+            }
+        }
+    }
+
+    let Some(taken) = app.diff_content.take() else {
         render_empty(f, inner, &app.theme);
         return;
     };
+    let guard = DiffSlotGuard {
+        slot: &mut app.diff_content,
+        held: Some(taken),
+    };
+    let d = guard.held.as_ref().expect("just took it");
+
     let selection = app.diff_selection;
     render_diff(
         f,
         inner,
         &d.diff,
-        d.highlighted.as_ref(),
+        &d.display,
         app.diff_layout,
         app.diff_mode,
         app.theme,
@@ -71,7 +97,10 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
         },
         &mut app.last_diff_hit,
     );
-    app.diff_content = Some(d);
+    // Drop fires here on the happy path; on unwind it fires implicitly
+    // from the panic propagation — either way `app.diff_content` is
+    // restored. Explicit drop for clarity.
+    drop(guard);
 }
 
 /// Pure diff renderer — no `App` dependency. Callers own the scroll state
@@ -86,7 +115,7 @@ pub fn render_diff(
     f: &mut Frame,
     area: Rect,
     diff: &DiffContent,
-    highlighted: Option<&DiffHighlighted>,
+    display: &DiffDisplay,
     layout: DiffLayout,
     mode: DiffMode,
     theme: Theme,
@@ -103,7 +132,7 @@ pub fn render_diff(
             f,
             area,
             diff,
-            highlighted,
+            display,
             mode,
             theme,
             search,
@@ -118,7 +147,7 @@ pub fn render_diff(
             f,
             area,
             diff,
-            highlighted,
+            display,
             mode,
             theme,
             search,
@@ -184,7 +213,7 @@ fn render_unified(
     f: &mut Frame,
     area: Rect,
     diff: &DiffContent,
-    highlighted: Option<&DiffHighlighted>,
+    display: &DiffDisplay,
     mode: DiffMode,
     theme: Theme,
     search: &SearchState,
@@ -209,26 +238,9 @@ fn render_unified(
         max_y,
     );
 
-    // Build all display lines. Content rows pick up per-line syntect tokens
-    // when available so the render path can emit syntax-colored spans
-    // instead of a single plain-fg span.
-    let mut all_lines: Vec<UnifiedLine> = Vec::new();
-    for (hi, hunk) in diff.hunks.iter().enumerate() {
-        if hi > 0 {
-            all_lines.push(UnifiedLine::Separator);
-        }
-        all_lines.push(UnifiedLine::HunkHeader(hunk.header.clone()));
-        let hunk_tokens = highlighted.and_then(|h| h.get(hi));
-        for (li, line) in hunk.lines.iter().enumerate() {
-            all_lines.push(UnifiedLine::Content {
-                tag: line.tag,
-                old_lineno: line.old_lineno,
-                new_lineno: line.new_lineno,
-                text: line.content.clone(),
-                tokens: hunk_tokens.and_then(|t| t.get(li)).cloned(),
-            });
-        }
-    }
+    // Display rows + tokens are pre-built in the worker on diff load — no
+    // per-frame hunk walk. See `DiffDisplay::build`.
+    let all_lines: &[UnifiedLine] = &display.unified_lines;
 
     // ` XXXXX  XXXXX ` (14 cols line-number gutter) + `+ ` (2 cols prefix)
     // = 16 cols before body. Constants here match the span math in
@@ -254,7 +266,7 @@ fn render_unified(
         .skip(*view.scroll)
         .take(visible_rows)
         .filter_map(|dl| match dl {
-            UnifiedLine::Content { text, .. } => Some(UnicodeWidthStr::width(text.as_str())),
+            UnifiedLine::Content { text, .. } => Some(UnicodeWidthStr::width(text.as_ref())),
             _ => None,
         })
         .max()
@@ -264,17 +276,9 @@ fn render_unified(
     let h = *view.h_scroll;
     let content_y = y;
 
-    // Snapshot rows + geometry so the mouse-selection handler can translate
-    // a terminal `(col, row)` hit into `(side, row_idx, byte_offset)` without
-    // touching the diff data structure. Rebuilt every frame.
-    let diff_rows: Vec<DiffRowText> = all_lines
-        .iter()
-        .map(|dl| match dl {
-            UnifiedLine::Separator => DiffRowText::Separator,
-            UnifiedLine::HunkHeader(h) => DiffRowText::Header(h.clone()),
-            UnifiedLine::Content { text, .. } => DiffRowText::Unified(text.clone()),
-        })
-        .collect();
+    // Geometry snapshot for the mouse-selection handler. `rows` shares
+    // the same `Arc<Vec<DiffRowText>>` built in `DiffDisplay::build` —
+    // per-frame work here is one refcount bump, not a clone of the vec.
     *hit_slot = Some(DiffHit {
         layout: DiffLayout::Unified,
         content_y,
@@ -286,7 +290,7 @@ fn render_unified(
         h_scroll: h,
         sbs_left_h_scroll: 0,
         sbs_right_h_scroll: 0,
-        rows: diff_rows,
+        rows: Arc::clone(&display.unified_row_texts),
     });
 
     let scroll = *view.scroll;
@@ -308,10 +312,10 @@ fn render_unified(
         let sel_range = selection
             .filter(|s| s.side == DiffSide::Unified)
             .and_then(|s| {
-                let txt = match dl {
+                let txt: &str = match dl {
                     UnifiedLine::Separator => "",
-                    UnifiedLine::HunkHeader(h) => h.as_str(),
-                    UnifiedLine::Content { text, .. } => text.as_str(),
+                    UnifiedLine::HunkHeader(h) => h.as_ref(),
+                    UnifiedLine::Content { text, .. } => text.as_ref(),
                 };
                 s.sel.line_byte_range(row_idx, txt)
             });
@@ -348,7 +352,8 @@ fn render_unified_line(
                 .fg(theme.accent)
                 .add_modifier(Modifier::DIM);
             let prefix = Span::styled(" ", base_style);
-            let header_tokens = vec![(base_style, header.clone())];
+            let header_tokens: Vec<(Style, Cow<'_, str>)> =
+                vec![(base_style, Cow::Borrowed(header.as_ref()))];
             let tokens = if match_ranges.is_empty() {
                 header_tokens
             } else {
@@ -389,11 +394,12 @@ fn render_unified_line(
             // onto unshifted text. `clip_spans` then handles h_scroll without
             // caring that the token stream was split.
             let body_style = Style::default().fg(fg).bg(bg);
-            let base_tokens: Vec<StyledToken> = match syntax_tokens {
-                Some(toks) if !toks.is_empty() => {
-                    toks.iter().map(|(s, t)| (s.bg(bg), t.clone())).collect()
-                }
-                _ => vec![(body_style, text.clone())],
+            let base_tokens: Vec<(Style, Cow<'_, str>)> = match syntax_tokens {
+                Some(toks) if !toks.is_empty() => toks
+                    .iter()
+                    .map(|(s, t)| (s.bg(bg), Cow::Borrowed(t.as_str())))
+                    .collect(),
+                _ => vec![(body_style, Cow::Borrowed(text.as_ref()))],
             };
             let tokens = if match_ranges.is_empty() {
                 base_tokens
@@ -429,7 +435,7 @@ fn render_unified_line(
             ];
             spans.extend(body_spans);
             spans.push(Span::styled(
-                " ".repeat(pad.min(area.width as usize)),
+                spaces(pad.min(area.width as usize)),
                 Style::default().bg(bg),
             ));
             let line = Line::from(spans);
@@ -438,14 +444,15 @@ fn render_unified_line(
     }
 }
 
-enum UnifiedLine {
+#[derive(Debug)]
+pub enum UnifiedLine {
     Separator,
-    HunkHeader(String),
+    HunkHeader(Arc<str>),
     Content {
         tag: LineTag,
         old_lineno: Option<u32>,
         new_lineno: Option<u32>,
-        text: String,
+        text: Arc<str>,
         /// Syntect-colored tokens for this line (when a syntax resolved).
         /// Concatenating token texts yields `text`; render path overlays
         /// the row's bg on each token. `Arc` so per-hunk `tokens_for` pass
@@ -456,72 +463,129 @@ enum UnifiedLine {
 
 // ─── Side-by-side view ───────────────────────────────────────────────────────
 
-struct SbsRow {
-    left_tag: LineTag,
-    left_no: Option<u32>,
-    left_text: String,
+#[derive(Debug)]
+pub struct SbsRow {
+    pub left_tag: LineTag,
+    pub left_no: Option<u32>,
+    pub left_text: Arc<str>,
     /// Syntect tokens for `left_text` (when a syntax resolved); concatenating
     /// token texts yields `left_text`. `None` falls back to a single plain-fg
     /// span at render time. `Arc` so pairing / render clones are O(1).
-    left_tokens: Option<LineTokens>,
-    right_tag: LineTag,
-    right_no: Option<u32>,
-    right_text: String,
-    right_tokens: Option<LineTokens>,
+    pub left_tokens: Option<LineTokens>,
+    pub right_tag: LineTag,
+    pub right_no: Option<u32>,
+    pub right_text: Arc<str>,
+    pub right_tokens: Option<LineTokens>,
 }
 
-enum SbsDisplayLine {
+#[derive(Debug)]
+pub enum SbsDisplayLine {
     Separator,
-    HunkHeader(String),
+    HunkHeader(Arc<str>),
     Row(SbsRow),
 }
 
-/// Flatten an entire diff into the SBS row layout used by `render_side_by_side`.
-/// Row indices in the returned vec line up 1:1 with `diff_scroll` in SBS mode,
-/// so match positions found by `find_widget` can be jump-targeted by setting
-/// `diff_scroll` directly.
+/// Pre-built display rows + per-row text snapshots for both layouts of a
+/// single diff. Built once per diff load (in the worker), then read by
+/// every frame — render no longer walks the hunks itself, and the mouse
+/// hit-test snapshot reuses the same row_texts Arcs (no per-frame copy).
 ///
-/// Returns text-only `DiffRowText` entries (no tokens / line numbers); the
-/// find widget only needs the per-side string per row to run its matcher.
-pub(crate) fn build_sbs_row_texts(diff: &DiffContent) -> Vec<DiffRowText> {
-    let mut out: Vec<DiffRowText> = Vec::new();
-    for (hi, hunk) in diff.hunks.iter().enumerate() {
-        if hi > 0 {
-            out.push(DiffRowText::Separator);
-        }
-        for line in build_sbs_lines(hunk, None) {
-            match line {
-                SbsDisplayLine::Separator => out.push(DiffRowText::Separator),
-                SbsDisplayLine::HunkHeader(h) => out.push(DiffRowText::Header(h)),
-                SbsDisplayLine::Row(row) => out.push(DiffRowText::Sbs {
-                    left: row.left_text,
-                    right: row.right_text,
-                }),
+/// Both layouts are built up-front because layout is a render-time toggle
+/// (`u`) — rebuilding on toggle would re-introduce the cost we're paying
+/// here once at load time.
+#[derive(Debug)]
+pub struct DiffDisplay {
+    pub unified_lines: Vec<UnifiedLine>,
+    pub sbs_lines: Vec<SbsDisplayLine>,
+    pub unified_row_texts: Arc<Vec<DiffRowText>>,
+    pub sbs_row_texts: Arc<Vec<DiffRowText>>,
+}
+
+impl DiffDisplay {
+    /// Build both unified + SBS display vectors in a single pass over
+    /// `diff.hunks`. Each hunk pushes its Separator + HunkHeader into both
+    /// vecs once and the highlight lookup `highlighted.and_then(|h| h.get(hi))`
+    /// happens once per hunk instead of twice. Per-line tokens are still
+    /// Arc-cloned into the unified layout; SBS's pairing state machine
+    /// continues to live inside `build_sbs_lines` since its output isn't
+    /// directly derivable from the unified order.
+    pub fn build(diff: &DiffContent, highlighted: Option<&DiffHighlighted>) -> Self {
+        let mut unified_lines: Vec<UnifiedLine> = Vec::new();
+        let mut sbs_lines: Vec<SbsDisplayLine> = Vec::new();
+        for (hi, hunk) in diff.hunks.iter().enumerate() {
+            if hi > 0 {
+                unified_lines.push(UnifiedLine::Separator);
+                sbs_lines.push(SbsDisplayLine::Separator);
             }
+            unified_lines.push(UnifiedLine::HunkHeader(Arc::clone(&hunk.header)));
+            let hunk_tokens = highlighted.and_then(|h| h.get(hi));
+            for (li, line) in hunk.lines.iter().enumerate() {
+                unified_lines.push(UnifiedLine::Content {
+                    tag: line.tag,
+                    old_lineno: line.old_lineno,
+                    new_lineno: line.new_lineno,
+                    text: Arc::clone(&line.content),
+                    tokens: hunk_tokens.and_then(|t| t.get(li)).cloned(),
+                });
+            }
+            sbs_lines.extend(build_sbs_lines(hunk, hunk_tokens));
+        }
+        let unified_row_texts = Arc::new(unified_row_texts_from(&unified_lines));
+        let sbs_row_texts = Arc::new(sbs_row_texts_from(&sbs_lines));
+        DiffDisplay {
+            unified_lines,
+            sbs_lines,
+            unified_row_texts,
+            sbs_row_texts,
         }
     }
-    out
+}
+
+fn unified_row_texts_from(lines: &[UnifiedLine]) -> Vec<DiffRowText> {
+    lines
+        .iter()
+        .map(|dl| match dl {
+            UnifiedLine::Separator => DiffRowText::Separator,
+            UnifiedLine::HunkHeader(h) => DiffRowText::Header(Arc::clone(h)),
+            UnifiedLine::Content { text, .. } => DiffRowText::Unified(Arc::clone(text)),
+        })
+        .collect()
+}
+
+fn sbs_row_texts_from(lines: &[SbsDisplayLine]) -> Vec<DiffRowText> {
+    lines
+        .iter()
+        .map(|dl| match dl {
+            SbsDisplayLine::Separator => DiffRowText::Separator,
+            SbsDisplayLine::HunkHeader(h) => DiffRowText::Header(Arc::clone(h)),
+            SbsDisplayLine::Row(r) => DiffRowText::Sbs {
+                left: Arc::clone(&r.left_text),
+                right: Arc::clone(&r.right_text),
+            },
+        })
+        .collect()
 }
 
 fn build_sbs_lines(hunk: &DiffHunk, hunk_tokens: Option<&Vec<LineTokens>>) -> Vec<SbsDisplayLine> {
     let mut rows: Vec<SbsDisplayLine> = Vec::new();
     // Carry tokens alongside each pending removal so a later Added pairing
     // keeps the left half's syntax highlighting.
-    let mut pending_removed: Vec<(Option<u32>, String, Option<LineTokens>)> = Vec::new();
+    let mut pending_removed: Vec<(Option<u32>, Arc<str>, Option<LineTokens>)> = Vec::new();
     let tokens_for =
         |li: usize| -> Option<LineTokens> { hunk_tokens.and_then(|t| t.get(li)).cloned() };
+    let empty: Arc<str> = empty_arc_str();
 
-    rows.push(SbsDisplayLine::HunkHeader(hunk.header.clone()));
+    rows.push(SbsDisplayLine::HunkHeader(Arc::clone(&hunk.header)));
 
     for (li, line) in hunk.lines.iter().enumerate() {
         match line.tag {
             LineTag::Removed => {
-                pending_removed.push((line.old_lineno, line.content.clone(), tokens_for(li)));
+                pending_removed.push((line.old_lineno, Arc::clone(&line.content), tokens_for(li)));
             }
             LineTag::Added => {
                 let added_tokens = tokens_for(li);
-                if let Some((old_no, old_text, old_tokens)) = pending_removed.first().cloned() {
-                    pending_removed.remove(0);
+                if !pending_removed.is_empty() {
+                    let (old_no, old_text, old_tokens) = pending_removed.remove(0);
                     rows.push(SbsDisplayLine::Row(SbsRow {
                         left_tag: LineTag::Removed,
                         left_no: old_no,
@@ -529,7 +593,7 @@ fn build_sbs_lines(hunk: &DiffHunk, hunk_tokens: Option<&Vec<LineTokens>>) -> Ve
                         left_tokens: old_tokens,
                         right_tag: LineTag::Added,
                         right_no: line.new_lineno,
-                        right_text: line.content.clone(),
+                        right_text: Arc::clone(&line.content),
                         right_tokens: added_tokens,
                     }));
                 } else {
@@ -537,11 +601,11 @@ fn build_sbs_lines(hunk: &DiffHunk, hunk_tokens: Option<&Vec<LineTokens>>) -> Ve
                     rows.push(SbsDisplayLine::Row(SbsRow {
                         left_tag: LineTag::Context,
                         left_no: None,
-                        left_text: String::new(),
+                        left_text: Arc::clone(&empty),
                         left_tokens: None,
                         right_tag: LineTag::Added,
                         right_no: line.new_lineno,
-                        right_text: line.content.clone(),
+                        right_text: Arc::clone(&line.content),
                         right_tokens: added_tokens,
                     }));
                 }
@@ -556,7 +620,7 @@ fn build_sbs_lines(hunk: &DiffHunk, hunk_tokens: Option<&Vec<LineTokens>>) -> Ve
                         left_tokens: old_tokens,
                         right_tag: LineTag::Context,
                         right_no: None,
-                        right_text: String::new(),
+                        right_text: Arc::clone(&empty),
                         right_tokens: None,
                     }));
                 }
@@ -565,11 +629,11 @@ fn build_sbs_lines(hunk: &DiffHunk, hunk_tokens: Option<&Vec<LineTokens>>) -> Ve
                 rows.push(SbsDisplayLine::Row(SbsRow {
                     left_tag: LineTag::Context,
                     left_no: line.old_lineno,
-                    left_text: line.content.clone(),
+                    left_text: Arc::clone(&line.content),
                     left_tokens: ctx_tokens.clone(),
                     right_tag: LineTag::Context,
                     right_no: line.new_lineno,
-                    right_text: line.content.clone(),
+                    right_text: Arc::clone(&line.content),
                     right_tokens: ctx_tokens,
                 }));
             }
@@ -585,7 +649,7 @@ fn build_sbs_lines(hunk: &DiffHunk, hunk_tokens: Option<&Vec<LineTokens>>) -> Ve
             left_tokens: old_tokens,
             right_tag: LineTag::Context,
             right_no: None,
-            right_text: String::new(),
+            right_text: Arc::clone(&empty),
             right_tokens: None,
         }));
     }
@@ -598,7 +662,7 @@ fn render_side_by_side(
     f: &mut Frame,
     area: Rect,
     diff: &DiffContent,
-    highlighted: Option<&DiffHighlighted>,
+    display: &DiffDisplay,
     mode: DiffMode,
     theme: Theme,
     search: &SearchState,
@@ -633,15 +697,8 @@ fn render_side_by_side(
     let _ = search;
     let (widget_left_target, widget_right_target) = sbs_side_targets(widget_unified_target);
 
-    // Build all display lines
-    let mut all_lines: Vec<SbsDisplayLine> = Vec::new();
-    for (hi, hunk) in diff.hunks.iter().enumerate() {
-        if hi > 0 {
-            all_lines.push(SbsDisplayLine::Separator);
-        }
-        let hunk_tokens = highlighted.and_then(|h| h.get(hi));
-        all_lines.extend(build_sbs_lines(hunk, hunk_tokens));
-    }
+    // Display rows + tokens pre-built in the worker — see `DiffDisplay::build`.
+    let all_lines: &[SbsDisplayLine] = &display.sbs_lines;
 
     // Half width: leave 1 col for center divider
     let half_w = (area.width.saturating_sub(1)) / 2;
@@ -670,8 +727,8 @@ fn render_side_by_side(
         .take(visible_rows)
         .fold((0, 0), |(ml, mr), dl| match dl {
             SbsDisplayLine::Row(row) => (
-                ml.max(UnicodeWidthStr::width(row.left_text.as_str())),
-                mr.max(UnicodeWidthStr::width(row.right_text.as_str())),
+                ml.max(UnicodeWidthStr::width(row.left_text.as_ref())),
+                mr.max(UnicodeWidthStr::width(row.right_text.as_ref())),
             ),
             _ => (ml, mr),
         });
@@ -683,21 +740,10 @@ fn render_side_by_side(
     let h_right = *view.sbs_right_h_scroll;
     let content_y = y;
 
-    // Snapshot rows + geometry for the selection handler. Each SBS row
-    // carries both halves so `DiffRowText::text_for(side)` can pick the
-    // right one at copy time. Separator + HunkHeader rows don't have a
-    // per-side split — the mouse handler treats them as neutral.
-    let diff_rows: Vec<DiffRowText> = all_lines
-        .iter()
-        .map(|dl| match dl {
-            SbsDisplayLine::Separator => DiffRowText::Separator,
-            SbsDisplayLine::HunkHeader(h) => DiffRowText::Header(h.clone()),
-            SbsDisplayLine::Row(r) => DiffRowText::Sbs {
-                left: r.left_text.clone(),
-                right: r.right_text.clone(),
-            },
-        })
-        .collect();
+    // Geometry snapshot for the selection handler. `rows` shares the
+    // worker-built `Arc<Vec<DiffRowText>>` — each row already carries both
+    // halves so `DiffRowText::text_for(side)` can pick the right one at
+    // copy time.
     let gutter = 7u16;
     *hit_slot = Some(DiffHit {
         layout: DiffLayout::SideBySide,
@@ -713,7 +759,7 @@ fn render_side_by_side(
         h_scroll: 0,
         sbs_left_h_scroll: h_left,
         sbs_right_h_scroll: h_right,
-        rows: diff_rows,
+        rows: Arc::clone(&display.sbs_row_texts),
     });
 
     let scroll = *view.scroll;
@@ -728,7 +774,7 @@ fn render_side_by_side(
             Some(s) => match s.side {
                 DiffSide::SbsLeft => {
                     if let SbsDisplayLine::Row(row) = dl {
-                        (s.sel.line_byte_range(row_idx, row.left_text.as_str()), None)
+                        (s.sel.line_byte_range(row_idx, row.left_text.as_ref()), None)
                     } else {
                         (None, None)
                     }
@@ -737,7 +783,7 @@ fn render_side_by_side(
                     if let SbsDisplayLine::Row(row) = dl {
                         (
                             None,
-                            s.sel.line_byte_range(row_idx, row.right_text.as_str()),
+                            s.sel.line_byte_range(row_idx, row.right_text.as_ref()),
                         )
                     } else {
                         (None, None)
@@ -755,14 +801,14 @@ fn render_side_by_side(
             find_widget.ranges_on_row(widget_right_target, row_idx);
         match dl {
             SbsDisplayLine::Separator => {
-                let line = Line::from(Span::styled(
-                    format!(
-                        " {:>5}  ⋯{}",
-                        "",
-                        " ".repeat(area.width.saturating_sub(10) as usize)
+                let pad = area.width.saturating_sub(10) as usize;
+                let line = Line::from(vec![
+                    Span::styled(
+                        format!(" {:>5}  ⋯", ""),
+                        Style::default().fg(theme.fg_secondary),
                     ),
-                    Style::default().fg(theme.fg_secondary),
-                ));
+                    Span::styled(spaces(pad), Style::default().fg(theme.fg_secondary)),
+                ]);
                 f.render_widget(line, Rect::new(area.x, y, area.width, 1));
             }
             SbsDisplayLine::HunkHeader(header) => {
@@ -779,11 +825,13 @@ fn render_side_by_side(
                 let base = Style::default()
                     .fg(theme.accent)
                     .add_modifier(Modifier::DIM);
+                let header_tokens: Vec<(Style, Cow<'_, str>)> =
+                    vec![(base, Cow::Borrowed(header.as_ref()))];
                 let tokens = if combined.is_empty() {
-                    vec![(base, header.clone())]
+                    header_tokens
                 } else {
                     overlay_match_highlight(
-                        vec![(base, header.clone())],
+                        header_tokens,
                         &combined,
                         combined_cur,
                         theme.search_match,
@@ -886,10 +934,7 @@ fn render_sbs_row(
         Style::default().fg(theme.fg_secondary).bg(left_bg),
     )];
     left_line_spans.extend(left_spans);
-    left_line_spans.push(Span::styled(
-        " ".repeat(left_pad),
-        Style::default().bg(left_bg),
-    ));
+    left_line_spans.push(Span::styled(spaces(left_pad), Style::default().bg(left_bg)));
     f.render_widget(Line::from(left_line_spans), Rect::new(area.x, y, half_w, 1));
 
     // ── Divider ──
@@ -935,7 +980,7 @@ fn render_sbs_row(
     )];
     right_line_spans.extend(right_spans);
     right_line_spans.push(Span::styled(
-        " ".repeat(right_pad),
+        spaces(right_pad),
         Style::default().bg(right_bg),
     ));
     f.render_widget(
@@ -945,17 +990,22 @@ fn render_sbs_row(
 }
 
 /// Pick the token stream for one SBS body: syntect tokens (bg overlaid per-token)
-/// when available, else a single plain-fg span with bg. `Arc` lets the caller
-/// pass a per-line handle it got cheaply from the hunk token table.
-fn build_sbs_body_tokens(
-    text: &str,
-    tokens: Option<&LineTokens>,
+/// when available, else a single plain-fg span with bg. Tokens are borrowed
+/// (`Cow::Borrowed`) so the overlay → clip pipeline doesn't allocate when
+/// the row has no search match. Lifetime `'a` ties the output to whichever
+/// of `text` / `tokens` it ends up referencing.
+fn build_sbs_body_tokens<'a>(
+    text: &'a str,
+    tokens: Option<&'a LineTokens>,
     fg: Color,
     bg: Color,
-) -> Vec<StyledToken> {
+) -> Vec<(Style, Cow<'a, str>)> {
     match tokens {
-        Some(toks) if !toks.is_empty() => toks.iter().map(|(s, t)| (s.bg(bg), t.clone())).collect(),
-        _ => vec![(Style::default().fg(fg).bg(bg), text.to_string())],
+        Some(toks) if !toks.is_empty() => toks
+            .iter()
+            .map(|(s, t)| (s.bg(bg), Cow::Borrowed(t.as_str())))
+            .collect(),
+        _ => vec![(Style::default().fg(fg).bg(bg), Cow::Borrowed(text))],
     }
 }
 
@@ -1041,7 +1091,7 @@ mod tests {
     ) -> DiffLine {
         DiffLine {
             tag,
-            content: content.to_string(),
+            content: Arc::from(content),
             old_lineno: old_no,
             new_lineno: new_no,
         }
@@ -1049,7 +1099,7 @@ mod tests {
 
     fn make_hunk(header: &str, lines: Vec<DiffLine>) -> DiffHunk {
         DiffHunk {
-            header: header.to_string(),
+            header: Arc::from(header),
             lines,
         }
     }
@@ -1135,8 +1185,8 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].left_tag, LineTag::Context);
         assert_eq!(rows[0].right_tag, LineTag::Context);
-        assert_eq!(rows[0].left_text, "same");
-        assert_eq!(rows[0].right_text, "same");
+        assert_eq!(rows[0].left_text.as_ref(), "same");
+        assert_eq!(rows[0].right_text.as_ref(), "same");
     }
 
     #[test]
@@ -1151,7 +1201,7 @@ mod tests {
         assert_eq!(rows[0].left_tag, LineTag::Context);
         assert!(rows[0].left_text.is_empty());
         assert_eq!(rows[0].right_tag, LineTag::Added);
-        assert_eq!(rows[0].right_text, "new line");
+        assert_eq!(rows[0].right_text.as_ref(), "new line");
     }
 
     #[test]
@@ -1164,7 +1214,7 @@ mod tests {
         let rows = get_rows(&lines);
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].left_tag, LineTag::Removed);
-        assert_eq!(rows[0].left_text, "old line");
+        assert_eq!(rows[0].left_text.as_ref(), "old line");
         assert_eq!(rows[0].right_tag, LineTag::Context);
         assert!(rows[0].right_text.is_empty());
     }
@@ -1181,8 +1231,8 @@ mod tests {
         let lines = build_sbs_lines(&hunk, None);
         let rows = get_rows(&lines);
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].left_text, "old");
-        assert_eq!(rows[0].right_text, "new");
+        assert_eq!(rows[0].left_text.as_ref(), "old");
+        assert_eq!(rows[0].right_text.as_ref(), "new");
     }
 
     #[test]

--- a/src/ui/file_preview_panel.rs
+++ b/src/ui/file_preview_panel.rs
@@ -58,7 +58,15 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, focused: bool) {
         Some(preview) => preview,
     };
 
-    match &preview.body {
+    // `render_text` / `render_image` take `&mut App` (image protocol lives
+    // on App), which rules out the RAII-slot-guard pattern used in
+    // `diff_panel::render` — that pattern needs concurrent disjoint
+    // `&mut app.preview_content` and `&mut App`, which Rust forbids when
+    // the render fn re-borrows the whole `app`. Use `catch_unwind` instead
+    // so a panic inside the body renderers still restores
+    // `app.preview_content`, then re-raises. Pre-fix, the unwind skipped
+    // the restore and the panel render-emptied until re-selection.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| match &preview.body {
         PreviewBody::Text { .. } => render_text(f, app, inner, &preview, focused),
         PreviewBody::Image(img) => render_image(f, app, inner, &preview.file_path, img, focused),
         PreviewBody::Binary(info) => {
@@ -67,9 +75,13 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect, focused: bool) {
         PreviewBody::Database(info) => {
             crate::ui::db_preview::render(f, app, inner, &preview.file_path, info, focused)
         }
-    }
+    }));
 
     app.preview_content = Some(preview);
+
+    if let Err(payload) = result {
+        std::panic::resume_unwind(payload);
+    }
 }
 
 /// Transitional card shown while a preview request is in flight against a
@@ -391,10 +403,20 @@ fn render_text(f: &mut Frame, app: &mut App, area: Rect, preview: &PreviewConten
         // fallback: build a token vec, overlay any search matches for this row,
         // then clip horizontally. Keeps horizontal-scroll and search highlight
         // independent of whether syntax tokens were produced.
-        let base_tokens: Vec<(Style, String)> =
+        //
+        // Borrowed (`Cow::Borrowed`) all the way through so the per-row hot
+        // path doesn't allocate when there's no match — the previous code
+        // cloned every syntect token's String every frame.
+        let base_tokens: Vec<(Style, std::borrow::Cow<'_, str>)> =
             match highlighted.as_ref().and_then(|hh| hh.get(real_idx)) {
-                Some(tokens) => tokens.clone(),
-                None => vec![(Style::default().fg(th.fg_primary), line.clone())],
+                Some(tokens) => tokens
+                    .iter()
+                    .map(|(s, t)| (*s, std::borrow::Cow::Borrowed(t.as_str())))
+                    .collect(),
+                None => vec![(
+                    Style::default().fg(th.fg_primary),
+                    std::borrow::Cow::Borrowed(line.as_str()),
+                )],
             };
         // Find widget owns highlights when it targets the preview; the
         // legacy `/` search is mutually exclusive (either side clears

--- a/src/ui/file_tree_panel.rs
+++ b/src/ui/file_tree_panel.rs
@@ -400,7 +400,10 @@ fn render_entry_row(
     if ranges.is_empty() {
         spans.push(Span::styled(entry.name.clone(), name_base_style));
     } else {
-        let name_tokens = vec![(name_base_style, entry.name.clone())];
+        let name_tokens: Vec<(Style, std::borrow::Cow<'_, str>)> = vec![(
+            name_base_style,
+            std::borrow::Cow::Borrowed(entry.name.as_str()),
+        )];
         let overlaid = overlay_match_highlight(
             name_tokens,
             &ranges,

--- a/src/ui/find_widget_panel.rs
+++ b/src/ui/find_widget_panel.rs
@@ -362,20 +362,18 @@ mod tests {
 
     #[test]
     fn counter_with_matches() {
-        let s = FindWidgetState {
-            matches: vec![
-                crate::search::MatchLoc {
-                    row: 0,
-                    byte_range: 0..1,
-                },
-                crate::search::MatchLoc {
-                    row: 0,
-                    byte_range: 2..3,
-                },
-            ],
-            current: Some(0),
-            ..FindWidgetState::default()
-        };
+        let mut s = FindWidgetState::default();
+        s.set_matches(vec![
+            crate::search::MatchLoc {
+                row: 0,
+                byte_range: 0..1,
+            },
+            crate::search::MatchLoc {
+                row: 0,
+                byte_range: 2..3,
+            },
+        ]);
+        s.current = Some(0);
         assert_eq!(format_counter(&s), "1/2");
     }
 

--- a/src/ui/git_graph_panel.rs
+++ b/src/ui/git_graph_panel.rs
@@ -300,7 +300,8 @@ fn build_row_line(
     if search_ranges.is_empty() {
         spans.push(Span::styled(subject, subject_style));
     } else {
-        let sub_tokens = vec![(subject_style, subject)];
+        let sub_tokens: Vec<(Style, std::borrow::Cow<'_, str>)> =
+            vec![(subject_style, std::borrow::Cow::Owned(subject))];
         let overlaid = overlay_match_highlight(
             sub_tokens,
             search_ranges,

--- a/src/ui/git_status_panel.rs
+++ b/src/ui/git_status_panel.rs
@@ -1427,7 +1427,8 @@ fn build_spans_with_path_overlay(
     for (i, s) in row.spans.iter().enumerate() {
         if i == 1 {
             // Filename span — overlay here.
-            let tokens = vec![(s.style, s.text.clone())];
+            let tokens: Vec<(Style, std::borrow::Cow<'static, str>)> =
+                vec![(s.style, std::borrow::Cow::Owned(s.text.clone()))];
             let overlaid =
                 overlay_match_highlight(tokens, ranges, current.clone(), match_bg, current_bg);
             for (style, text) in overlaid {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -351,7 +351,23 @@ fn render_graph_diff_column(f: &mut Frame, app: &mut App, area: Rect) {
     // one of them renders Diff at a time.
     app.last_diff_rect = Some(inner);
 
-    let Some(d) = app.commit_detail.file_diff.take() else {
+    // RAII guard around take/restore — mirrors `diff_panel::render`'s
+    // pattern so a panic inside `render_diff` doesn't strand the loaded
+    // commit-file diff in `None` (would render the loading banner
+    // forever even after the load is long since complete).
+    struct FileDiffGuard<'a> {
+        slot: &'a mut Option<crate::app::CommitFileDiff>,
+        held: Option<crate::app::CommitFileDiff>,
+    }
+    impl<'a> Drop for FileDiffGuard<'a> {
+        fn drop(&mut self) {
+            if let Some(d) = self.held.take() {
+                *self.slot = Some(d);
+            }
+        }
+    }
+
+    let Some(taken) = app.commit_detail.file_diff.take() else {
         // In 3-col mode this only fires when `commit_file_diff_load.loading`
         // is still true. Show a quiet "loading…" banner so the column is
         // never blank between the click and the async result landing.
@@ -365,12 +381,17 @@ fn render_graph_diff_column(f: &mut Frame, app: &mut App, area: Rect) {
         }
         return;
     };
+    let guard = FileDiffGuard {
+        slot: &mut app.commit_detail.file_diff,
+        held: Some(taken),
+    };
+    let d = guard.held.as_ref().expect("just took it");
     let selection = app.diff_selection;
     diff_panel::render_diff(
         f,
         inner,
         &d.diff,
-        d.highlighted.as_ref(),
+        &d.display,
         app.commit_detail.diff_layout,
         app.commit_detail.diff_mode,
         app.theme,
@@ -388,7 +409,7 @@ fn render_graph_diff_column(f: &mut Frame, app: &mut App, area: Rect) {
         },
         &mut app.last_diff_hit,
     );
-    app.commit_detail.file_diff = Some(d);
+    drop(guard);
 }
 
 fn render_tab_bar(f: &mut Frame, app: &mut App, area: Rect) {

--- a/src/ui/selection.rs
+++ b/src/ui/selection.rs
@@ -181,26 +181,31 @@ pub enum DiffRowText {
     /// copied text so drag-selections span seamlessly across it.
     Separator,
     /// `@@ -1,5 +2,7 @@` hunk header. Copy includes the full header text.
-    Header(String),
+    Header(std::sync::Arc<str>),
     /// Unified content row — left/right don't apply.
-    Unified(String),
+    Unified(std::sync::Arc<str>),
     /// SBS paired content row. Each half is its own selectable string,
-    /// picked by the selection's `side`.
-    Sbs { left: String, right: String },
+    /// picked by the selection's `side`. Arcs are shared with the
+    /// underlying `DiffLine.content` / `DiffHunk.header` so building this
+    /// snapshot from a diff is O(N) refcount bumps, not O(N×len) copies.
+    Sbs {
+        left: std::sync::Arc<str>,
+        right: std::sync::Arc<str>,
+    },
 }
 
 impl DiffRowText {
     pub fn text_for(&self, side: DiffSide) -> &str {
         match self {
             DiffRowText::Separator => "",
-            DiffRowText::Header(h) => h.as_str(),
-            DiffRowText::Unified(s) => s.as_str(),
+            DiffRowText::Header(h) => h.as_ref(),
+            DiffRowText::Unified(s) => s.as_ref(),
             DiffRowText::Sbs { left, right } => match side {
-                DiffSide::SbsLeft => left.as_str(),
+                DiffSide::SbsLeft => left.as_ref(),
                 // SBS content row requested through the unified side (rare —
                 // would mean a stale selection from a layout change): fall
                 // through to right like a context row.
-                DiffSide::SbsRight | DiffSide::Unified => right.as_str(),
+                DiffSide::SbsRight | DiffSide::Unified => right.as_ref(),
             },
         }
     }
@@ -237,7 +242,10 @@ pub struct DiffHit {
 
     /// Flattened display rows in the same order `render_*` produces them.
     /// Index into this vec is what `PreviewSelection.anchor.0` points at.
-    pub rows: Vec<DiffRowText>,
+    /// Wrapped in `Arc` so the per-frame `*hit_slot = Some(DiffHit { rows, .. })`
+    /// just bumps a refcount instead of cloning the whole vec — the rows
+    /// themselves are pre-built in `DiffDisplay` at load time.
+    pub rows: std::sync::Arc<Vec<DiffRowText>>,
 }
 
 impl DiffHit {
@@ -582,7 +590,7 @@ mod tests {
             h_scroll: 0,
             sbs_left_h_scroll: 0,
             sbs_right_h_scroll: 0,
-            rows,
+            rows: std::sync::Arc::new(rows),
         }
     }
 
@@ -599,7 +607,7 @@ mod tests {
             h_scroll: 0,
             sbs_left_h_scroll: 0,
             sbs_right_h_scroll: 0,
-            rows,
+            rows: std::sync::Arc::new(rows),
         }
     }
 

--- a/src/ui/text.rs
+++ b/src/ui/text.rs
@@ -1,7 +1,37 @@
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
+use std::borrow::Cow;
 use std::ops::Range;
+use std::sync::{Arc, LazyLock};
 use unicode_width::UnicodeWidthChar;
+
+/// Shared empty `Arc<str>` — handed out by `empty_arc_str()` so the
+/// many "no content for this half" SBS pairings, etc., don't each
+/// allocate a fresh empty Arc. `Arc::clone(&EMPTY)` is a refcount bump;
+/// `Arc::from("")` was a full allocation per call.
+static EMPTY_ARC_STR: LazyLock<Arc<str>> = LazyLock::new(|| Arc::from(""));
+
+/// Cheap shared `Arc<str>` for the empty-string case.
+pub fn empty_arc_str() -> Arc<str> {
+    Arc::clone(&EMPTY_ARC_STR)
+}
+
+/// 256-cell ASCII space buffer. Most padding / clip-spans filler is well
+/// under this; render frame allocations were dominated by `" ".repeat(N)`
+/// because every visible diff/preview row added 1-3 of them.
+const SPACES_BUF: &str = "                                                                                                                                                                                                                                                                ";
+
+/// Borrow `n` spaces from the static buffer. Falls back to a fresh
+/// allocation only when `n` exceeds 256 cells (very wide terminals); the
+/// common case (≤256) is zero-alloc. Returns `Cow<'static, str>` so it
+/// flows directly into `Span::styled` without further conversion.
+pub fn spaces(n: usize) -> Cow<'static, str> {
+    if n <= SPACES_BUF.len() {
+        Cow::Borrowed(&SPACES_BUF[..n])
+    } else {
+        Cow::Owned(" ".repeat(n))
+    }
+}
 
 /// 从字符串头部按显示列截取，直到累计宽度超过 `max_width` 为止。返回
 /// 的切片以显示列为单位，保证不会切在宽字符中间。
@@ -22,8 +52,14 @@ pub fn truncate_to_width(s: &str, max_width: usize) -> &str {
 /// 等量的 filler 空格，确保多行同一 `skip_cols` 下的输出保持竖向对齐
 /// —— 不补 filler 会让后续内容向左漂移 1 列，多行混合 CJK 时整列错位。
 /// 右端超出 `max_width` 的宽字符直接整体丢弃（不强行半切）。
+///
+/// Tokens are `(Style, Cow<'_, str>)` so the overlay → clip pipeline can
+/// thread borrowed slices end-to-end. Callers that already hold owned
+/// `String` (e.g. test paths) wrap via `Cow::Owned`; render paths that
+/// borrow into `Arc<str>` use `Cow::Borrowed` and avoid the per-row
+/// `.to_string()` storm.
 pub fn clip_spans<'a>(
-    tokens: &'a [(Style, String)],
+    tokens: &'a [(Style, Cow<'a, str>)],
     skip_cols: usize,
     max_width: usize,
 ) -> Vec<Span<'a>> {
@@ -56,7 +92,7 @@ pub fn clip_spans<'a>(
                     let filler_w = skipped + cw - skip_cols;
                     let render = filler_w.min(max_width.saturating_sub(kept_cols));
                     if render > 0 {
-                        out.push(Span::styled(" ".repeat(render), *style));
+                        out.push(Span::styled(spaces(render), *style));
                         kept_cols += render;
                         if kept_cols >= max_width {
                             break 'outer;
@@ -105,17 +141,17 @@ pub fn clip_spans<'a>(
 /// Returns a new token vec with (potentially) more tokens because each match
 /// range that straddles a token boundary forces a split. Rows with no matches
 /// round-trip unchanged.
-pub fn overlay_match_highlight(
-    tokens: Vec<(Style, String)>,
+pub fn overlay_match_highlight<'a>(
+    tokens: Vec<(Style, Cow<'a, str>)>,
     ranges: &[Range<usize>],
     current_range: Option<Range<usize>>,
     match_bg: Color,
     current_bg: Color,
-) -> Vec<(Style, String)> {
+) -> Vec<(Style, Cow<'a, str>)> {
     if ranges.is_empty() {
         return tokens;
     }
-    let mut out: Vec<(Style, String)> = Vec::with_capacity(tokens.len());
+    let mut out: Vec<(Style, Cow<'a, str>)> = Vec::with_capacity(tokens.len());
     let mut abs = 0usize;
     for (style, text) in tokens {
         if text.is_empty() {
@@ -136,28 +172,48 @@ pub fn overlay_match_highlight(
             }
             let next_kind = kind_at(base_abs + i, ranges, current_range.as_ref());
             if next_kind != run_kind {
-                out.push(styled_segment(
-                    style,
-                    &text[seg_start..i],
-                    run_kind,
-                    match_bg,
-                    current_bg,
-                ));
+                push_match_segment(
+                    &mut out, style, &text, seg_start, i, run_kind, match_bg, current_bg,
+                );
                 seg_start = i;
                 run_kind = next_kind;
             }
         }
         if seg_start < len {
-            out.push(styled_segment(
-                style,
-                &text[seg_start..len],
-                run_kind,
-                match_bg,
-                current_bg,
-            ));
+            push_match_segment(
+                &mut out, style, &text, seg_start, len, run_kind, match_bg, current_bg,
+            );
         }
     }
     out
+}
+
+/// Slice `parent[start..end]` into `out` with the kind's style applied.
+/// Borrows when `parent` is `Cow::Borrowed`; allocates a fresh String when
+/// `parent` is `Cow::Owned` (the slice doesn't outlive the input Vec).
+/// Clippy's `ptr_arg` lint flags `&Cow<…>` but we genuinely need to
+/// discriminate the variants to pick borrow-vs-clone — silence it here.
+#[allow(clippy::ptr_arg, clippy::too_many_arguments)]
+fn push_match_segment<'a>(
+    out: &mut Vec<(Style, Cow<'a, str>)>,
+    base: Style,
+    parent: &Cow<'a, str>,
+    start: usize,
+    end: usize,
+    kind: MatchKind,
+    match_bg: Color,
+    current_bg: Color,
+) {
+    let style = match kind {
+        MatchKind::None => base,
+        MatchKind::Match => apply_search_bg(base, match_bg, /*is_current=*/ false),
+        MatchKind::Current => apply_search_bg(base, current_bg, /*is_current=*/ true),
+    };
+    let seg: Cow<'a, str> = match parent {
+        Cow::Borrowed(s) => Cow::Borrowed(&s[start..end]),
+        Cow::Owned(s) => Cow::Owned(s[start..end].to_string()),
+    };
+    out.push((style, seg));
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -179,21 +235,6 @@ fn kind_at(abs: usize, ranges: &[Range<usize>], current: Option<&Range<usize>>) 
         }
     }
     MatchKind::None
-}
-
-fn styled_segment(
-    base: Style,
-    text: &str,
-    kind: MatchKind,
-    match_bg: Color,
-    current_bg: Color,
-) -> (Style, String) {
-    let style = match kind {
-        MatchKind::None => base,
-        MatchKind::Match => apply_search_bg(base, match_bg, /*is_current=*/ false),
-        MatchKind::Current => apply_search_bg(base, current_bg, /*is_current=*/ true),
-    };
-    (style, text.to_string())
 }
 
 fn apply_search_bg(base: Style, bg: Color, is_current: bool) -> Style {
@@ -226,14 +267,14 @@ fn apply_search_bg(base: Style, bg: Color, is_current: bool) -> Style {
 ///
 /// Empty ranges round-trip the tokens unchanged. Mirrors the split-at-boundary
 /// pattern in [`overlay_match_highlight`].
-pub fn overlay_selection_highlight(
-    tokens: Vec<(Style, String)>,
+pub fn overlay_selection_highlight<'a>(
+    tokens: Vec<(Style, Cow<'a, str>)>,
     range: Range<usize>,
-) -> Vec<(Style, String)> {
+) -> Vec<(Style, Cow<'a, str>)> {
     if range.start >= range.end {
         return tokens;
     }
-    let mut out: Vec<(Style, String)> = Vec::with_capacity(tokens.len());
+    let mut out: Vec<(Style, Cow<'a, str>)> = Vec::with_capacity(tokens.len());
     let mut abs = 0usize;
     for (style, text) in tokens {
         if text.is_empty() {
@@ -252,21 +293,13 @@ pub fn overlay_selection_highlight(
             }
             let next_selected = byte_in_range(base_abs + i, &range);
             if next_selected != run_selected {
-                out.push(styled_selection_segment(
-                    style,
-                    &text[seg_start..i],
-                    run_selected,
-                ));
+                push_selection_segment(&mut out, style, &text, seg_start, i, run_selected);
                 seg_start = i;
                 run_selected = next_selected;
             }
         }
         if seg_start < len {
-            out.push(styled_selection_segment(
-                style,
-                &text[seg_start..len],
-                run_selected,
-            ));
+            push_selection_segment(&mut out, style, &text, seg_start, len, run_selected);
         }
     }
     out
@@ -276,13 +309,25 @@ fn byte_in_range(abs: usize, range: &Range<usize>) -> bool {
     abs >= range.start && abs < range.end
 }
 
-fn styled_selection_segment(base: Style, text: &str, selected: bool) -> (Style, String) {
+#[allow(clippy::ptr_arg)]
+fn push_selection_segment<'a>(
+    out: &mut Vec<(Style, Cow<'a, str>)>,
+    base: Style,
+    parent: &Cow<'a, str>,
+    start: usize,
+    end: usize,
+    selected: bool,
+) {
     let style = if selected {
         base.add_modifier(Modifier::REVERSED)
     } else {
         base
     };
-    (style, text.to_string())
+    let seg: Cow<'a, str> = match parent {
+        Cow::Borrowed(s) => Cow::Borrowed(&s[start..end]),
+        Cow::Owned(s) => Cow::Owned(s[start..end].to_string()),
+    };
+    out.push((style, seg));
 }
 
 #[cfg(test)]
@@ -326,7 +371,7 @@ mod tests {
 
     #[test]
     fn clip_spans_skip_zero_equivalent_to_truncate() {
-        let tokens = vec![(sty(), "hello ".to_string()), (sty(), "world".to_string())];
+        let tokens = vec![(sty(), "hello ".into()), (sty(), "world".into())];
         let out = clip_spans(&tokens, 0, 8);
         let joined: String = out.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(joined, "hello wo");
@@ -334,7 +379,7 @@ mod tests {
 
     #[test]
     fn clip_spans_skip_past_first_token() {
-        let tokens = vec![(sty(), "hello ".to_string()), (sty(), "world".to_string())];
+        let tokens = vec![(sty(), "hello ".into()), (sty(), "world".into())];
         let out = clip_spans(&tokens, 6, 5);
         let joined: String = out.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(joined, "world");
@@ -343,7 +388,7 @@ mod tests {
 
     #[test]
     fn clip_spans_skip_splits_first_token() {
-        let tokens = vec![(sty(), "abcdef".to_string())];
+        let tokens = vec![(sty(), "abcdef".into())];
         let out = clip_spans(&tokens, 2, 10);
         let joined: String = out.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(joined, "cdef");
@@ -351,7 +396,7 @@ mod tests {
 
     #[test]
     fn clip_spans_max_width_zero_returns_empty() {
-        let tokens = vec![(sty(), "abc".to_string())];
+        let tokens = vec![(sty(), "abc".into())];
         assert!(clip_spans(&tokens, 0, 0).is_empty());
     }
 
@@ -363,7 +408,7 @@ mod tests {
         // clipped at the same `skip_cols` aligned vertically. Joined
         // output is " 好" (1 cell filler + 2 cells from '好'),
         // visible width 3.
-        let tokens = vec![(sty(), "你好".to_string())];
+        let tokens = vec![(sty(), "你好".into())];
         let out = clip_spans(&tokens, 1, 10);
         let joined: String = out.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(joined, " 好");
@@ -377,8 +422,8 @@ mod tests {
         // outputs of identical visible width. Without filler in
         // the straddle case, row B was 1 cell shorter and every
         // following column visually shifted left.
-        let row_a = vec![(sty(), "abcdef".to_string())]; // skip=1 cuts after 'a'
-        let row_b = vec![(sty(), "你好啊".to_string())]; // skip=1 splits '你'
+        let row_a = vec![(sty(), "abcdef".into())]; // skip=1 cuts after 'a'
+        let row_b = vec![(sty(), "你好啊".into())]; // skip=1 splits '你'
 
         let out_a = clip_spans(&row_a, 1, 5);
         let out_b = clip_spans(&row_b, 1, 5);
@@ -395,7 +440,7 @@ mod tests {
 
     #[test]
     fn clip_spans_skip_beyond_total_width() {
-        let tokens = vec![(sty(), "hi".to_string())];
+        let tokens = vec![(sty(), "hi".into())];
         assert!(clip_spans(&tokens, 10, 10).is_empty());
     }
 
@@ -403,7 +448,7 @@ mod tests {
     fn clip_spans_preserves_distinct_styles_across_tokens() {
         let a = Style::default();
         let b = Style::default().fg(ratatui::style::Color::Red);
-        let tokens = vec![(a, "hello".to_string()), (b, " world".to_string())];
+        let tokens = vec![(a, "hello".into()), (b, " world".into())];
         let out = clip_spans(&tokens, 0, 20);
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].content.as_ref(), "hello");
@@ -414,7 +459,7 @@ mod tests {
 
     #[test]
     fn clip_spans_truncates_across_token_boundary() {
-        let tokens = vec![(sty(), "abc".to_string()), (sty(), "defgh".to_string())];
+        let tokens = vec![(sty(), "abc".into()), (sty(), "defgh".into())];
         let out = clip_spans(&tokens, 0, 5);
         let joined: String = out.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(joined, "abcde");
@@ -423,9 +468,9 @@ mod tests {
     #[test]
     fn clip_spans_empty_token_tolerated() {
         let tokens = vec![
-            (sty(), "".to_string()),
-            (sty(), "abc".to_string()),
-            (sty(), "".to_string()),
+            (sty(), "".into()),
+            (sty(), "abc".into()),
+            (sty(), "".into()),
         ];
         let out = clip_spans(&tokens, 1, 10);
         let joined: String = out.iter().map(|s| s.content.as_ref()).collect();
@@ -434,13 +479,13 @@ mod tests {
 
     // ── overlay_match_highlight ──────────────────────────────────────────────
 
-    fn collect_text(v: &[(Style, String)]) -> String {
-        v.iter().map(|(_, s)| s.as_str()).collect()
+    fn collect_text(v: &[(Style, Cow<'_, str>)]) -> String {
+        v.iter().map(|(_, s)| s.as_ref()).collect()
     }
 
     #[test]
     fn overlay_no_ranges_is_identity() {
-        let tokens = vec![(Style::default(), "hello".to_string())];
+        let tokens = vec![(Style::default(), "hello".into())];
         let out = overlay_match_highlight(
             tokens.clone(),
             &[],
@@ -453,7 +498,7 @@ mod tests {
 
     #[test]
     fn overlay_single_match_splits_and_colors() {
-        let tokens = vec![(Style::default(), "abcdef".to_string())];
+        let tokens = vec![(Style::default(), "abcdef".into())];
         let r = 2..4;
         let out = overlay_match_highlight(
             tokens,
@@ -474,10 +519,10 @@ mod tests {
     #[test]
     fn overlay_match_spans_token_boundary() {
         let tokens = vec![
-            (Style::default(), "abc".to_string()),
+            (Style::default(), "abc".into()),
             (
                 Style::default().fg(ratatui::style::Color::Red),
-                "def".to_string(),
+                "def".into(),
             ),
         ];
         // Range "bcde" — crosses boundary.
@@ -504,7 +549,7 @@ mod tests {
 
     #[test]
     fn overlay_current_overrides_match() {
-        let tokens = vec![(Style::default(), "foofoo".to_string())];
+        let tokens = vec![(Style::default(), "foofoo".into())];
         let out = overlay_match_highlight(
             tokens,
             &[0..3, 3..6],
@@ -522,7 +567,7 @@ mod tests {
         // Non-current match on a diff (bg-bearing) row uses REVERSED so
         // the diff add/remove color stays visible under the highlight.
         let base = Style::default().bg(ratatui::style::Color::Green);
-        let tokens = vec![(base, "abcdef".to_string())];
+        let tokens = vec![(base, "abcdef".into())];
         let r = 2..4;
         let out = overlay_match_highlight(
             tokens,
@@ -542,7 +587,7 @@ mod tests {
         // the active match unreadable on the amber highlight.
         let tokens = vec![(
             Style::default().fg(ratatui::style::Color::Magenta),
-            "foobar".to_string(),
+            "foobar".into(),
         )];
         let r = 0..3;
         let out = overlay_match_highlight(
@@ -566,7 +611,7 @@ mod tests {
         let base = Style::default()
             .bg(ratatui::style::Color::Green)
             .fg(ratatui::style::Color::Magenta);
-        let tokens = vec![(base, "abcdef".to_string())];
+        let tokens = vec![(base, "abcdef".into())];
         let r = 2..4;
         let out = overlay_match_highlight(
             tokens,
@@ -583,7 +628,7 @@ mod tests {
 
     #[test]
     fn overlay_preserves_text_across_segments() {
-        let tokens = vec![(Style::default(), "hello world".to_string())];
+        let tokens = vec![(Style::default(), "hello world".into())];
         let out = overlay_match_highlight(
             tokens,
             &[0..5, 6..11],
@@ -598,14 +643,14 @@ mod tests {
 
     #[test]
     fn selection_overlay_empty_range_is_identity() {
-        let tokens = vec![(Style::default(), "hello".to_string())];
+        let tokens = vec![(Style::default(), "hello".into())];
         let out = overlay_selection_highlight(tokens.clone(), 3..3);
         assert_eq!(out, tokens);
     }
 
     #[test]
     fn selection_overlay_reverses_range() {
-        let tokens = vec![(Style::default(), "abcdef".to_string())];
+        let tokens = vec![(Style::default(), "abcdef".into())];
         let out = overlay_selection_highlight(tokens, 2..4);
         assert_eq!(collect_text(&out), "abcdef");
         assert_eq!(out.len(), 3);
@@ -618,10 +663,10 @@ mod tests {
     #[test]
     fn selection_overlay_spans_token_boundary() {
         let tokens = vec![
-            (Style::default(), "abc".to_string()),
+            (Style::default(), "abc".into()),
             (
                 Style::default().fg(ratatui::style::Color::Red),
-                "def".to_string(),
+                "def".into(),
             ),
         ];
         let out = overlay_selection_highlight(tokens, 1..5);
@@ -640,7 +685,7 @@ mod tests {
 
     #[test]
     fn selection_overlay_full_token_range() {
-        let tokens = vec![(Style::default(), "abc".to_string())];
+        let tokens = vec![(Style::default(), "abc".into())];
         let out = overlay_selection_highlight(tokens, 0..3);
         assert_eq!(out.len(), 1);
         assert!(out[0].0.add_modifier.contains(Modifier::REVERSED));

--- a/tests/drag_autoscroll.rs
+++ b/tests/drag_autoscroll.rs
@@ -260,9 +260,11 @@ fn unified_hit(rows: usize, scroll: usize) -> DiffHit {
         h_scroll: 0,
         sbs_left_h_scroll: 0,
         sbs_right_h_scroll: 0,
-        rows: (0..rows)
-            .map(|i| DiffRowText::Unified(format!("row {}", i)))
-            .collect(),
+        rows: std::sync::Arc::new(
+            (0..rows)
+                .map(|i| DiffRowText::Unified(format!("row {}", i).into()))
+                .collect(),
+        ),
     }
 }
 

--- a/tests/find_widget_mutex.rs
+++ b/tests/find_widget_mutex.rs
@@ -39,20 +39,22 @@ fn opening_widget_clears_legacy_search() {
 
     // Park the legacy `/` in a dormant-but-non-empty state — the
     // "user committed a search, then went back to navigating" shape.
+    // Go through `set_matches` so the `row_index` invariant holds.
     app.search = SearchState {
         active: false,
         backwards: false,
         query: "foo".to_string(),
         cursor: 3,
         target: Some(SearchTarget::FilePreview),
-        matches: vec![MatchLoc {
-            row: 0,
-            byte_range: 0..3,
-        }],
-        current: Some(0),
         snapshot: None,
         wrap_msg: None,
+        ..SearchState::default()
     };
+    app.search.set_matches(vec![MatchLoc {
+        row: 0,
+        byte_range: 0..3,
+    }]);
+    app.search.current = Some(0);
     assert_eq!(app.search.target, Some(SearchTarget::FilePreview));
 
     // Opening the widget must wipe `app.search` so its highlights stop

--- a/tests/find_widget_sbs.rs
+++ b/tests/find_widget_sbs.rs
@@ -30,41 +30,41 @@ fn fresh_app() -> (App, TempDir, CwdGuard) {
 /// left-vs-right targeted search can distinguish them.
 fn install_paired_diff(app: &mut App) {
     let hunk = DiffHunk {
-        header: "@@ -1,3 +1,3 @@".to_string(),
+        header: "@@ -1,3 +1,3 @@".into(),
         lines: vec![
             DiffLine {
                 tag: LineTag::Context,
-                content: "ctx 1".to_string(),
+                content: "ctx 1".into(),
                 old_lineno: Some(1),
                 new_lineno: Some(1),
             },
             DiffLine {
                 tag: LineTag::Removed,
-                content: "old needle here".to_string(),
+                content: "old needle here".into(),
                 old_lineno: Some(2),
                 new_lineno: None,
             },
             DiffLine {
                 tag: LineTag::Added,
-                content: "new needle there".to_string(),
+                content: "new needle there".into(),
                 old_lineno: None,
                 new_lineno: Some(2),
             },
             DiffLine {
                 tag: LineTag::Context,
-                content: "ctx 3".to_string(),
+                content: "ctx 3".into(),
                 old_lineno: Some(3),
                 new_lineno: Some(3),
             },
         ],
     };
-    app.diff_content = Some(HighlightedDiff {
-        diff: DiffContent {
+    app.diff_content = Some(HighlightedDiff::new(
+        DiffContent {
             file_path: "scratch.rs".to_string(),
             hunks: vec![hunk],
         },
-        highlighted: None,
-    });
+        None,
+    ));
 }
 
 fn diff_selection(side: DiffSide) -> DiffSelection {

--- a/tests/focused_preview_scroll.rs
+++ b/tests/focused_preview_scroll.rs
@@ -232,13 +232,13 @@ fn hover_wash_reaches_last_char_of_filename() {
         additions: 0,
         deletions: 0,
     });
-    app.diff_content = Some(reef::app::HighlightedDiff {
-        diff: reef::git::DiffContent {
+    app.diff_content = Some(reef::app::HighlightedDiff::new(
+        reef::git::DiffContent {
             file_path: name.to_string(),
             hunks: Vec::new(),
         },
-        highlighted: None,
-    });
+        None,
+    ));
     app.enter_focused_preview();
     // Drive picker-open so the wash uses the accent (easier to spot than
     // hover_bg) and we're sure the path is up.
@@ -287,13 +287,13 @@ fn hovering_file_path_washes_chip_and_path_only() {
     });
     // Seed diff_content so `focused_preview_interactive_width` can read
     // the path (matches what diff_panel draws in the header).
-    app.diff_content = Some(reef::app::HighlightedDiff {
-        diff: reef::git::DiffContent {
+    app.diff_content = Some(reef::app::HighlightedDiff::new(
+        reef::git::DiffContent {
             file_path: long_name.to_string(),
             hunks: Vec::new(),
         },
-        highlighted: None,
-    });
+        None,
+    ));
     app.enter_focused_preview();
 
     let backend = TestBackend::new(100, 24);
@@ -350,13 +350,13 @@ fn clicking_inside_file_path_toggles_picker() {
         additions: 0,
         deletions: 0,
     });
-    app.diff_content = Some(reef::app::HighlightedDiff {
-        diff: reef::git::DiffContent {
+    app.diff_content = Some(reef::app::HighlightedDiff::new(
+        reef::git::DiffContent {
             file_path: long_name.to_string(),
             hunks: Vec::new(),
         },
-        highlighted: None,
-    });
+        None,
+    ));
     app.enter_focused_preview();
 
     let backend = TestBackend::new(100, 24);
@@ -401,13 +401,13 @@ fn clicking_tag_tail_does_not_toggle_picker() {
         additions: 0,
         deletions: 0,
     });
-    app.diff_content = Some(reef::app::HighlightedDiff {
-        diff: reef::git::DiffContent {
+    app.diff_content = Some(reef::app::HighlightedDiff::new(
+        reef::git::DiffContent {
             file_path: "a.txt".to_string(),
             hunks: Vec::new(),
         },
-        highlighted: None,
-    });
+        None,
+    ));
     app.enter_focused_preview();
 
     let backend = TestBackend::new(100, 24);

--- a/tests/git_repo_integration.rs
+++ b/tests/git_repo_integration.rs
@@ -137,7 +137,7 @@ fn get_diff_unstaged_shows_additions() {
         .iter()
         .flat_map(|h| h.lines.iter())
         .filter(|l| l.tag == LineTag::Added)
-        .map(|l| l.content.as_str())
+        .map(|l| l.content.as_ref())
         .collect();
     assert!(added.iter().any(|c| c.contains("line2")));
 }
@@ -361,7 +361,7 @@ fn get_range_file_diff_collapses_multiple_edits() {
         .iter()
         .flat_map(|h| h.lines.iter())
         .filter(|l| matches!(l.tag, LineTag::Added))
-        .map(|l| l.content.as_str())
+        .map(|l| l.content.as_ref())
         .collect::<Vec<_>>()
         .join("\n");
     assert!(all_content.contains("v3"));


### PR DESCRIPTION
## Summary

Six rounds of profiling + max/high-effort code review collapsed into one PR. The hottest render paths on diff/preview now do refcount bumps instead of per-frame heap copies; tab/theme/layout flips short-circuit on a process-wide LRU; SBS 2-col commit-detail no longer re-allocates 1k+ Strings per frame.

- **Data model**: `DiffLine.content` / `DiffHunk.header` → `Arc<str>`; `HighlightedDiff.highlighted` → `Option<Arc<DiffHighlighted>>`.
- **Render caches**: new `DiffDisplay` pre-builds unified + SBS row vecs and per-row mouse-hit text snapshots once at diff-load. `DiffHit.rows` becomes `Arc<Vec<_>>` for cheap per-frame snapshot. `RowSpan.text` becomes `SpanText { Static / Owned / Shared }` for zero-alloc-where-possible.
- **Token pipeline**: `overlay_*` + `clip_spans` switched to `(Style, Cow<'_, str>)`; no-match rows are zero-alloc end-to-end. Static `SPACES_BUF` kills per-row `" ".repeat(N)`.
- **Highlight LRU**: hand-rolled `HighlightLru` (cap 32, true LRU eviction). `InFlightCell` + `PublishGuard` so concurrent same-key misses share one syntect run and panic-unwind always wakes waiters. Hash includes hunk_lens + length-prefixed path so prior collision classes are closed. Negative results (over-cap diffs) cached as `None`. `assert_invariant` gated behind `cfg(debug_assertions)`.
- **Search**: new `row_index` field on `SearchState` / `FindWidgetState` for O(1+k) per-row lookup. `unified_display_rows` returns `Vec<Arc<str>>`; `collect_rows` borrows directly from `display.*_row_texts` (`Vec<Cow<'_, str>>`). Find widget SBS path reads `display.sbs_row_texts` instead of re-running pairing every keystroke.
- **Panic safety**: `diff_panel::render`, `render_graph_diff_column`, `file_preview_panel::render` no longer permanently lose loaded content on render panic (RAII guards for the first two; `catch_unwind` + `resume_unwind` for the third).
- **Tests/bench**: `_reset_highlight_cache()` hook + `benches/diff_perf.rs` with 6 micro-benches.

## Bench (criterion, 1k lines / 20 hunks)

| Bench                           | Before    | After    | Delta   |
| ------------------------------- | --------- | -------- | ------- |
| unified_display_rows/1k_lines   | 24.98 µs  | 2.88 µs  | **-88.5%** |
| find_keystroke/unified_1k_lines | ~250 µs   | 101 µs   | **~2.5x** |
| DiffDisplay::build/1k_lines     | 33.26 µs  | 30.38 µs | -8.7%   |
| ranges_on_row/lookup_50_rows    | 1.08 µs   | 0.95 µs  | -12%    |
| highlight_diff/miss_1k_lines    | n/a       | 61.5 ms  | new     |
| highlight_diff/cache_hit_1k     | n/a       | 9.71 µs  | **6336x vs miss** |

Re-opening the same file diff (tab flip, theme toggle keeping dark constant, layout toggle) goes from ~60ms to ~10µs.

## Resource trade-off

- ~3-5 MB extra resident memory for the highlight LRU (cap 32 × per-entry `Vec<Vec<Arc<...>>>`). Reef's overall RSS is tens of MB; net <5%.
- Per-frame short-lived heap allocations drop dramatically — the 1k-line SBS-mode 60Hz path went from ~60k String allocations/sec to near zero.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib` — 667 tests pass
- [x] `cargo test --workspace --doc` — passes
- [x] `cargo bench --bench diff_perf` — numbers above
- [ ] Manual smoke: open large diff, scroll, switch layouts (u), toggle theme (t), search (/), find widget (Space+F), 2-col Graph mode
- [ ] Manual smoke: tab between Git / Graph / Files on the same file (cache hit path)
- [ ] Manual smoke: trigger a deliberate render panic (e.g. via debugger) and confirm panel re-renders correctly on next frame

## Notes for review

- The single mega-commit is intentional: changes are tightly coupled (Arc<str> migration triggers SpanText which triggers RowSpan signature changes which ripple through all call sites). Bisecting wouldn't be more useful with smaller commits.
- Round-by-round audit history available on request — every fix has been through ≥1 review pass and the bench numbers haven't regressed across rounds.