### PR TITLE
Polish Markdown code block rendering

### DIFF
--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,7 +1,7 @@
 use pulldown_cmark::{
     Alignment as MdAlignment, CodeBlockKind, Event, Options, Parser, Tag, TagEnd,
 };
-use ratatui::style::{Modifier, Style};
+use ratatui::style::{Color, Modifier, Style};
 use std::borrow::Cow;
 use unicode_width::UnicodeWidthStr;
 
@@ -30,10 +30,14 @@ pub enum MarkdownRole {
     Heading,
     Quote,
     Code,
+    CodeBlockHeader,
+    CodeBlockText,
     Link,
     TableHeader,
     Border,
 }
+
+const CODE_BLOCK_LABEL_FG: Color = Color::Rgb(150, 180, 205);
 
 impl MarkdownPreview {
     pub fn spans_for_row(&self, row: usize) -> Option<&[MarkdownSpan]> {
@@ -68,6 +72,11 @@ impl MarkdownStyle {
             MarkdownRole::Heading => base.fg(theme.accent).add_modifier(Modifier::BOLD),
             MarkdownRole::Quote => base.fg(theme.fg_secondary),
             MarkdownRole::Code => base.fg(theme.accent),
+            MarkdownRole::CodeBlockHeader => base
+                .fg(code_block_label_fg(theme))
+                .bg(code_block_bg(theme))
+                .add_modifier(Modifier::BOLD),
+            MarkdownRole::CodeBlockText => base.fg(code_block_fg(theme)).bg(code_block_bg(theme)),
             MarkdownRole::Link => base.fg(theme.accent).add_modifier(Modifier::UNDERLINED),
             MarkdownRole::Border => base.fg(theme.fg_secondary),
             MarkdownRole::TableHeader => base.add_modifier(Modifier::BOLD),
@@ -79,6 +88,30 @@ impl MarkdownStyle {
             out = out.add_modifier(Modifier::ITALIC);
         }
         out
+    }
+}
+
+pub fn code_block_bg(theme: &crate::ui::theme::Theme) -> Color {
+    if theme.is_dark {
+        Color::Rgb(36, 38, 46)
+    } else {
+        Color::Rgb(246, 248, 250)
+    }
+}
+
+fn code_block_fg(theme: &crate::ui::theme::Theme) -> Color {
+    if theme.is_dark {
+        Color::Rgb(230, 232, 238)
+    } else {
+        theme.fg_primary
+    }
+}
+
+fn code_block_label_fg(theme: &crate::ui::theme::Theme) -> Color {
+    if theme.is_dark {
+        CODE_BLOCK_LABEL_FG
+    } else {
+        theme.fg_secondary
     }
 }
 
@@ -183,18 +216,17 @@ pub fn build_markdown_preview(path: &str, source: &str) -> Option<MarkdownPrevie
                 Tag::CodeBlock(kind) => {
                     flush_inline(&mut rows, &mut inline);
                     in_code_block = true;
-                    let lang = match kind {
-                        CodeBlockKind::Fenced(lang) => lang.to_string(),
-                        CodeBlockKind::Indented => String::new(),
+                    let label = match kind {
+                        CodeBlockKind::Fenced(lang) => code_block_label(lang.as_ref()),
+                        CodeBlockKind::Indented => None,
                     };
-                    rows.push(vec![MarkdownSpan {
-                        text: if lang.is_empty() {
-                            "╭─ code".to_string()
-                        } else {
-                            format!("╭─ {lang}")
-                        },
-                        style: MarkdownStyle::role(MarkdownRole::Border),
-                    }]);
+                    if let Some(label) = label {
+                        rows.push(vec![MarkdownSpan {
+                            text: format!(" {label} "),
+                            style: MarkdownStyle::role(MarkdownRole::CodeBlockHeader),
+                        }]);
+                    }
+                    rows.push(code_block_padding_row());
                 }
                 Tag::List(start) => {
                     flush_inline(&mut rows, &mut inline);
@@ -265,10 +297,7 @@ pub fn build_markdown_preview(path: &str, source: &str) -> Option<MarkdownPrevie
                     }
                 }
                 TagEnd::CodeBlock => {
-                    rows.push(vec![MarkdownSpan {
-                        text: "╰─".to_string(),
-                        style: MarkdownStyle::role(MarkdownRole::Border),
-                    }]);
+                    rows.push(code_block_padding_row());
                     push_blank(&mut rows);
                     in_code_block = false;
                 }
@@ -325,15 +354,15 @@ pub fn build_markdown_preview(path: &str, source: &str) -> Option<MarkdownPrevie
             },
             Event::Text(text) => {
                 if in_code_block {
-                    for part in text.split('\n') {
+                    for part in text.split_terminator('\n') {
                         rows.push(vec![
                             MarkdownSpan {
-                                text: "│ ".to_string(),
-                                style: MarkdownStyle::role(MarkdownRole::Border),
+                                text: "  ".to_string(),
+                                style: MarkdownStyle::role(MarkdownRole::CodeBlockText),
                             },
                             MarkdownSpan {
                                 text: part.to_string(),
-                                style: MarkdownStyle::role(MarkdownRole::Code),
+                                style: MarkdownStyle::role(MarkdownRole::CodeBlockText),
                             },
                         ]);
                     }
@@ -419,6 +448,17 @@ fn trim_trailing_blanks(rows: &mut Vec<Vec<MarkdownSpan>>) {
     while rows.last().is_some_and(Vec::is_empty) {
         rows.pop();
     }
+}
+
+fn code_block_label(info: &str) -> Option<String> {
+    info.split_whitespace().next().map(str::to_string)
+}
+
+fn code_block_padding_row() -> Vec<MarkdownSpan> {
+    vec![MarkdownSpan {
+        text: String::new(),
+        style: MarkdownStyle::role(MarkdownRole::CodeBlockText),
+    }]
 }
 
 fn render_table(table: TableBuild) -> Vec<Vec<MarkdownSpan>> {
@@ -572,8 +612,26 @@ mod tests {
                 .any(|l| l.contains("• bold site (https://x.test)"))
         );
         assert!(rendered.iter().any(|l| l == "│ quote"));
-        assert!(rendered.iter().any(|l| l == "╭─ rs"));
-        assert!(rendered.iter().any(|l| l == "│ fn main() {}"));
+        assert!(rendered.iter().any(|l| l == " rs "));
+        assert!(rendered.iter().any(|l| l == "  fn main() {}"));
+        let code_row = md
+            .rows
+            .iter()
+            .find(|row| row_text(row) == "  fn main() {}")
+            .expect("code row");
+        assert!(
+            code_row
+                .iter()
+                .all(|span| span.style.role == MarkdownRole::CodeBlockText)
+        );
+    }
+
+    #[test]
+    fn unlabeled_code_block_has_no_header() {
+        let md = build_markdown_preview("README.md", "```\nplain\n```\n").unwrap();
+        let rendered = texts(&md);
+
+        assert_eq!(rendered, vec!["", "  plain", ""]);
     }
 
     #[test]

--- a/src/ui/file_preview_panel.rs
+++ b/src/ui/file_preview_panel.rs
@@ -4,10 +4,10 @@ use crate::find_widget::FindTarget;
 use crate::i18n::{Msg, t};
 use crate::search::SearchTarget;
 use crate::ui::focus::header_title_style;
-use crate::ui::text::{clip_spans, overlay_match_highlight, overlay_selection_highlight};
+use crate::ui::text::{clip_spans, overlay_match_highlight, overlay_selection_highlight, spaces};
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Padding};
 use ratatui_image::StatefulImage;
@@ -570,7 +570,57 @@ fn render_markdown(
             Some(r) if r.start < r.end => overlay_selection_highlight(tokens, r),
             _ => tokens,
         };
-        let rendered = Line::from(clip_spans(&tokens, h, content_w));
+        let mut spans = clip_spans(&tokens, h, content_w);
+        pad_markdown_row_bg(&mut spans, content_w, markdown_row_bg(row, &th));
+        let rendered = Line::from(spans);
         f.render_widget(rendered, Rect::new(area.x, cy, area.width, 1));
+    }
+}
+
+fn pad_markdown_row_bg<'a>(spans: &mut Vec<Span<'a>>, content_w: usize, bg: Option<Color>) {
+    let Some(bg) = bg else {
+        return;
+    };
+    let used = spans
+        .iter()
+        .map(|s| UnicodeWidthStr::width(s.content.as_ref()))
+        .sum::<usize>();
+    if used < content_w {
+        spans.push(Span::styled(
+            spaces(content_w - used),
+            Style::default().bg(bg),
+        ));
+    }
+}
+
+fn markdown_row_bg(
+    row: &[crate::markdown::MarkdownSpan],
+    th: &crate::ui::theme::Theme,
+) -> Option<Color> {
+    row.iter()
+        .any(|s| {
+            matches!(
+                s.style.role,
+                crate::markdown::MarkdownRole::CodeBlockHeader
+                    | crate::markdown::MarkdownRole::CodeBlockText
+            )
+        })
+        .then_some(crate::markdown::code_block_bg(th))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn markdown_code_background_pads_to_full_row() {
+        let mut spans = vec![Span::styled(" code ", Style::default())];
+        let bg = crate::markdown::code_block_bg(&crate::ui::theme::Theme::light());
+        pad_markdown_row_bg(&mut spans, 10, Some(bg));
+
+        assert_eq!(spans.len(), 2);
+        assert_eq!(spans[1].content.as_ref(), "    ");
+        assert_eq!(spans[1].style.bg, Some(bg));
+        assert_eq!(bg, Color::Rgb(246, 248, 250));
     }
 }

