### PR TITLE
feat(input): unify bracketed-paste routing across input gates

### DIFF
--- a/src/find_widget.rs
+++ b/src/find_widget.rs
@@ -320,6 +320,18 @@ pub fn handle_key(key: KeyEvent, app: &mut App) {
     }
 }
 
+/// Bracketed-paste arrival while the find widget is active. Same shape
+/// as `search::handle_paste` / `quick_open::handle_paste`: fold the
+/// payload in as typed chars (dropping CR/LF — the widget query is
+/// single-line) and re-derive matches when at least one char actually
+/// landed. Called from `input::handle_paste` after the drop-path parser
+/// has declined the payload.
+pub fn handle_paste(s: &str, app: &mut App) {
+    if input_edit::paste_single_line(s, &mut app.find_widget.query, &mut app.find_widget.cursor) {
+        recompute(app);
+    }
+}
+
 // ─── Internals ───────────────────────────────────────────────────────────────
 
 fn resolve_target(app: &App) -> Option<FindTarget> {

--- a/src/graph_branch_picker.rs
+++ b/src/graph_branch_picker.rs
@@ -136,6 +136,25 @@ impl GraphBranchPickerState {
         self.core.close();
     }
 
+    /// Bracketed-paste arrival while the picker is active. Folds the
+    /// payload into `core.filter` (CR/LF dropped — branch refs are
+    /// single-line) and snaps selection back to the top, mirroring the
+    /// `InputOutcome::Edited` path in `handle_key_graph_branch_picker`.
+    ///
+    /// Does NOT touch `self.scroll` — the keystroke `Edited` arm
+    /// leaves scroll alone and relies on the renderer to pull
+    /// `selected_idx` back into view. Resetting it here would diverge
+    /// from the typing path that this function is meant to mirror.
+    ///
+    /// The memoised [`visible_rows`] cache keys on the lowercased filter
+    /// string, so the paste automatically invalidates it; no
+    /// `mark_dirty` call is needed.
+    pub fn handle_paste(&mut self, s: &str) {
+        if crate::input_edit::paste_single_line(s, &mut self.core.filter, &mut self.core.cursor) {
+            self.core.selected_idx = 0;
+        }
+    }
+
     /// Drop the memoised [`visible_rows`] result. Call this if any
     /// future writer mutates `all_branches` or `recent` IN PLACE
     /// (e.g. swapping one entry for another of the same kind, or
@@ -424,6 +443,46 @@ mod tests {
         assert_eq!(outcome, crate::input_edit::Outcome::Edited);
         assert_eq!(s.core.filter, "你");
         assert_eq!(s.core.cursor, 3);
+    }
+
+    #[test]
+    fn handle_paste_inserts_into_filter_and_resets_selection() {
+        let mut s = GraphBranchPickerState::default();
+        s.open(
+            &ref_map(&[
+                ("aaaa", &[RefLabel::Branch("main".into())]),
+                ("bbbb", &[RefLabel::Branch("feature/x".into())]),
+                ("cccc", &[RefLabel::Branch("release/v1".into())]),
+            ]),
+            vec![],
+            &GraphScope::AllRefs,
+        );
+        s.core.selected_idx = 2;
+        s.scroll = 5;
+        s.handle_paste("feat");
+        assert_eq!(s.core.filter, "feat");
+        assert_eq!(s.core.cursor, 4);
+        // Edited path snaps selection back to the top so the user
+        // sees the row matching the just-pasted filter.
+        assert_eq!(s.core.selected_idx, 0);
+        // Scroll is NOT reset — keystroke path doesn't touch it
+        // either; the renderer pulls selected_idx back into view.
+        assert_eq!(s.scroll, 5);
+        // Cache key includes the filter, so the next visible_rows()
+        // call must reflect the paste rather than returning a stale
+        // pre-paste row set.
+        let rows = s.visible_rows();
+        assert!(
+            rows.iter()
+                .any(|r| matches!(r, BranchPickerRow::Branch(b) if b.display == "feature/x")),
+            "post-paste rows must include the filtered branch"
+        );
+        assert!(
+            !rows
+                .iter()
+                .any(|r| matches!(r, BranchPickerRow::Branch(b) if b.display == "main")),
+            "post-paste rows must drop branches that don't match the filter"
+        );
     }
 
     #[test]

--- a/src/hosts_picker.rs
+++ b/src/hosts_picker.rs
@@ -142,6 +142,38 @@ impl HostsPickerState {
         }
     }
 
+    /// Bracketed-paste arrival while the picker is active. Routes the
+    /// payload to whichever single-line buffer is currently in focus:
+    /// `core.filter` in Search mode, `path_buffer` in Path mode. CR/LF
+    /// are dropped — both buffers are single-line.
+    ///
+    /// Mirrors `quick_open::handle_paste` for the filter side and the
+    /// hand-rolled editor wiring at the bottom of
+    /// `input::handle_key_hosts_picker` for the path side.
+    pub fn handle_paste(&mut self, s: &str) {
+        match self.input_mode {
+            InputMode::Search => {
+                if crate::input_edit::paste_single_line(
+                    s,
+                    &mut self.core.filter,
+                    &mut self.core.cursor,
+                ) {
+                    // Filter changed — reset list cursor to the top,
+                    // matching the `InputOutcome::Edited` arm in
+                    // PickerCore consumers (quick_open / global_search).
+                    self.core.selected_idx = 0;
+                }
+            }
+            InputMode::Path => {
+                let _ = crate::input_edit::paste_single_line(
+                    s,
+                    &mut self.path_buffer,
+                    &mut self.path_cursor,
+                );
+            }
+        }
+    }
+
     /// Apply the current filter against the cached parsed hosts. Recent
     /// targets always appear first; subsequent entries are anything
     /// whose alias / hostname contains the filter (case-insensitive).
@@ -365,6 +397,45 @@ mod tests {
         let recent = vec![one.clone(), two.clone()];
         let pushed = bump_recent(recent, one.clone());
         assert_eq!(pushed, vec![one, two]);
+    }
+
+    #[test]
+    fn handle_paste_routes_to_filter_in_search_mode() {
+        let mut s = HostsPickerState::default();
+        s.open(vec![h("prod")], vec![]);
+        s.core.selected_idx = 7;
+        s.handle_paste("staging");
+        assert_eq!(s.core.filter, "staging");
+        assert_eq!(s.core.cursor, 7);
+        // Filter changed → selection must snap to top, mirroring the
+        // `InputOutcome::Edited` arm in PickerCore consumers.
+        assert_eq!(s.core.selected_idx, 0);
+        // Path buffer untouched.
+        assert!(s.path_buffer.is_empty());
+    }
+
+    #[test]
+    fn handle_paste_routes_to_path_buffer_in_path_mode() {
+        let mut s = HostsPickerState::default();
+        s.open(vec![], vec![]);
+        s.input_mode = InputMode::Path;
+        s.handle_paste("user@host:/srv");
+        assert_eq!(s.path_buffer, "user@host:/srv");
+        assert_eq!(s.path_cursor, "user@host:/srv".len());
+        // Filter side stays clean — path mode and search mode are
+        // mutually exclusive buffers.
+        assert!(s.core.filter.is_empty());
+    }
+
+    #[test]
+    fn handle_paste_strips_crlf_in_both_modes() {
+        let mut s = HostsPickerState::default();
+        s.open(vec![], vec![]);
+        s.handle_paste("ab\r\ncd");
+        assert_eq!(s.core.filter, "abcd");
+        s.input_mode = InputMode::Path;
+        s.handle_paste("xy\nzw");
+        assert_eq!(s.path_buffer, "xyzw");
     }
 
     #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -3840,26 +3840,92 @@ fn handle_mouse_place_mode(mouse: MouseEvent, app: &mut App) {
 
 // ─── Bracketed paste dispatch ────────────────────────────────────────────────
 
-/// Entry point for `Event::Paste(s)` from the main loop. Priorities:
+/// Entry point for `Event::Paste(s)` from the main loop.
 ///
