### PR TITLE
fix(ui): widen sidebar divider drag zone

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -146,26 +146,6 @@ pub fn render(f: &mut Frame, app: &mut App) {
     // sidebar slot is absent so the editor slides left by one.
     let editor_idx = if has_sidebar { 1 } else { 0 };
 
-    // Drag zone on the sidebar | right split border — only meaningful when
-    // the sidebar actually occupies a column.
-    if has_sidebar {
-        let split_x = body_layout[0].x + body_layout[0].width.saturating_sub(1);
-        app.hit_registry.register(
-            Rect::new(split_x, body_layout[0].y, 2, body_layout[0].height),
-            ClickAction::StartDragSplit,
-        );
-    }
-    // Second drag zone for the commit | diff boundary in 3-col mode. The
-    // commit column sits right after the (optional) sidebar.
-    if three_col {
-        let commit_rect = body_layout[editor_idx];
-        let mid_split_x = commit_rect.x + commit_rect.width.saturating_sub(1);
-        app.hit_registry.register(
-            Rect::new(mid_split_x, commit_rect.y, 2, commit_rect.height),
-            ClickAction::StartDragGraphDiffSplit,
-        );
-    }
-
     match app.active_tab {
         Tab::Git => {
             if !app.backend.has_repo() {
@@ -201,6 +181,36 @@ pub fn render(f: &mut Frame, app: &mut App) {
             let focused = matches!(app.active_panel, crate::app::Panel::Diff);
             file_preview_panel::render(f, app, body_layout[editor_idx], focused);
         }
+    }
+
+    // Divider drag zones, registered AFTER the panels so they shadow any
+    // panel-registered row hit zones near the boundary. Without this the
+    // sidebar's last column lives under a tree/status/graph row click and
+    // grabbing the divider requires landing on the single column to its
+    // right — clicking a few cells too far left turns a divider drag into
+    // a sidebar item drag. The widened span gives a multi-cell safety
+    // margin on each side of the boundary so the divider is comfortable
+    // to grab without being precise.
+    const DIVIDER_SAFE_LEFT: u16 = 3;
+    const DIVIDER_SAFE_RIGHT: u16 = 2;
+    if has_sidebar {
+        let split_x = body_layout[0].x + body_layout[0].width.saturating_sub(1);
+        let zone_x = split_x.saturating_sub(DIVIDER_SAFE_LEFT);
+        let zone_w = (split_x + DIVIDER_SAFE_RIGHT + 1).saturating_sub(zone_x);
+        app.hit_registry.register(
+            Rect::new(zone_x, body_layout[0].y, zone_w, body_layout[0].height),
+            ClickAction::StartDragSplit,
+        );
+    }
+    if three_col {
+        let commit_rect = body_layout[editor_idx];
+        let mid_split_x = commit_rect.x + commit_rect.width.saturating_sub(1);
+        let zone_x = mid_split_x.saturating_sub(DIVIDER_SAFE_LEFT);
+        let zone_w = (mid_split_x + DIVIDER_SAFE_RIGHT + 1).saturating_sub(zone_x);
+        app.hit_registry.register(
+            Rect::new(zone_x, commit_rect.y, zone_w, commit_rect.height),
+            ClickAction::StartDragGraphDiffSplit,
+        );
     }
 
     render_status_bar(f, app, main_layout[3]);


### PR DESCRIPTION
## Summary
- Sidebar divider was nearly impossible to grab cleanly: the hit zone was registered before panels rendered, so the tree / git-status / graph row click zones (which span the full sidebar width) shadowed the divider's last column. Only a single column outside the sidebar actually triggered drag — clicking a hair too far left grabbed a sidebar item, and on Files tab the tree-drag arm path turned the mis-click into an item drag.
- Register the divider zones after the panels so they sit on top of any panel-registered row hit zones near the boundary, and widen the zone to a 3-cell left / 2-cell right safety margin (configurable via two consts). Same treatment for the Graph 3-col middle divider.

## Test plan
- [ ] Files tab: click the last 3 columns of the sidebar → divider drag starts, no tree-item drag
- [ ] Files tab: click 1–2 columns to the right of the sidebar → divider drag still works
- [ ] Git tab: same near-boundary clicks → divider drag, not a status-row click
- [ ] Graph tab (3-col): sidebar | commit divider AND commit | diff divider both have the expanded safe zone
- [ ] Sidebar-hidden state: no divider zone registered, nothing breaks
- [ ] Narrow terminal where sidebar clamps to min width: divider still grabbable, no panic on saturating math