--- a/tests/snapshots/ui_snapshots__markdown_preview.snap
+++ b/tests/snapshots/ui_snapshots__markdown_preview.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/ui_snapshots.rs
-assertion_line: 618
 expression: output
 ---
  reef  [TMPDIR]  ⎇ (detached)
@@ -9,16 +8,16 @@ expression: output
    README.md U         │ ──────────────────────────────────────────────────────
                        │ Markdown Preview
                        │
+                       │  rs
+                       │
+                       │   fn main() {}
+                       │
+                       │
                        │ ┏━━━━━━┳━━━━━━━┓
                        │ ┃ Name ┃ Count ┃
                        │ ┣━━━━━━╋━━━━━━━┫
                        │ ┃ reef ┃    12 ┃
                        │ ┗━━━━━━┻━━━━━━━┛
-                       │
-                       │
-                       │
-                       │
-                       │
                        │
                        │
                        │

--- a/tests/ui_snapshots.rs
+++ b/tests/ui_snapshots.rs
@@ -587,7 +587,7 @@ fn snapshot_markdown_preview() {
     let (tmp, _raw) = tempdir_repo();
     std::fs::write(
         tmp.path().join("README.md"),
-        "# Markdown Preview\n\n| Name | Count |\n|:---|---:|\n| reef | 12 |\n",
+        "# Markdown Preview\n\n```rs\nfn main() {}\n```\n\n| Name | Count |\n|:---|---:|\n| reef | 12 |\n",
     )
     .unwrap();
     let home = tempfile::TempDir::new().expect("home tempdir");


### PR DESCRIPTION
## Summary
- render Markdown code blocks with themed background padding
- show language labels only when the fenced block declares one
- keep light theme code blocks subtle

## Checks
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings