### PR TITLE
feat(markdown): add reading preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,15 +863,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
  "libgit2-sys",
  "log",
- "url",
 ]
 
 [[package]]
@@ -1375,9 +1374,9 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2011,6 +2011,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.11.1",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,6 +2328,7 @@ dependencies = [
  "notify",
  "nucleo-matcher",
  "proptest",
+ "pulldown-cmark",
  "ratatui",
  "ratatui-image",
  "reef-proto",
@@ -3073,6 +3085,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ tempfile     = "3"
 # but the crate is unavoidable once the toggle exists since literal
 # substring matching can't express word boundaries / alternation.
 regex        = "1"
+# Markdown preview parsing. HTML rendering helpers are disabled; reef builds
+# a terminal-native preview model instead.
+pulldown-cmark = { version = "0.13.4", default-features = false }
 # Code navigation (goto-definition / find-references). `tree-sitter` is the
 # always-on engine — grammars are statically linked C source so the binary
 # stays self-contained and works offline. Phase 2 layers stack-graphs on top

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 crossterm     = "0.29.0"
-git2          = { version = "0.20.4", default-features = false }
+git2          = { version = "0.21.0", default-features = false }
 ratatui       = "0.30.0"
 similar       = "3.1.0"
 unicode-width = "0.2.2"

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 workspace = true
 
 [dependencies]
-git2          = { version = "0.20.4", default-features = false }
+git2          = { version = "0.21.0", default-features = false }
 tempfile      = "3"
 # Generate tiny image fixtures on the fly so tests for the image-preview
 # branch don't ship binary PNG blobs in the repo.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -730,6 +730,10 @@ pub struct App {
     /// 上一帧 preview 内容行的起点(content_x, content_y)与 gutter 宽度。
     /// mouse handler 据此把终端列行坐标映射回文件行/列。
     pub last_preview_content_origin: Option<(u16, u16, u16)>,
+    /// Markdown reading view content origin. Kept separate from
+    /// `last_preview_content_origin` so source navigation never treats
+    /// rendered Markdown rows as file byte coordinates.
+    pub last_markdown_content_origin: Option<(u16, u16)>,
     /// 连击计数器:记录上一次 preview 区 Down(Left) 的时间/位置/次数,用于
     /// 检测双击(选词)和三击(选行)。与全局 `last_click` 独立,不干扰
     /// hit_registry 的 double-click 逻辑。
@@ -1314,6 +1318,7 @@ impl App {
             vertical_scroll_pacer: crate::input::ScrollPacer::new(),
             horizontal_scroll_pacer: crate::input::ScrollPacer::new(),
             last_preview_content_origin: None,
+            last_markdown_content_origin: None,
             preview_click_state: None,
             diff_selection: None,
             last_diff_rect: None,

--- a/src/backend/remote.rs
+++ b/src/backend/remote.rs
@@ -551,6 +551,11 @@ impl Backend for RemoteBackend {
         } else {
             None
         };
+        let markdown = if within_cap {
+            crate::markdown::build_markdown_preview(&rel_str, &content)
+        } else {
+            None
+        };
 
         // SSH mode: tree-sitter still runs locally — file bytes have
         // already crossed the SSH boundary into `raw`. The result is
@@ -573,6 +578,7 @@ impl Backend for RemoteBackend {
             body: PreviewBody::Text {
                 lines,
                 highlighted,
+                markdown,
                 parsed,
             },
         })

--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -71,6 +72,25 @@ impl PreviewContent {
     /// pagination flow vs the standard text-scroll flow.
     pub fn is_database(&self) -> bool {
         matches!(self.body, PreviewBody::Database(_))
+    }
+}
+
+impl PreviewBody {
+    pub fn display_text_rows(&self) -> Vec<Cow<'_, str>> {
+        match self {
+            PreviewBody::Text {
+                markdown: Some(markdown),
+                ..
+            } => markdown
+                .text_rows
+                .iter()
+                .map(|l| Cow::Borrowed(l.as_str()))
+                .collect(),
+            PreviewBody::Text { lines, .. } => {
+                lines.iter().map(|l| Cow::Borrowed(l.as_str())).collect()
+            }
+            _ => Vec::new(),
+        }
     }
 }
 