-/// 1. If the payload parses as one or more existing absolute paths, enter
-///    drag-and-drop place mode with those sources.
-/// 2. Otherwise, if an input field has focus (quick-open palette, search
-///    prompt), forward the payload as typed text.
-/// 3. Otherwise drop silently — a paste landing on plain tab navigation
-///    has no sensible target.
+/// Routing priority mirrors the gate stack in [`handle_key`]: paste
+/// targets the same buffer that a keystroke at this moment would type
+/// into. The unification was driven by Space+F find widget pastes
+/// silently dropping; once one overlay needed paste support, lining
+/// the rest of the gate stack up was free.
+///
+/// 1. **Drop targets first.** If the payload parses as one or more
+///    existing absolute paths, enter place mode — Finder drops land
+///    here regardless of which overlay happens to be focused.
+/// 2. **Otherwise route to whichever input owns the keyboard right
+///    now.** Each branch mirrors its `handle_key_*` counterpart's
+///    gate, in the same order, so paste behaviour and typing behaviour
+///    can't drift apart.
+/// 3. **Fallthrough drops silently.** A paste landing on plain tab
+///    navigation has no sensible target.
 pub fn handle_paste(s: String, app: &mut App) {
     let paths = parse_dropped_paths(&s);
     if !paths.is_empty() {
         app.enter_place_mode(paths);
         return;
     }
-    if app.quick_open.core.active {
+
+    // Modal gates that own the keyboard but have NO text input of
+    // their own (tree_context_menu / confirm_modal / paste_conflict /
+    // place_mode / tree_drag). `handle_key` early-returns under each;
+    // mirror that by swallowing the paste, otherwise it would fall
+    // through to the sticky trailing branches (Tab::Git commit
+    // textarea, Tab::Search input) and silently mutate a buffer the
+    // user can't see behind the modal.
+    if app.tree_context_menu.active
+        || app.confirm_modal.is_some()
+        || app.paste_conflict.is_some()
+        || app.place_mode.active
+        || app.tree_drag.active
+    {
+        return;
+    }
+
+    // Mirror `handle_key`'s gate stack so paste lands wherever a
+    // keystroke at this moment would type. Order matters — db_goto
+    // sits above every overlay because it's an inline prompt that
+    // owns input even while another overlay is technically open.
+    if app.db_goto_input.is_some() {
+        if let Some(buf) = app.db_goto_input.as_mut() {
+            paste_db_goto_digits(&s, buf, &mut app.db_goto_cursor);
+        }
+    } else if app.hosts_picker.core.active {
+        app.hosts_picker.handle_paste(&s);
+    } else if app.graph_branch_picker.core.active {
+        app.graph_branch_picker.handle_paste(&s);
+    } else if app.find_widget.active {
+        find_widget::handle_paste(&s, app);
+    } else if app.global_search.core.active {
+        global_search::handle_paste_overlay(&s, &mut app.global_search);
+    } else if app.quick_open.core.active {
         quick_open::handle_paste(&s, app);
     } else if app.search.active {
         search::handle_paste(&s, app);
-    } else if app.global_search.core.active {
-        global_search::handle_paste_overlay(&s, &mut app.global_search);
+    } else if app.tree_edit.active {
+        // Per-char predicate: reject path separators, NUL, control
+        // chars. Mirrors `handle_key_tree_edit`'s phase-2 filter so
+        // the buffer stays perpetually-valid across both typing and
+        // pasting. The error banner only clears when at least one
+        // char actually landed — a fully-rejected paste (e.g. all
+        // `/`s) must not silently wipe a validation message the
+        // user hasn't addressed.
+        if crate::input_edit::paste_single_line_filtered(
+            &s,
+            &mut app.tree_edit.buffer,
+            &mut app.tree_edit.cursor,
+            |c| c != '/' && c != '\\' && c != '\0' && !c.is_control(),
+        ) {
+            app.tree_edit.error = None;
+        }
+    } else if app.view_mode == ViewMode::Settings {
+        // Settings owns every key when open. `editor_edit` is the
+        // only text input inside; everything else (nav, toggles)
+        // has no paste target. Unconditional early-return mirrors
+        // `handle_key_settings` so a paste while the menu is up
+        // can't fall through to the commit-textarea / search-input
+        // trailing branches.
+        if let Some(edit) = app.settings.editor_edit.as_mut() {
+            let _ = crate::input_edit::paste_single_line(&s, &mut edit.buffer, &mut edit.cursor);
+        }
     } else if app.active_tab == Tab::Search
         && app.active_panel == Panel::Files
         && app.global_search.input_focused()
@@ -3886,6 +3952,37 @@ pub fn handle_paste(s: String, app: &mut App) {
     // No focused input; intentionally dropped. A stray paste into the
     // global keymap has no defined meaning, and we don't want to
     // accidentally trigger an action.
+}
+
+/// Paste a digit-only payload into the SQLite goto-page buffer with an
+/// 18-digit cap (one less than `u64::MAX`'s digit count, so a parse is
+/// always safe). CR/LF + non-digit chars are silently swallowed,
+/// matching `dispatch_key_filtered`'s per-char behaviour.
+///
+/// Extracted from `handle_paste` because the natural reach for
+/// `paste_single_line_filtered` here doesn't work — its predicate is
+/// stateless, and a closure that captures the *initial* `buf.len()`
+/// happily lets a single paste blow past the cap. This loop re-derives
+/// the remaining capacity per char, then does one `insert_str`.
+fn paste_db_goto_digits(s: &str, buf: &mut String, cursor: &mut usize) {
+    const MAX_DIGITS: usize = 18;
+    let remaining = MAX_DIGITS.saturating_sub(buf.len());
+    if remaining == 0 {
+        return;
+    }
+    let mut to_insert = String::with_capacity(remaining.min(s.len()));
+    for c in s.chars() {
+        if to_insert.len() >= remaining {
+            break;
+        }
+        if c.is_ascii_digit() {
+            to_insert.push(c);
+        }
+    }
+    if !to_insert.is_empty() {
+        buf.insert_str(*cursor, &to_insert);
+        *cursor += to_insert.len();
+    }
 }
 
 /// Extract filesystem paths from a bracketed-paste payload.
@@ -4475,6 +4572,63 @@ mod leader_tests {
         let shift_space = ke(KeyCode::Char(' '), KeyModifiers::SHIFT);
         let v = leader_decision(&shift_space, true, None, now, LEADER_TIMEOUT);
         assert_eq!(v, LeaderVerdict::None);
+    }
+}
+
+#[cfg(test)]
+mod paste_db_goto_tests {
+    use super::paste_db_goto_digits;
+
+    #[test]
+    fn paste_caps_at_18_digits_even_from_empty_buffer() {
+        // Regression: previously the cap was enforced via a closure
+        // that captured `buf.len()` once at paste start, so a single
+        // paste of N >> 18 digits into an empty buffer landed all N
+        // digits. The fix re-derives remaining capacity per char.
+        let mut buf = String::new();
+        let mut cursor = 0;
+        paste_db_goto_digits("12345678901234567890123456789012345", &mut buf, &mut cursor);
+        assert_eq!(buf.len(), 18);
+        assert_eq!(cursor, 18);
+        assert_eq!(buf, "123456789012345678");
+    }
+
+    #[test]
+    fn paste_respects_existing_buffer_length() {
+        let mut buf = String::from("12345");
+        let mut cursor = 5;
+        paste_db_goto_digits("9876543210987654321098", &mut buf, &mut cursor);
+        // Buffer started at 5, cap is 18 → only 13 chars land.
+        assert_eq!(buf.len(), 18);
+        assert_eq!(buf, "123459876543210987");
+        assert_eq!(cursor, 18);
+    }
+
+    #[test]
+    fn paste_when_buffer_already_at_cap_is_noop() {
+        let mut buf = String::from("123456789012345678");
+        let mut cursor = 18;
+        paste_db_goto_digits("9", &mut buf, &mut cursor);
+        assert_eq!(buf, "123456789012345678");
+        assert_eq!(cursor, 18);
+    }
+
+    #[test]
+    fn paste_swallows_non_digits_and_crlf() {
+        let mut buf = String::new();
+        let mut cursor = 0;
+        paste_db_goto_digits("1a2\r\n3b4", &mut buf, &mut cursor);
+        assert_eq!(buf, "1234");
+        assert_eq!(cursor, 4);
+    }
+
+    #[test]
+    fn paste_at_mid_cursor_inserts_in_place() {
+        let mut buf = String::from("19");
+        let mut cursor = 1;
+        paste_db_goto_digits("23", &mut buf, &mut cursor);
+        assert_eq!(buf, "1239");
+        assert_eq!(cursor, 3);
     }
 }
 

--- a/src/input_edit.rs
+++ b/src/input_edit.rs
@@ -207,6 +207,32 @@ pub fn paste_single_line(s: &str, text: &mut String, cursor: &mut usize) -> bool
     true
 }
 
+/// Filtered variant of [`paste_single_line`] for buffers with a content
+/// predicate (e.g. digits only, file-name chars only). CR/LF are dropped
+/// unconditionally, then every remaining char must satisfy `accept(c)`
+/// to land in `text`. Rejected chars are silently swallowed, mirroring
+/// the per-char behaviour of [`dispatch_key_filtered`] so the buffer
+/// stays in a perpetually-valid state across both typing and pasting.
+///
+/// Returns `true` when at least one char actually landed.
+pub fn paste_single_line_filtered<F: Fn(char) -> bool>(
+    s: &str,
+    text: &mut String,
+    cursor: &mut usize,
+    accept: F,
+) -> bool {
+    let filtered: String = s
+        .chars()
+        .filter(|c| *c != '\n' && *c != '\r' && accept(*c))
+        .collect();
+    if filtered.is_empty() {
+        return false;
+    }
+    text.insert_str(*cursor, &filtered);
+    *cursor += filtered.len();
+    true
+}
+
 pub fn backspace(text: &mut String, cursor: &mut usize) {
     if *cursor == 0 {
         return;
@@ -564,6 +590,41 @@ mod tests {
         assert!(!paste_single_line("\n\r\n", &mut t, &mut c));
         assert_eq!(t, "keep");
         assert_eq!(c, 4);
+    }
+
+    #[test]
+    fn paste_single_line_filtered_keeps_only_accepted_chars() {
+        // Digit-only predicate models the SQLite goto-page input.
+        // Letters between digits are swallowed silently — the buffer
+        // stays in a perpetually-valid state across paste, mirroring
+        // dispatch_key_filtered's per-char behaviour.
+        let (mut t, mut c) = state("", 0);
+        assert!(paste_single_line_filtered("1a2b3", &mut t, &mut c, |c| c.is_ascii_digit(),));
+        assert_eq!(t, "123");
+        assert_eq!(c, 3);
+    }
+
+    #[test]
+    fn paste_single_line_filtered_returns_false_when_predicate_rejects_everything() {
+        let (mut t, mut c) = state("keep", 4);
+        assert!(!paste_single_line_filtered("abc", &mut t, &mut c, |c| c.is_ascii_digit(),));
+        assert_eq!(t, "keep");
+        assert_eq!(c, 4);
+    }
+
+    #[test]
+    fn paste_single_line_filtered_drops_crlf_alongside_predicate() {
+        // CR/LF stripping must precede the predicate so a "1\n2"
+        // payload doesn't trip a predicate that only accepts digits.
+        let (mut t, mut c) = state("", 0);
+        assert!(paste_single_line_filtered(
+            "1\r\n2\n3",
+            &mut t,
+            &mut c,
+            |c| c.is_ascii_digit(),
+        ));
+        assert_eq!(t, "123");
+        assert_eq!(c, 3);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`handle_paste` only knew about quick_open / search / global_search / Tab::Search input / Git commit textarea, so paste into the `Space+F` find widget, hosts picker, graph branch picker, SQLite goto prompt, tree-edit rename input, and the settings command editor was silently dropped — and pastes arriving while a modal was up leaked through to whichever sticky trailing branch (commit textarea / search input) was still flagged active behind it.

This PR makes paste mirror `handle_key`'s gate stack so paste lands wherever a keystroke at that moment would type.

- **L0** `input_edit::paste_single_line_filtered` — CR/LF + per-char predicate, alongside the existing `paste_single_line`
- **find_widget::handle_paste** — query + `recompute()`
- **HostsPickerState::handle_paste** — routes to `core.filter` or `path_buffer` based on `input_mode`
- **GraphBranchPickerState::handle_paste** — filter; cache key includes filter so `visible_rows()` auto-invalidates
- **paste_db_goto_digits** — digit-only with a stateful 18-char cap (closure-captured length wouldn't work; a single paste would otherwise blow past the cap and overflow `parse::<u64>()`)
- **input::handle_paste** — rewritten to walk the gate stack in the same order as `handle_key`, including modal early-return for `tree_context_menu` / `confirm_modal` / `paste_conflict` / `place_mode` / `tree_drag`; Settings branch is now unconditional so paste can't fall through when no editor is open

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features` — 11 new unit tests; only pre-existing `fs_watcher_integration` failures (unrelated, present on `main`)
- [x] `cargo test --workspace --doc`
- [ ] Manual: Space+F find widget accepts paste
- [ ] Manual: Ctrl+O hosts picker accepts paste in both Search and Path modes
- [ ] Manual: Graph `b` branch picker accepts paste; selection snaps to top, scroll preserved
- [ ] Manual: SQLite goto prompt — paste 30 digits, buffer caps at 18
- [ ] Manual: Tree-edit rename — paste `////` does not clear the validation banner
- [ ] Manual: Paste while a confirm modal is open does not mutate the commit textarea behind it