--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -32,6 +32,7 @@ pub enum PreviewBody {
     Text {
         lines: Vec<String>,
         highlighted: Option<Vec<Vec<(ratatui::style::Style, String)>>>,
+        markdown: Option<crate::markdown::MarkdownPreview>,
         /// Tree-sitter parse for the navigation engine (`gd` /
         /// Ctrl+click / `gr`). Populated by the preview worker when
         /// the file's extension matches a bundled grammar AND the
@@ -791,6 +792,11 @@ pub fn load_preview(
     } else {
         None
     };
+    let markdown = if within_cap {
+        crate::markdown::build_markdown_preview(&rel_str, &content)
+    } else {
+        None
+    };
 
     // Tree-sitter parse for navigation. Same cap as highlight — keeps
     // the two caches coherent: when one is populated the other is too,
@@ -811,6 +817,7 @@ pub fn load_preview(
         body: PreviewBody::Text {
             lines,
             highlighted,
+            markdown,
             parsed,
         },
     })
@@ -1228,6 +1235,45 @@ mod tests {
             PreviewBody::Text { lines, .. } => {
                 assert_eq!(lines, vec!["fn main() {}".to_string()]);
             }
+            other => panic!("expected Text body, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_preview_markdown_attaches_render_model() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_bytes(
+            tmp.path(),
+            "README.md",
+            b"# Title\n\n| Name | Count |\n|:---|---:|\n| reef | 1 |\n",
+        );
+
+        let content = load_preview(tmp.path(), Path::new("README.md"), true, true).expect("some");
+        match content.body {
+            PreviewBody::Text {
+                lines, markdown, ..
+            } => {
+                assert_eq!(lines[0], "# Title");
+                let rows: Vec<String> = markdown
+                    .expect("markdown render model")
+                    .rows
+                    .iter()
+                    .map(|r| r.iter().map(|s| s.text.as_str()).collect())
+                    .collect();
+                assert!(rows.contains(&"┃ reef ┃     1 ┃".to_string()));
+            }
+            other => panic!("expected Text body, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_preview_plain_text_has_no_markdown_model() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_bytes(tmp.path(), "notes.txt", b"# not markdown here\n");
+
+        let content = load_preview(tmp.path(), Path::new("notes.txt"), true, true).expect("some");
+        match content.body {
+            PreviewBody::Text { markdown, .. } => assert!(markdown.is_none()),
             other => panic!("expected Text body, got {other:?}"),
         }
     }

--- a/src/find_widget.rs
+++ b/src/find_widget.rs
@@ -402,12 +402,9 @@ fn diff_target_from_layout(
 /// `display.unified_row_texts` / `display.sbs_row_texts` rather than
 /// re-flattening the diff on every keystroke.
 fn collect_rows(app: &App, target: FindTarget) -> Vec<std::borrow::Cow<'_, str>> {
-    use std::borrow::Cow;
     match target {
         FindTarget::FilePreview => match app.preview_content.as_ref().map(|p| &p.body) {
-            Some(crate::file_tree::PreviewBody::Text { lines, .. }) => {
-                lines.iter().map(|l| Cow::Borrowed(l.as_str())).collect()
-            }
+            Some(body) => body.display_text_rows(),
             _ => Vec::new(),
         },
         FindTarget::DiffUnified => match &app.diff_content {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -221,7 +221,7 @@ impl GitRepo {
         self.repo
             .head()
             .ok()
-            .and_then(|h| h.shorthand().map(String::from))
+            .and_then(|h| h.shorthand().ok().map(String::from))
             .unwrap_or_else(|| "(detached)".into())
     }
 
@@ -263,7 +263,7 @@ impl GitRepo {
 
         for entry in statuses.iter() {
             let status = entry.status();
-            let fallback_path = entry.path().map(str::to_string);
+            let fallback_path = entry.path().ok().map(str::to_string);
 
             // Staged changes (index vs HEAD). Check RENAMED before MODIFIED
             // because libgit2 surfaces renamed+edited files with both flags
@@ -602,7 +602,7 @@ impl GitRepo {
     pub fn ahead_behind(&self) -> Option<(usize, usize)> {
         let head = self.repo.head().ok()?;
         let head_oid = head.target()?;
-        let shorthand = head.shorthand()?;
+        let shorthand = head.shorthand().ok()?;
         let branch = self
             .repo
             .find_branch(shorthand, git2::BranchType::Local)
@@ -874,7 +874,7 @@ impl GitRepo {
                 else {
                     continue;
                 };
-                let Some(name) = r.name() else { continue };
+                let Ok(name) = r.name() else { continue };
 
                 let label = if let Some(rest) = name.strip_prefix("refs/heads/") {
                     RefLabel::Branch(rest.to_string())
@@ -1078,7 +1078,7 @@ fn commit_to_info(commit: &git2::Commit) -> CommitInfo {
     let author_name = author.name().unwrap_or("").to_string();
     let author_email = author.email().unwrap_or("").to_string();
     let time = author.when().seconds();
-    let subject = commit.summary().unwrap_or("").to_string();
+    let subject = commit.summary().ok().flatten().unwrap_or("").to_string();
     CommitInfo {
         oid,
         short_oid,

--- a/src/global_search.rs
+++ b/src/global_search.rs
@@ -339,9 +339,14 @@ pub(crate) fn current_text_selection(app: &App) -> Option<String> {
     if let (Some(sel), Some(preview)) =
         (app.preview_selection.as_ref(), app.preview_content.as_ref())
         && !sel.is_empty()
-        && let crate::file_tree::PreviewBody::Text { lines, .. } = &preview.body
+        && matches!(&preview.body, crate::file_tree::PreviewBody::Text { .. })
     {
-        let text = crate::ui::selection::collect_selected_text(lines, sel);
+        let rows = preview.body.display_text_rows();
+        let text = crate::ui::selection::collect_selected_text_from_rows(
+            rows.iter().map(|row| row.as_ref()),
+            rows.len(),
+            sel,
+        );
         if let Some(line) = first_nonempty_trimmed_line(&text) {
             return Some(line);
         }

--- a/src/input.rs
+++ b/src/input.rs
@@ -17,7 +17,7 @@ use crate::settings;
 use crate::ui;
 use crate::ui::selection::{
     DiffSelection, DiffSide, PreviewSelection, col_to_byte_offset, collect_diff_selected_text,
-    collect_selected_text, word_at_byte,
+    collect_selected_text_from_rows, word_at_byte,
 };
 use crate::ui::toast::Toast;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
@@ -2982,7 +2982,6 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
 /// clipboard copy. A `Drag` after a double/triple click extends the active
 /// endpoint normally (VS Code-style word-range extension).
 fn handle_preview_selection(mouse: &MouseEvent, app: &mut App) -> bool {
-    let content_origin = app.last_preview_content_origin;
     match mouse.kind {
         MouseEventKind::Down(MouseButton::Left) => {
             let Some(rect) = app.last_preview_rect else {
@@ -2997,11 +2996,8 @@ fn handle_preview_selection(mouse: &MouseEvent, app: &mut App) -> bool {
             // the same line in `handle_diff_selection`.
             app.active_panel = Panel::Diff;
 
-            let Some(origin) = content_origin else {
-                return false;
-            };
             let Some((file_line, byte_offset)) =
-                mouse_to_file_coord(app, mouse.column, mouse.row, origin)
+                mouse_to_preview_coord(app, mouse.column, mouse.row)
             else {
                 return false;
             };
@@ -3022,23 +3018,13 @@ fn handle_preview_selection(mouse: &MouseEvent, app: &mut App) -> bool {
             };
             app.preview_click_state = Some((now, mouse.column, mouse.row, click_count));
 
-            let preview_lines: &[String] = app
-                .preview_content
-                .as_ref()
-                .and_then(|p| match &p.body {
-                    crate::file_tree::PreviewBody::Text { lines, .. } => Some(lines.as_slice()),
-                    _ => None,
-                })
-                .unwrap_or_default();
-            let line_len = preview_lines.get(file_line).map(|l| l.len()).unwrap_or(0);
+            let preview_line = preview_display_line(app, file_line).unwrap_or("");
+            let line_len = preview_line.len();
 
             let sel = match click_count {
                 2 => {
                     // Double-click → select word
-                    let word = preview_lines
-                        .get(file_line)
-                        .map(|l| word_at_byte(l, byte_offset))
-                        .unwrap_or(byte_offset..byte_offset);
+                    let word = word_at_byte(preview_line, byte_offset);
                     PreviewSelection {
                         anchor: (file_line, word.start),
                         active: (file_line, word.end),
@@ -3071,10 +3057,7 @@ fn handle_preview_selection(mouse: &MouseEvent, app: &mut App) -> bool {
             // the tick will guard on origin separately and we still want
             // the latest mouse position for the next valid frame.
             app.last_drag_mouse = Some((mouse.column, mouse.row));
-            let Some(origin) = content_origin else {
-                return true; // swallow even without update — the drag is ours
-            };
-            if let Some(pos) = mouse_to_file_coord(app, mouse.column, mouse.row, origin) {
+            if let Some(pos) = mouse_to_preview_coord(app, mouse.column, mouse.row) {
                 if let Some(s) = app.preview_selection.as_mut() {
                     s.active = pos;
                 }
@@ -3097,8 +3080,8 @@ fn handle_preview_selection(mouse: &MouseEvent, app: &mut App) -> bool {
                 if let Some(preview) = app.preview_content.as_ref() {
                     // Only text bodies have selectable lines — image/binary
                     // previews have no `lines` vector.
-                    if let crate::file_tree::PreviewBody::Text { lines, .. } = &preview.body {
-                        let text = collect_selected_text(lines, &sel_snapshot);
+                    if matches!(&preview.body, crate::file_tree::PreviewBody::Text { .. }) {
+                        let text = collect_preview_selected_text(preview, &sel_snapshot);
                         if !text.is_empty() {
                             match clipboard::copy_to_clipboard(&text) {
                                 Ok(()) => app.toasts.push(Toast::info(t(Msg::ClipboardCopied))),
@@ -3265,6 +3248,26 @@ fn point_in_rect(rect: Rect, col: u16, row: u16) -> bool {
     col >= rect.x && col < rect.x + rect.width && row >= rect.y && row < rect.y + rect.height
 }
 
+fn preview_display_line(app: &App, row: usize) -> Option<&str> {
+    let preview = app.preview_content.as_ref()?;
+    match &preview.body {
+        crate::file_tree::PreviewBody::Text {
+            markdown: Some(markdown),
+            ..
+        } => markdown.text_for_row(row),
+        crate::file_tree::PreviewBody::Text { lines, .. } => lines.get(row).map(String::as_str),
+        _ => None,
+    }
+}
+
+fn collect_preview_selected_text(
+    preview: &crate::file_tree::PreviewContent,
+    sel: &PreviewSelection,
+) -> String {
+    let rows = preview.body.display_text_rows();
+    collect_selected_text_from_rows(rows.iter().map(|row| row.as_ref()), rows.len(), sel)
+}
+
 /// Translate a terminal `(column, row)` hit into `(file_line_index,
 /// byte_offset_in_line)` using the cached content-area origin + current
 /// scroll state. Returns `None` when the preview is empty / unloaded.
@@ -3299,6 +3302,44 @@ pub(crate) fn mouse_to_file_coord(
     let byte_offset = col_to_byte_offset(line, visible_col);
 
     Some((file_line, byte_offset))
+}
+
+fn mouse_to_preview_coord(app: &App, col: u16, row: u16) -> Option<(usize, usize)> {
+    let preview = app.preview_content.as_ref()?;
+    match &preview.body {
+        crate::file_tree::PreviewBody::Text {
+            markdown: Some(markdown),
+            ..
+        } => {
+            if markdown.text_rows.is_empty() {
+                return None;
+            }
+            let (content_x, content_y) = app.last_markdown_content_origin?;
+            let visible_row = row.saturating_sub(content_y) as usize;
+            let line_idx = (app.preview_scroll + visible_row).min(markdown.text_rows.len() - 1);
+            let visible_col = (col.saturating_sub(content_x) as usize) + app.preview_h_scroll;
+            let byte_offset = col_to_byte_offset(&markdown.text_rows[line_idx], visible_col);
+            Some((line_idx, byte_offset))
+        }
+        crate::file_tree::PreviewBody::Text { .. } => {
+            let origin = app.last_preview_content_origin?;
+            mouse_to_file_coord(app, col, row, origin)
+        }
+        _ => None,
+    }
+}
+
+fn preview_content_top(app: &App) -> Option<u16> {
+    let preview = app.preview_content.as_ref()?;
+    match &preview.body {
+        crate::file_tree::PreviewBody::Text {
+            markdown: Some(_), ..
+        } => app.last_markdown_content_origin.map(|(_, y)| y),
+        crate::file_tree::PreviewBody::Text { .. } => {
+            app.last_preview_content_origin.map(|(_, y, _)| y)
+        }
+        _ => None,
+    }
 }
 
 // ─── Drag-select auto-scroll ────────────────────────────────────────────────
@@ -3372,9 +3413,6 @@ fn tick_preview_drag_autoscroll(app: &mut App) {
     if !dragging {
         return;
     }
-    let Some(origin) = app.last_preview_content_origin else {
-        return;
-    };
     let Some((mx, my)) = app.last_drag_mouse else {
         return;
     };
@@ -3382,7 +3420,9 @@ fn tick_preview_drag_autoscroll(app: &mut App) {
     if view_h == 0 {
         return;
     }
-    let content_top = origin.1;
+    let Some(content_top) = preview_content_top(app) else {
+        return;
+    };
     let content_bottom = content_top.saturating_add(view_h);
     let step = autoscroll_step(my, content_top, content_bottom);
     if step == 0 {
@@ -3404,6 +3444,10 @@ fn tick_preview_drag_autoscroll(app: &mut App) {
         return;
     };
     let line_count = match &preview.body {
+        crate::file_tree::PreviewBody::Text {
+            markdown: Some(markdown),
+            ..
+        } => markdown.text_rows.len(),
         crate::file_tree::PreviewBody::Text { lines, .. } => lines.len(),
         _ => return,
     };
@@ -3422,7 +3466,7 @@ fn tick_preview_drag_autoscroll(app: &mut App) {
 
     // Re-translate the frozen mouse against the new scroll — this is what
     // makes the selection extend with the viewport as it scrolls.
-    if let Some(coord) = mouse_to_file_coord(app, mx, my, origin) {
+    if let Some(coord) = mouse_to_preview_coord(app, mx, my) {
         if let Some(s) = app.preview_selection.as_mut() {
             s.active = coord;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod images;
 pub mod input;
 pub mod input_edit;
 pub mod input_edit_multi;
+pub mod markdown;
 pub mod nav;
 pub mod paste_conflict;
 pub mod picker_core;

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -8,6 +8,7 @@ use unicode_width::UnicodeWidthStr;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MarkdownPreview {
     pub rows: Vec<Vec<MarkdownSpan>>,
+    pub text_rows: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -37,6 +38,10 @@ pub enum MarkdownRole {
 impl MarkdownPreview {
     pub fn spans_for_row(&self, row: usize) -> Option<&[MarkdownSpan]> {
         self.rows.get(row).map(Vec::as_slice)
+    }
+
+    pub fn text_for_row(&self, row: usize) -> Option<&str> {
+        self.text_rows.get(row).map(String::as_str)
     }
 }
 
@@ -372,7 +377,8 @@ pub fn build_markdown_preview(path: &str, source: &str) -> Option<MarkdownPrevie
     flush_inline(&mut rows, &mut inline);
     trim_trailing_blanks(&mut rows);
 
-    Some(MarkdownPreview { rows })
+    let text_rows = rows.iter().map(|row| row_text(row)).collect();
+    Some(MarkdownPreview { rows, text_rows })
 }
 
 pub fn is_markdown_path(path: &str) -> bool {
@@ -517,6 +523,10 @@ fn spans_width(spans: &[MarkdownSpan]) -> usize {
         .sum()
 }
 
+fn row_text(row: &[MarkdownSpan]) -> String {
+    row.iter().map(|s| s.text.as_str()).collect()
+}
+
 fn table_border(s: &str) -> MarkdownSpan {
     MarkdownSpan {
         text: s.to_string(),
@@ -571,6 +581,7 @@ mod tests {
         let source = "| 名称 | Count |\n|:---|---:|\n| 鲨鱼 | 12 |\n| ray | 3 |\n";
         let md = build_markdown_preview("README.md", source).unwrap();
         let rendered = texts(&md);
+        assert_eq!(md.text_rows, rendered);
         assert_eq!(rendered[0], "┏━━━━━━┳━━━━━━━┓");
         assert_eq!(rendered[1], "┃ 名称 ┃ Count ┃");
         assert_eq!(rendered[2], "┣━━━━━━╋━━━━━━━┫");

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,0 +1,581 @@
+use pulldown_cmark::{
+    Alignment as MdAlignment, CodeBlockKind, Event, Options, Parser, Tag, TagEnd,
+};
+use ratatui::style::{Modifier, Style};
+use std::borrow::Cow;
+use unicode_width::UnicodeWidthStr;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkdownPreview {
+    pub rows: Vec<Vec<MarkdownSpan>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkdownSpan {
+    pub text: String,
+    pub style: MarkdownStyle,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MarkdownStyle {
+    pub role: MarkdownRole,
+    pub bold: bool,
+    pub italic: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarkdownRole {
+    Normal,
+    Heading,
+    Quote,
+    Code,
+    Link,
+    TableHeader,
+    Border,
+}
+
+impl MarkdownPreview {
+    pub fn spans_for_row(&self, row: usize) -> Option<&[MarkdownSpan]> {
+        self.rows.get(row).map(Vec::as_slice)
+    }
+}
+
+impl MarkdownStyle {
+    fn normal() -> Self {
+        Self {
+            role: MarkdownRole::Normal,
+            bold: false,
+            italic: false,
+        }
+    }
+
+    fn role(role: MarkdownRole) -> Self {
+        Self {
+            role,
+            bold: false,
+            italic: false,
+        }
+    }
+
+    fn apply(self, base: Style, theme: &crate::ui::theme::Theme) -> Style {
+        let mut out = match self.role {
+            MarkdownRole::Normal => base,
+            MarkdownRole::Heading => base.fg(theme.accent).add_modifier(Modifier::BOLD),
+            MarkdownRole::Quote => base.fg(theme.fg_secondary),
+            MarkdownRole::Code => base.fg(theme.accent),
+            MarkdownRole::Link => base.fg(theme.accent).add_modifier(Modifier::UNDERLINED),
+            MarkdownRole::Border => base.fg(theme.fg_secondary),
+            MarkdownRole::TableHeader => base.add_modifier(Modifier::BOLD),
+        };
+        if self.bold {
+            out = out.add_modifier(Modifier::BOLD);
+        }
+        if self.italic {
+            out = out.add_modifier(Modifier::ITALIC);
+        }
+        out
+    }
+}
+
+impl MarkdownSpan {
+    pub fn styled_text<'a>(&'a self, theme: &crate::ui::theme::Theme) -> (Style, Cow<'a, str>) {
+        (
+            self.style
+                .apply(Style::default().fg(theme.fg_primary), theme),
+            Cow::Borrowed(self.text.as_str()),
+        )
+    }
+}
+
+#[derive(Debug)]
+struct InlineState {
+    spans: Vec<MarkdownSpan>,
+    style: MarkdownStyle,
+    link_dest: Option<String>,
+}
+
+impl InlineState {
+    fn new() -> Self {
+        Self {
+            spans: Vec::new(),
+            style: MarkdownStyle::normal(),
+            link_dest: None,
+        }
+    }
+
+    fn push(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        if let Some(last) = self.spans.last_mut()
+            && last.style == self.style
+        {
+            last.text.push_str(text);
+            return;
+        }
+        self.spans.push(MarkdownSpan {
+            text: text.to_string(),
+            style: self.style,
+        });
+    }
+
+    fn finish(mut self) -> Vec<MarkdownSpan> {
+        if let Some(dest) = self.link_dest.take() {
+            self.style.role = MarkdownRole::Link;
+            self.push(&format!(" ({dest})"));
+        }
+        self.spans
+    }
+}
+
+impl Default for InlineState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Default)]
+struct TableBuild {
+    alignments: Vec<MdAlignment>,
+    rows: Vec<Vec<Vec<MarkdownSpan>>>,
+    current_row: Vec<Vec<MarkdownSpan>>,
+    current_cell: InlineState,
+}
+
+pub fn build_markdown_preview(path: &str, source: &str) -> Option<MarkdownPreview> {
+    if !is_markdown_path(path) {
+        return None;
+    }
+
+    let mut rows = Vec::new();
+    let mut inline = InlineState::new();
+    let mut table: Option<TableBuild> = None;
+    let mut quote_depth = 0usize;
+    let mut list_stack: Vec<Option<u64>> = Vec::new();
+    let mut in_code_block = false;
+
+    let parser = Parser::new_ext(
+        source,
+        Options::ENABLE_TABLES
+            | Options::ENABLE_STRIKETHROUGH
+            | Options::ENABLE_TASKLISTS
+            | Options::ENABLE_FOOTNOTES,
+    );
+    for event in parser {
+        match event {
+            Event::Start(tag) => match tag {
+                Tag::Heading { .. } => {
+                    flush_inline(&mut rows, &mut inline);
+                    inline.style.role = MarkdownRole::Heading;
+                    inline.style.bold = true;
+                }
+                Tag::BlockQuote(_) => {
+                    flush_inline(&mut rows, &mut inline);
+                    quote_depth += 1;
+                    inline.style.role = MarkdownRole::Quote;
+                    inline.push(&format!("{} ", "│".repeat(quote_depth)));
+                }
+                Tag::CodeBlock(kind) => {
+                    flush_inline(&mut rows, &mut inline);
+                    in_code_block = true;
+                    let lang = match kind {
+                        CodeBlockKind::Fenced(lang) => lang.to_string(),
+                        CodeBlockKind::Indented => String::new(),
+                    };
+                    rows.push(vec![MarkdownSpan {
+                        text: if lang.is_empty() {
+                            "╭─ code".to_string()
+                        } else {
+                            format!("╭─ {lang}")
+                        },
+                        style: MarkdownStyle::role(MarkdownRole::Border),
+                    }]);
+                }
+                Tag::List(start) => {
+                    flush_inline(&mut rows, &mut inline);
+                    list_stack.push(start);
+                }
+                Tag::Item => {
+                    flush_inline(&mut rows, &mut inline);
+                    let indent = "  ".repeat(list_stack.len().saturating_sub(1));
+                    let marker = match list_stack.last_mut() {
+                        Some(Some(n)) => {
+                            let marker = format!("{n}. ");
+                            *n += 1;
+                            marker
+                        }
+                        _ => "• ".to_string(),
+                    };
+                    inline.push(&indent);
+                    inline.push(&marker);
+                }
+                Tag::Emphasis => active_inline(&mut inline, &mut table).style.italic = true,
+                Tag::Strong => active_inline(&mut inline, &mut table).style.bold = true,
+                Tag::Link { dest_url, .. } => {
+                    let active = active_inline(&mut inline, &mut table);
+                    active.style.role = MarkdownRole::Link;
+                    active.link_dest = Some(dest_url.to_string());
+                }
+                Tag::Image { dest_url, .. } => {
+                    let active = active_inline(&mut inline, &mut table);
+                    active.push("image: ");
+                    active.link_dest = Some(dest_url.to_string());
+                }
+                Tag::Table(alignments) => {
+                    flush_inline(&mut rows, &mut inline);
+                    table = Some(TableBuild {
+                        alignments,
+                        ..TableBuild::default()
+                    });
+                }
+                Tag::TableHead | Tag::TableRow => {
+                    if let Some(t) = table.as_mut() {
+                        t.current_row.clear();
+                    }
+                }
+                Tag::TableCell => {
+                    if let Some(t) = table.as_mut() {
+                        t.current_cell = InlineState::new();
+                    }
+                }
+                Tag::Paragraph => {}
+                _ => {}
+            },
+            Event::End(end) => match end {
+                TagEnd::Heading(_) => {
+                    flush_inline(&mut rows, &mut inline);
+                    push_blank(&mut rows);
+                    inline.style = MarkdownStyle::normal();
+                }
+                TagEnd::BlockQuote(_) => {
+                    flush_inline(&mut rows, &mut inline);
+                    quote_depth = quote_depth.saturating_sub(1);
+                    inline.style = if quote_depth > 0 {
+                        MarkdownStyle::role(MarkdownRole::Quote)
+                    } else {
+                        MarkdownStyle::normal()
+                    };
+                    if quote_depth == 0 {
+                        push_blank(&mut rows);
+                    }
+                }
+                TagEnd::CodeBlock => {
+                    rows.push(vec![MarkdownSpan {
+                        text: "╰─".to_string(),
+                        style: MarkdownStyle::role(MarkdownRole::Border),
+                    }]);
+                    push_blank(&mut rows);
+                    in_code_block = false;
+                }
+                TagEnd::List(_) => {
+                    flush_inline(&mut rows, &mut inline);
+                    list_stack.pop();
+                    if list_stack.is_empty() {
+                        push_blank(&mut rows);
+                    }
+                }
+                TagEnd::Item => flush_inline(&mut rows, &mut inline),
+                TagEnd::Emphasis => active_inline(&mut inline, &mut table).style.italic = false,
+                TagEnd::Strong => active_inline(&mut inline, &mut table).style.bold = false,
+                TagEnd::Link => {
+                    let active = active_inline(&mut inline, &mut table);
+                    if let Some(dest) = active.link_dest.take() {
+                        active.push(&format!(" ({dest})"));
+                    }
+                    active.style.role = MarkdownRole::Normal;
+                }
+                TagEnd::Image => {
+                    let active = active_inline(&mut inline, &mut table);
+                    if let Some(dest) = active.link_dest.take() {
+                        active.push(&format!(" ({dest})"));
+                    }
+                    active.style.role = MarkdownRole::Normal;
+                }
+                TagEnd::TableCell => {
+                    if let Some(t) = table.as_mut() {
+                        let cell = std::mem::take(&mut t.current_cell);
+                        t.current_row.push(cell.finish());
+                    }
+                }
+                TagEnd::TableHead | TagEnd::TableRow => {
+                    if let Some(t) = table.as_mut()
+                        && !t.current_row.is_empty()
+                    {
+                        t.rows.push(std::mem::take(&mut t.current_row));
+                    }
+                }
+                TagEnd::Table => {
+                    if let Some(t) = table.take() {
+                        rows.extend(render_table(t));
+                        push_blank(&mut rows);
+                    }
+                }
+                TagEnd::Paragraph => {
+                    flush_inline(&mut rows, &mut inline);
+                    if table.is_none() && list_stack.is_empty() && quote_depth == 0 {
+                        push_blank(&mut rows);
+                    }
+                }
+                _ => {}
+            },
+            Event::Text(text) => {
+                if in_code_block {
+                    for part in text.split('\n') {
+                        rows.push(vec![
+                            MarkdownSpan {
+                                text: "│ ".to_string(),
+                                style: MarkdownStyle::role(MarkdownRole::Border),
+                            },
+                            MarkdownSpan {
+                                text: part.to_string(),
+                                style: MarkdownStyle::role(MarkdownRole::Code),
+                            },
+                        ]);
+                    }
+                    continue;
+                }
+                for (idx, part) in text.split('\n').enumerate() {
+                    if idx > 0 {
+                        flush_inline(&mut rows, &mut inline);
+                    }
+                    active_inline(&mut inline, &mut table).push(part);
+                }
+            }
+            Event::Code(text) => {
+                let active = active_inline(&mut inline, &mut table);
+                let old = active.style;
+                active.style.role = MarkdownRole::Code;
+                active.push(text.as_ref());
+                active.style = old;
+            }
+            Event::SoftBreak | Event::HardBreak => flush_inline(&mut rows, &mut inline),
+            Event::Rule => {
+                flush_inline(&mut rows, &mut inline);
+                rows.push(vec![MarkdownSpan {
+                    text: "─".repeat(32),
+                    style: MarkdownStyle::role(MarkdownRole::Border),
+                }]);
+                push_blank(&mut rows);
+            }
+            Event::Html(html) | Event::InlineHtml(html) => {
+                active_inline(&mut inline, &mut table).push(html.as_ref())
+            }
+            Event::FootnoteReference(name) => {
+                active_inline(&mut inline, &mut table).push(&format!("[^{name}]"))
+            }
+            Event::TaskListMarker(checked) => {
+                active_inline(&mut inline, &mut table).push(if checked { "☑ " } else { "☐ " })
+            }
+            _ => {}
+        }
+    }
+    flush_inline(&mut rows, &mut inline);
+    trim_trailing_blanks(&mut rows);
+
+    Some(MarkdownPreview { rows })
+}
+
+pub fn is_markdown_path(path: &str) -> bool {
+    let p = std::path::Path::new(path);
+    matches!(
+        p.extension()
+            .and_then(|e| e.to_str())
+            .map(str::to_ascii_lowercase),
+        Some(ext) if matches!(ext.as_str(), "md" | "markdown" | "mdown" | "mkd")
+    )
+}
+
+fn active_inline<'a>(
+    inline: &'a mut InlineState,
+    table: &'a mut Option<TableBuild>,
+) -> &'a mut InlineState {
+    if let Some(t) = table.as_mut() {
+        return &mut t.current_cell;
+    }
+    inline
+}
+
+fn flush_inline(rows: &mut Vec<Vec<MarkdownSpan>>, inline: &mut InlineState) {
+    if inline.spans.is_empty() {
+        return;
+    }
+    rows.push(std::mem::take(&mut inline.spans));
+}
+
+fn push_blank(rows: &mut Vec<Vec<MarkdownSpan>>) {
+    if rows.last().is_some_and(Vec::is_empty) {
+        return;
+    }
+    rows.push(Vec::new());
+}
+
+fn trim_trailing_blanks(rows: &mut Vec<Vec<MarkdownSpan>>) {
+    while rows.last().is_some_and(Vec::is_empty) {
+        rows.pop();
+    }
+}
+
+fn render_table(table: TableBuild) -> Vec<Vec<MarkdownSpan>> {
+    if table.rows.is_empty() {
+        return Vec::new();
+    }
+    let cols = table.rows.iter().map(Vec::len).max().unwrap_or(0);
+    if cols == 0 {
+        return Vec::new();
+    }
+
+    let mut widths = vec![3usize; cols];
+    for row in &table.rows {
+        for (idx, cell) in row.iter().enumerate() {
+            widths[idx] = widths[idx].max(spans_width(cell));
+        }
+    }
+
+    let mut out = Vec::new();
+    out.push(table_rule("┏", "┳", "┓", &widths));
+    for (row_idx, row) in table.rows.iter().enumerate() {
+        let header = row_idx == 0;
+        out.push(render_table_row(row, &widths, &table.alignments, header));
+        if header {
+            out.push(table_rule("┣", "╋", "┫", &widths));
+        }
+    }
+    out.push(table_rule("┗", "┻", "┛", &widths));
+    out
+}
+
+fn table_rule(left: &str, join: &str, right: &str, widths: &[usize]) -> Vec<MarkdownSpan> {
+    let mut text = String::from(left);
+    for (idx, width) in widths.iter().enumerate() {
+        text.push_str(&"━".repeat(width + 2));
+        text.push_str(if idx + 1 == widths.len() { right } else { join });
+    }
+    vec![MarkdownSpan {
+        text,
+        style: MarkdownStyle::role(MarkdownRole::Border),
+    }]
+}
+
+fn render_table_row(
+    row: &[Vec<MarkdownSpan>],
+    widths: &[usize],
+    alignments: &[MdAlignment],
+    header: bool,
+) -> Vec<MarkdownSpan> {
+    let mut out = Vec::new();
+    out.push(table_border("┃ "));
+    for (idx, width) in widths.iter().enumerate() {
+        let cell = row.get(idx).cloned().unwrap_or_default();
+        push_aligned_cell(
+            &mut out,
+            cell,
+            *width,
+            *alignments.get(idx).unwrap_or(&MdAlignment::None),
+            header,
+        );
+        out.push(table_border(" ┃"));
+        if idx + 1 < widths.len() {
+            out.push(table_border(" "));
+        }
+    }
+    out
+}
+
+fn push_aligned_cell(
+    out: &mut Vec<MarkdownSpan>,
+    mut cell: Vec<MarkdownSpan>,
+    width: usize,
+    alignment: MdAlignment,
+    header: bool,
+) {
+    let cell_w = spans_width(&cell);
+    let pad = width.saturating_sub(cell_w);
+    let (left, right) = match alignment {
+        MdAlignment::Right => (pad, 0),
+        MdAlignment::Center => (pad / 2, pad - pad / 2),
+        MdAlignment::Left | MdAlignment::None => (0, pad),
+    };
+    if left > 0 {
+        out.push(normal_spaces(left));
+    }
+    if header {
+        for span in &mut cell {
+            span.style.role = MarkdownRole::TableHeader;
+            span.style.bold = true;
+        }
+    }
+    out.extend(cell);
+    if right > 0 {
+        out.push(normal_spaces(right));
+    }
+}
+
+fn spans_width(spans: &[MarkdownSpan]) -> usize {
+    spans
+        .iter()
+        .map(|s| UnicodeWidthStr::width(s.text.as_str()))
+        .sum()
+}
+
+fn table_border(s: &str) -> MarkdownSpan {
+    MarkdownSpan {
+        text: s.to_string(),
+        style: MarkdownStyle::role(MarkdownRole::Border),
+    }
+}
+
+fn normal_spaces(width: usize) -> MarkdownSpan {
+    MarkdownSpan {
+        text: " ".repeat(width),
+        style: MarkdownStyle::normal(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn texts(md: &MarkdownPreview) -> Vec<String> {
+        md.rows
+            .iter()
+            .map(|r| r.iter().map(|s| s.text.as_str()).collect())
+            .collect()
+    }
+
+    #[test]
+    fn markdown_path_detection_is_extension_based() {
+        assert!(is_markdown_path("README.md"));
+        assert!(is_markdown_path("notes.Markdown"));
+        assert!(!is_markdown_path("notes.txt"));
+    }
+
+    #[test]
+    fn builds_headings_lists_quotes_links_and_code() {
+        let source =
+            "# Title\n\n- **bold** [site](https://x.test)\n> quote\n\n```rs\nfn main() {}\n```\n";
+        let md = build_markdown_preview("README.md", source).unwrap();
+        let rendered = texts(&md);
+        assert!(rendered.iter().any(|l| l == "Title"));
+        assert!(
+            rendered
+                .iter()
+                .any(|l| l.contains("• bold site (https://x.test)"))
+        );
+        assert!(rendered.iter().any(|l| l == "│ quote"));
+        assert!(rendered.iter().any(|l| l == "╭─ rs"));
+        assert!(rendered.iter().any(|l| l == "│ fn main() {}"));
+    }
+
+    #[test]
+    fn builds_integrated_table_with_cjk_width() {
+        let source = "| 名称 | Count |\n|:---|---:|\n| 鲨鱼 | 12 |\n| ray | 3 |\n";
+        let md = build_markdown_preview("README.md", source).unwrap();
+        let rendered = texts(&md);
+        assert_eq!(rendered[0], "┏━━━━━━┳━━━━━━━┓");
+        assert_eq!(rendered[1], "┃ 名称 ┃ Count ┃");
+        assert_eq!(rendered[2], "┣━━━━━━╋━━━━━━━┫");
+        assert_eq!(rendered[3], "┃ 鲨鱼 ┃    12 ┃");
+        assert_eq!(rendered[4], "┃ ray  ┃     3 ┃");
+        assert_eq!(rendered[5], "┗━━━━━━┻━━━━━━━┛");
+    }
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -361,12 +361,7 @@ fn collect_rows(app: &App, target: SearchTarget) -> Vec<std::borrow::Cow<'_, str
             .map(|r| Cow::Borrowed(r.commit.subject.as_str()))
             .collect(),
         SearchTarget::FilePreview => match &app.preview_content {
-            Some(p) => match &p.body {
-                crate::file_tree::PreviewBody::Text { lines, .. } => {
-                    lines.iter().map(|l| Cow::Borrowed(l.as_str())).collect()
-                }
-                _ => Vec::new(),
-            },
+            Some(p) => p.body.display_text_rows(),
             _ => Vec::new(),
         },
         SearchTarget::Diff => match &app.diff_content {

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -3662,6 +3662,7 @@ mod preview_panic_guard_tests {
             body: crate::file_tree::PreviewBody::Text {
                 lines: vec!["hi".into()],
                 highlighted: None,
+                markdown: None,
                 parsed: None,
             },
         };

--- a/src/ui/file_preview_panel.rs
+++ b/src/ui/file_preview_panel.rs
@@ -510,7 +510,7 @@ fn render_markdown(
     let y = render_card_header(f, area, &preview.file_path, &th, focused, None);
     let content_height = (max_y - y) as usize;
     app.last_preview_view_h = content_height as u16;
-    let max_scroll = markdown.rows.len().saturating_sub(content_height);
+    let max_scroll = markdown.text_rows.len().saturating_sub(content_height);
     app.preview_scroll = app.preview_scroll.min(max_scroll);
 
     let content_w = area.width as usize;
@@ -533,14 +533,43 @@ fn render_markdown(
     // Markdown preview is a reading view; byte-position mouse mapping is
     // intentionally disabled instead of pretending rendered rows are source.
     app.last_preview_content_origin = None;
+    app.last_markdown_content_origin = Some((area.x, y));
+    let selection = app.preview_selection;
 
     for (i, row) in markdown.rows.iter().skip(app.preview_scroll).enumerate() {
         let cy = y + i as u16;
         if cy >= max_y {
             break;
         }
-        let tokens: Vec<(Style, std::borrow::Cow<'_, str>)> =
+        let real_idx = app.preview_scroll + i;
+        let base_tokens: Vec<(Style, std::borrow::Cow<'_, str>)> =
             row.iter().map(|s| s.styled_text(&th)).collect();
+        let (ranges, cur) = if app.find_widget.target == Some(FindTarget::FilePreview) {
+            app.find_widget
+                .ranges_on_row(FindTarget::FilePreview, real_idx)
+        } else {
+            app.search
+                .ranges_on_row(SearchTarget::FilePreview, real_idx)
+        };
+        let tokens = if ranges.is_empty() {
+            base_tokens
+        } else {
+            overlay_match_highlight(
+                base_tokens,
+                &ranges,
+                cur,
+                th.search_match,
+                th.search_current,
+            )
+        };
+        let tokens = match selection.as_ref().and_then(|s| {
+            markdown
+                .text_for_row(real_idx)
+                .and_then(|text| s.line_byte_range(real_idx, text))
+        }) {
+            Some(r) if r.start < r.end => overlay_selection_highlight(tokens, r),
+            _ => tokens,
+        };
         let rendered = Line::from(clip_spans(&tokens, h, content_w));
         f.render_widget(rendered, Rect::new(area.x, cy, area.width, 1));
     }

--- a/src/ui/file_preview_panel.rs
+++ b/src/ui/file_preview_panel.rs
@@ -339,14 +339,21 @@ fn binary_reason_text(info: &BinaryInfo) -> String {
 }
 
 fn render_text(f: &mut Frame, app: &mut App, area: Rect, preview: &PreviewContent, focused: bool) {
-    let (lines, highlighted) = match &preview.body {
+    let (lines, highlighted, markdown) = match &preview.body {
         PreviewBody::Text {
-            lines, highlighted, ..
-        } => (lines, highlighted),
+            lines,
+            highlighted,
+            markdown,
+            ..
+        } => (lines, highlighted, markdown),
         _ => return,
     };
     let th = app.theme;
     let max_y = area.y + area.height;
+    if let Some(markdown) = markdown {
+        render_markdown(f, app, area, preview, markdown, focused);
+        return;
+    }
 
     // [i/N] match counter — shown only when an in-panel `/` search has
     // committed matches against this preview. Cleared automatically on tab
@@ -486,6 +493,55 @@ fn render_text(f: &mut Frame, app: &mut App, area: Rect, preview: &PreviewConten
         spans.extend(clip_spans(&tokens, h, content_w));
 
         let rendered = Line::from(spans);
+        f.render_widget(rendered, Rect::new(area.x, cy, area.width, 1));
+    }
+}
+
+fn render_markdown(
+    f: &mut Frame,
+    app: &mut App,
+    area: Rect,
+    preview: &PreviewContent,
+    markdown: &crate::markdown::MarkdownPreview,
+    focused: bool,
+) {
+    let th = app.theme;
+    let max_y = area.y + area.height;
+    let y = render_card_header(f, area, &preview.file_path, &th, focused, None);
+    let content_height = (max_y - y) as usize;
+    app.last_preview_view_h = content_height as u16;
+    let max_scroll = markdown.rows.len().saturating_sub(content_height);
+    app.preview_scroll = app.preview_scroll.min(max_scroll);
+
+    let content_w = area.width as usize;
+    let max_visible_w = markdown
+        .rows
+        .iter()
+        .skip(app.preview_scroll)
+        .take(content_height)
+        .map(|row| {
+            row.iter()
+                .map(|s| UnicodeWidthStr::width(s.text.as_str()))
+                .sum::<usize>()
+        })
+        .max()
+        .unwrap_or(0);
+    let max_h = max_visible_w.saturating_sub(content_w);
+    app.preview_h_scroll = app.preview_h_scroll.min(max_h);
+    let h = app.preview_h_scroll;
+
+    // Markdown preview is a reading view; byte-position mouse mapping is
+    // intentionally disabled instead of pretending rendered rows are source.
+    app.last_preview_content_origin = None;
+
+    for (i, row) in markdown.rows.iter().skip(app.preview_scroll).enumerate() {
+        let cy = y + i as u16;
+        if cy >= max_y {
+            break;
+        }
+        let tokens: Vec<(Style, std::borrow::Cow<'_, str>)> =
+            row.iter().map(|s| s.styled_text(&th)).collect();
+        let rendered = Line::from(clip_spans(&tokens, h, content_w));
         f.render_widget(rendered, Rect::new(area.x, cy, area.width, 1));
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -55,6 +55,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
     // handler would treat clicks on other panels as selection gestures.
     app.last_preview_rect = None;
     app.last_preview_content_origin = None;
+    app.last_markdown_content_origin = None;
     // Same story for the diff panel — both Git tab Diff and Graph tab's
     // 3-col diff column write into these slots during their own render.
     // If the active tab renders neither, wiping here keeps a stale rect

--- a/src/ui/selection.rs
+++ b/src/ui/selection.rs
@@ -377,14 +377,27 @@ pub fn collect_diff_selected_text(hit: &DiffHit, sel: &DiffSelection) -> String 
 
 /// 把选中范围从 `lines` 提取成一段纯文本。多行之间用 `\n` 连接。
 pub fn collect_selected_text(lines: &[String], sel: &PreviewSelection) -> String {
+    collect_selected_text_from_rows(lines.iter().map(String::as_str), lines.len(), sel)
+}
+
+pub fn collect_selected_text_from_rows<'a>(
+    rows: impl Iterator<Item = &'a str>,
+    row_count: usize,
+    sel: &PreviewSelection,
+) -> String {
     if sel.is_empty() {
         return String::new();
     }
+    if row_count == 0 {
+        return String::new();
+    }
     let (start, end) = sel.normalized();
-    let last = end.0.min(lines.len().saturating_sub(1));
+    let last = end.0.min(row_count - 1);
+    if start.0 > last {
+        return String::new();
+    }
     let mut out = String::new();
-    for row in start.0..=last {
-        let line = &lines[row];
+    for (row, line) in rows.enumerate().skip(start.0).take(last + 1 - start.0) {
         let range = match sel.line_byte_range(row, line) {
             Some(r) => r,
             None => continue,

--- a/tests/backend_preview_loopback.rs
+++ b/tests/backend_preview_loopback.rs
@@ -118,6 +118,39 @@ fn load_preview_text_lines_match() {
     assert_eq!(ll, rl, "text lines diverged");
 }
 
+#[test]
+fn load_preview_markdown_model_matches_on_local_and_remote() {
+    let _lock = BACKEND_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (tmp, _repo) = tempdir_repo();
+    let body = "# Title\n\n| Name | Count |\n|:---|---:|\n| reef | 1 |\n";
+    std::fs::write(tmp.path().join("README.md"), body.as_bytes()).unwrap();
+
+    let local = LocalBackend::open_at(tmp.path().to_path_buf());
+    let remote = spawn_remote(tmp.path());
+
+    let l = local
+        .load_preview(Path::new("README.md"), true, true)
+        .unwrap();
+    let r = remote
+        .load_preview(Path::new("README.md"), true, true)
+        .unwrap();
+    let (
+        PreviewBody::Text {
+            markdown: Some(lm), ..
+        },
+        PreviewBody::Text {
+            markdown: Some(rm), ..
+        },
+    ) = (&l.body, &r.body)
+    else {
+        panic!(
+            "expected both Markdown Text, got {:?} / {:?}",
+            l.body, r.body
+        );
+    };
+    assert_eq!(lm, rm);
+}
+
 /// Build a tiny SQLite fixture at `path` with `SETUP_SQL` so both
 /// backends have something real to read. Bare-minimum schema —
 /// enough to exercise the table list, row count, and first-page

--- a/tests/drag_autoscroll.rs
+++ b/tests/drag_autoscroll.rs
@@ -36,6 +36,7 @@ fn text_preview(line_count: usize) -> PreviewContent {
         body: PreviewBody::Text {
             lines: (0..line_count).map(|i| format!("line {}", i)).collect(),
             highlighted: None,
+            markdown: None,
             parsed: None,
         },
     }

--- a/tests/find_widget_mouse.rs
+++ b/tests/find_widget_mouse.rs
@@ -38,6 +38,7 @@ fn fresh_app() -> (App, TempDir, CwdGuard) {
                 "    bar();".to_string(),
             ],
             highlighted: None,
+            markdown: None,
             parsed: None,
         },
     });
@@ -141,6 +142,7 @@ fn match_case_toggle_flips_and_rematches() {
         body: PreviewBody::Text {
             lines: vec!["Bar bar BAR".to_string()],
             highlighted: None,
+            markdown: None,
             parsed: None,
         },
     });
@@ -169,6 +171,7 @@ fn whole_word_toggle_flips_and_filters_matches() {
         body: PreviewBody::Text {
             lines: vec!["foo food foobar foo!".to_string()],
             highlighted: None,
+            markdown: None,
             parsed: None,
         },
     });
@@ -199,6 +202,7 @@ fn regex_toggle_reinterprets_query() {
         body: PreviewBody::Text {
             lines: vec!["abc 12 d345 ef".to_string()],
             highlighted: None,
+            markdown: None,
             parsed: None,
         },
     });

--- a/tests/find_widget_mutex.rs
+++ b/tests/find_widget_mutex.rs
@@ -27,6 +27,7 @@ fn fresh_app() -> (App, TempDir, CwdGuard) {
         body: PreviewBody::Text {
             lines: vec!["foo bar foo".to_string(), "bar foo".to_string()],
             highlighted: None,
+            markdown: None,
             parsed: None,
         },
     });

--- a/tests/find_widget_seed.rs
+++ b/tests/find_widget_seed.rs
@@ -32,6 +32,7 @@ fn install_text_preview(app: &mut App, lines: &[&str]) {
         body: PreviewBody::Text {
             lines: lines.iter().map(|s| s.to_string()).collect(),
             highlighted: None,
+            markdown: None,
             parsed: None,
         },
     });

--- a/tests/global_search_seed.rs
+++ b/tests/global_search_seed.rs
@@ -38,6 +38,18 @@ fn install_text_preview(app: &mut App, lines: &[&str]) {
     });
 }
 
+fn install_markdown_preview(app: &mut App, source: &str) {
+    app.preview_content = Some(PreviewContent {
+        file_path: "README.md".to_string(),
+        body: PreviewBody::Text {
+            lines: source.lines().map(str::to_string).collect(),
+            highlighted: None,
+            markdown: reef::markdown::build_markdown_preview("README.md", source),
+            parsed: None,
+        },
+    });
+}
+
 fn select_byte_range(app: &mut App, start: (usize, usize), end: (usize, usize)) {
     let mut sel = PreviewSelection::new(start);
     sel.active = end;
@@ -128,4 +140,24 @@ fn begin_with_empty_selection_keeps_existing_query() {
     global_search::begin(&mut app);
 
     assert_eq!(app.global_search.core.filter, "kept");
+}
+
+#[test]
+fn begin_seeds_from_markdown_rendered_rows() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (mut app, _tmp, _g) = fresh_app();
+    install_markdown_preview(&mut app, "| Name | Count |\n|---|---:|\n| reef | 12 |\n");
+    let rendered = match &app.preview_content.as_ref().unwrap().body {
+        PreviewBody::Text {
+            markdown: Some(markdown),
+            ..
+        } => markdown.text_rows[1].clone(),
+        _ => panic!("markdown preview expected"),
+    };
+    assert_eq!(rendered, "┃ Name ┃ Count ┃");
+    select_byte_range(&mut app, (1, 0), (1, rendered.len()));
+
+    global_search::begin(&mut app);
+
+    assert_eq!(app.global_search.core.filter, rendered);
 }

--- a/tests/global_search_seed.rs
+++ b/tests/global_search_seed.rs
@@ -32,6 +32,7 @@ fn install_text_preview(app: &mut App, lines: &[&str]) {
         body: PreviewBody::Text {
             lines: lines.iter().map(|s| s.to_string()).collect(),
             highlighted: None,
+            markdown: None,
             parsed: None,
         },
     });

--- a/tests/nav_goto_definition.rs
+++ b/tests/nav_goto_definition.rs
@@ -39,6 +39,7 @@ fn install_rust_preview(app: &mut App, file_path: &str, src: &str) {
         body: PreviewBody::Text {
             lines: src.lines().map(|s| s.to_string()).collect(),
             highlighted: None,
+            markdown: None,
             parsed,
         },
     });
@@ -198,6 +199,7 @@ fn goto_definition_on_unknown_extension_is_noop() {
         body: PreviewBody::Text {
             lines: vec!["fn helper() {}".to_string()],
             highlighted: None,
+            markdown: None,
             parsed: None,
         },
     });

--- a/tests/nav_lsp_refine.rs
+++ b/tests/nav_lsp_refine.rs
@@ -33,6 +33,7 @@ fn install_rust_preview(app: &mut App, file_path: &str, src: &str) {
         body: PreviewBody::Text {
             lines: src.lines().map(|s| s.to_string()).collect(),
             highlighted: None,
+            markdown: None,
             parsed,
         },
     });
@@ -221,6 +222,7 @@ fn vue_goto_registers_pending_jump_and_uses_cache_on_repeat() {
         body: PreviewBody::Text {
             lines: src.lines().map(|s| s.to_string()).collect(),
             highlighted: None,
+            markdown: None,
             parsed,
         },
     });

--- a/tests/snapshots/ui_snapshots__markdown_preview.snap
+++ b/tests/snapshots/ui_snapshots__markdown_preview.snap
@@ -1,0 +1,25 @@
+---
+source: tests/ui_snapshots.rs
+assertion_line: 618
+expression: output
+---
+ reef  [TMPDIR]  ⎇ (detached)
+ 📁  Files │ 🔎  Search │ ⎇ Git │ ⑂ Graph        ⊟  1:Files 2:Search 3:Git 4:Graph
+ +   📁    ↻   ⊟        │ README.md
+   README.md U         │ ──────────────────────────────────────────────────────
+                       │ Markdown Preview
+                       │
+                       │ ┏━━━━━━┳━━━━━━━┓
+                       │ ┃ Name ┃ Count ┃
+                       │ ┣━━━━━━╋━━━━━━━┫
+                       │ ┃ reef ┃    12 ┃
+                       │ ┗━━━━━━┻━━━━━━━┛
+                       │
+                       │
+                       │
+                       │
+                       │
+                       │
+                       │
+                       │
+ 🔗  SSH        ⚙  q:quit Tab:switch s:stage u:unstage r:refresh h:help  [Files]

--- a/tests/ui_snapshots.rs
+++ b/tests/ui_snapshots.rs
@@ -615,6 +615,8 @@ fn snapshot_markdown_preview() {
     wait_for_preview(&mut app);
 
     let output = render_app(&mut app, 80, 20);
+    assert!(app.last_markdown_content_origin.is_some());
+    assert!(app.last_preview_content_origin.is_none());
     with_filters(&[], || insta::assert_snapshot!("markdown_preview", output));
 }
 

--- a/tests/ui_snapshots.rs
+++ b/tests/ui_snapshots.rs
@@ -581,6 +581,44 @@ fn snapshot_binary_info_pdf() {
 }
 
 #[test]
+fn snapshot_markdown_preview() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    force_en_lang();
+    let (tmp, _raw) = tempdir_repo();
+    std::fs::write(
+        tmp.path().join("README.md"),
+        "# Markdown Preview\n\n| Name | Count |\n|:---|---:|\n| reef | 12 |\n",
+    )
+    .unwrap();
+    let home = tempfile::TempDir::new().expect("home tempdir");
+    let _h = HomeGuard::enter(home.path());
+    let _g = CwdGuard::enter(tmp.path());
+
+    let mut app = App::new(Theme::dark(), None);
+    app.refresh_file_tree();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        app.tick();
+        if !app.file_tree_load.loading && !app.file_tree.entries.is_empty() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    let idx = app
+        .file_tree
+        .entries
+        .iter()
+        .position(|e| e.name == "README.md")
+        .expect("README.md in tree");
+    app.file_tree.selected = idx;
+    app.load_preview();
+    wait_for_preview(&mut app);
+
+    let output = render_app(&mut app, 80, 20);
+    with_filters(&[], || insta::assert_snapshot!("markdown_preview", output));
+}
+
+#[test]
 fn snapshot_search_tab_replace_open_with_excluded_row() {
     // Lock in the VSCode-style Find & Replace layout in Tab::Search:
     // chevron toggle in the find input row, second `↪ ` prompt for the


### PR DESCRIPTION
## Summary
- add structured Markdown reading previews for .md files
- render integrated table borders with alignment and CJK width handling
- keep plain text preview behavior unchanged

## Tests
- cargo test -p reef markdown -- --nocapture
- cargo test -p reef --test ui_snapshots snapshot_markdown_preview -- --nocapture
- cargo test -p reef --test backend_preview_loopback markdown -- --nocapture
- cargo check -p reef
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings