### PR TITLE
fix(markdown): make rendered links interactive

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9,6 +9,7 @@ use crate::ui::mouse::{ClickAction, HitTestRegistry};
 use crate::ui::theme::Theme;
 use crate::ui::toast::Toast;
 use std::collections::{HashMap, HashSet};
+use std::path::Component;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, mpsc};
 use std::time::{Duration, Instant};
@@ -5322,6 +5323,9 @@ impl App {
             ClickAction::NavCandidatesClose => {
                 self.nav_close_candidates();
             }
+            ClickAction::OpenMarkdownLink(target) => {
+                self.open_markdown_link(&target);
+            }
             ClickAction::HostsPickerSelect(idx) => {
                 // Mouse click on a hosts-picker row: move selection to
                 // that row and (for paths that already have a target)
@@ -5447,6 +5451,108 @@ impl App {
                 self.close_focused_preview_files();
             }
         }
+    }
+
+    pub fn open_markdown_link(&mut self, target: &str) {
+        if Self::is_url_link(target) {
+            match Self::open_external_url(target) {
+                Ok(()) => self.toasts.push(Toast::info(format!("Opened {target}"))),
+                Err(e) => self
+                    .toasts
+                    .push(Toast::error(format!("Open link failed: {e}"))),
+            }
+            return;
+        }
+
+        let Some(rel) = self.markdown_file_link_target(target) else {
+            self.toasts
+                .push(Toast::warn(format!("Markdown link not found: {target}")));
+            return;
+        };
+        self.set_active_tab(Tab::Files);
+        self.file_tree.reveal(&rel);
+        self.refresh_file_tree_with_target(Some(rel.clone()));
+        self.load_preview_for_path(rel);
+    }
+
+    fn is_url_link(target: &str) -> bool {
+        url::Url::parse(target).is_ok_and(|url| matches!(url.scheme(), "http" | "https" | "mailto"))
+    }
+
+    fn open_external_url(target: &str) -> Result<(), String> {
+        let mut command = Self::open_external_url_command(target)?;
+        command.spawn().map(|_| ()).map_err(|e| e.to_string())
+    }
+
+    #[cfg(target_os = "macos")]
+    fn open_external_url_command(target: &str) -> Result<std::process::Command, String> {
+        let mut command = std::process::Command::new("open");
+        command.arg(target);
+        Ok(command)
+    }
+
+    #[cfg(target_os = "windows")]
+    fn open_external_url_command(target: &str) -> Result<std::process::Command, String> {
+        let mut command = std::process::Command::new("cmd");
+        command.args(["/C", "start", "", target]);
+        Ok(command)
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn open_external_url_command(target: &str) -> Result<std::process::Command, String> {
+        let mut command = std::process::Command::new("xdg-open");
+        command.arg(target);
+        Ok(command)
+    }
+
+    #[cfg(not(any(unix, target_os = "windows")))]
+    fn open_external_url_command(_target: &str) -> Result<std::process::Command, String> {
+        Err("opening URLs is not supported on this platform".to_string())
+    }
+
+    fn markdown_file_link_target(&self, target: &str) -> Option<PathBuf> {
+        let path_part = target
+            .split_once('#')
+            .map(|(path, _)| path)
+            .unwrap_or(target);
+        if path_part.is_empty() {
+            return None;
+        }
+
+        let path = Path::new(path_part);
+        if path.is_absolute() {
+            if self.backend.is_remote() {
+                return Self::remote_workdir_relative(&self.backend.workdir_path(), path);
+            }
+            return self.workdir_relative(path);
+        }
+
+        let preview_path = self
+            .preview_content
+            .as_ref()
+            .map(|preview| Path::new(&preview.file_path))?;
+        let base = preview_path.parent().unwrap_or_else(|| Path::new(""));
+        Self::normalize_relative_path(base.join(path))
+    }
+
+    fn remote_workdir_relative(root: &Path, abs: &Path) -> Option<PathBuf> {
+        let rel = abs.strip_prefix(root).ok()?;
+        Self::normalize_relative_path(rel.to_path_buf())
+    }
+
+    fn normalize_relative_path(path: PathBuf) -> Option<PathBuf> {
+        let mut out = PathBuf::new();
+        for component in path.components() {
+            match component {
+                Component::Normal(part) => out.push(part),
+                Component::CurDir => {}
+                Component::ParentDir => {
+                    out.pop().then_some(())?;
+                }
+                Component::RootDir | Component::Prefix(_) => return None,
+            }
+        }
+        Some(out)
     }
 
     /// Pick the "create anchor" target for a toolbar `+ File` / `+ Folder`
@@ -6067,9 +6173,11 @@ mod tests {
         folder_contains, load_graph_scope_pref, persist_graph_scope,
     };
     use crate::backend::LocalBackend;
+    use crate::file_tree::{PreviewBody, PreviewContent};
     use crate::git::GraphScope;
     use crate::tasks::{GraphPayload, WorkerResult};
     use crate::ui::theme::Theme;
+    use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use test_support::{HOME_LOCK, HomeGuard, commit_file, tempdir_repo};
 
@@ -6116,6 +6224,49 @@ mod tests {
         };
         assert_eq!(g.selected_range(), (4, 9));
         assert!(g.is_range());
+    }
+
+    #[test]
+    fn markdown_link_targets_resolve_from_preview_directory() {
+        assert_eq!(
+            App::normalize_relative_path(PathBuf::from("docs/../README.md")),
+            Some(PathBuf::from("README.md"))
+        );
+        assert_eq!(
+            App::normalize_relative_path(PathBuf::from("../outside.md")),
+            None
+        );
+        assert!(App::is_url_link("https://example.com/a"));
+
+        let mut fx = make_scope_fixture();
+        fx.app.preview_content = Some(PreviewContent {
+            file_path: "docs/guide/index.md".into(),
+            body: PreviewBody::Text {
+                lines: vec![],
+                highlighted: None,
+                parsed: None,
+                markdown: None,
+            },
+        });
+
+        assert_eq!(
+            fx.app.markdown_file_link_target("../intro.md#top"),
+            Some(PathBuf::from("docs/intro.md"))
+        );
+        assert_eq!(fx.app.markdown_file_link_target("#local"), None);
+    }
+
+    #[test]
+    fn remote_markdown_absolute_links_resolve_under_workdir() {
+        let root = PathBuf::from("/home/me/repo");
+        assert_eq!(
+            App::remote_workdir_relative(&root, Path::new("/home/me/repo/docs/a.md")),
+            Some(PathBuf::from("docs/a.md"))
+        );
+        assert_eq!(
+            App::remote_workdir_relative(&root, Path::new("/etc/passwd")),
+            None
+        );
     }
 
     // ── Graph scope: set / fallback / cache ─────────────────────────────

--- a/src/input.rs
+++ b/src/input.rs
@@ -2680,13 +2680,22 @@ pub fn handle_mouse<B: Backend>(mouse: MouseEvent, app: &mut App, terminal: &Ter
         }
     }
 
+    // Clicking a rendered Markdown link opens it. Sits before preview
+    // drag-selection so links behave like links; non-link text still
+    // falls through to selectable reading-view text.
+    if let MouseEventKind::Down(MouseButton::Left) = mouse.kind
+        && let Some(rect) = app.last_preview_rect
+        && point_in_rect(rect, mouse.column, mouse.row)
+        && let Some(action @ ui::mouse::ClickAction::OpenMarkdownLink(_)) =
+            app.hit_registry.hit_test(mouse.column, mouse.row)
+    {
+        app.handle_action(action);
+        return;
+    }
+
     // Ctrl+click on the preview pane → goto-definition. Sits in front
     // of the drag-select fast-path so the click doesn't accidentally
-    // start a new text selection. Cmd / SUPER is deliberately NOT
-    // honored: macOS Terminal.app and (by default) iTerm2 intercept
-    // Cmd+click before it reaches reef, so binding it would give
-    // inconsistent behaviour across terminals. Documented in the
-    // plan file. Users wanting parity can remap in their terminal.
+    // start a new text selection.
     if let MouseEventKind::Down(MouseButton::Left) = mouse.kind
         && mouse.modifiers.contains(KeyModifiers::CONTROL)
         && let Some(rect) = app.last_preview_rect

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -15,6 +15,7 @@ pub struct MarkdownPreview {
 pub struct MarkdownSpan {
     pub text: String,
     pub style: MarkdownStyle,
+    pub link: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -117,11 +118,13 @@ fn code_block_label_fg(theme: &crate::ui::theme::Theme) -> Color {
 
 impl MarkdownSpan {
     pub fn styled_text<'a>(&'a self, theme: &crate::ui::theme::Theme) -> (Style, Cow<'a, str>) {
-        (
-            self.style
-                .apply(Style::default().fg(theme.fg_primary), theme),
-            Cow::Borrowed(self.text.as_str()),
-        )
+        let mut style = self
+            .style
+            .apply(Style::default().fg(theme.fg_primary), theme);
+        if self.link.is_some() {
+            style = style.fg(theme.accent).add_modifier(Modifier::UNDERLINED);
+        }
+        (style, Cow::Borrowed(self.text.as_str()))
     }
 }
 
@@ -147,6 +150,7 @@ impl InlineState {
         }
         if let Some(last) = self.spans.last_mut()
             && last.style == self.style
+            && last.link == self.link_dest
         {
             last.text.push_str(text);
             return;
@@ -154,14 +158,11 @@ impl InlineState {
         self.spans.push(MarkdownSpan {
             text: text.to_string(),
             style: self.style,
+            link: self.link_dest.clone(),
         });
     }
 
-    fn finish(mut self) -> Vec<MarkdownSpan> {
-        if let Some(dest) = self.link_dest.take() {
-            self.style.role = MarkdownRole::Link;
-            self.push(&format!(" ({dest})"));
-        }
+    fn finish(self) -> Vec<MarkdownSpan> {
         self.spans
     }
 }
@@ -224,6 +225,7 @@ pub fn build_markdown_preview(path: &str, source: &str) -> Option<MarkdownPrevie
                         rows.push(vec![MarkdownSpan {
                             text: format!(" {label} "),
                             style: MarkdownStyle::role(MarkdownRole::CodeBlockHeader),
+                            link: None,
                         }]);
                     }
                     rows.push(code_block_padding_row());
@@ -313,16 +315,15 @@ pub fn build_markdown_preview(path: &str, source: &str) -> Option<MarkdownPrevie
                 TagEnd::Strong => active_inline(&mut inline, &mut table).style.bold = false,
                 TagEnd::Link => {
                     let active = active_inline(&mut inline, &mut table);
-                    if let Some(dest) = active.link_dest.take() {
-                        active.push(&format!(" ({dest})"));
-                    }
+                    active.link_dest = None;
                     active.style.role = MarkdownRole::Normal;
                 }
                 TagEnd::Image => {
                     let active = active_inline(&mut inline, &mut table);
-                    if let Some(dest) = active.link_dest.take() {
+                    if let Some(dest) = active.link_dest.clone() {
                         active.push(&format!(" ({dest})"));
                     }
+                    active.link_dest = None;
                     active.style.role = MarkdownRole::Normal;
                 }
                 TagEnd::TableCell => {
@@ -359,10 +360,12 @@ pub fn build_markdown_preview(path: &str, source: &str) -> Option<MarkdownPrevie
                             MarkdownSpan {
                                 text: "  ".to_string(),
                                 style: MarkdownStyle::role(MarkdownRole::CodeBlockText),
+                                link: None,
                             },
                             MarkdownSpan {
                                 text: part.to_string(),
                                 style: MarkdownStyle::role(MarkdownRole::CodeBlockText),
+                                link: None,
                             },
                         ]);
                     }
@@ -388,6 +391,7 @@ pub fn build_markdown_preview(path: &str, source: &str) -> Option<MarkdownPrevie
                 rows.push(vec![MarkdownSpan {
                     text: "─".repeat(32),
                     style: MarkdownStyle::role(MarkdownRole::Border),
+                    link: None,
                 }]);
                 push_blank(&mut rows);
             }
@@ -458,6 +462,7 @@ fn code_block_padding_row() -> Vec<MarkdownSpan> {
     vec![MarkdownSpan {
         text: String::new(),
         style: MarkdownStyle::role(MarkdownRole::CodeBlockText),
+        link: None,
     }]
 }
 
@@ -499,6 +504,7 @@ fn table_rule(left: &str, join: &str, right: &str, widths: &[usize]) -> Vec<Mark
     vec![MarkdownSpan {
         text,
         style: MarkdownStyle::role(MarkdownRole::Border),
+        link: None,
     }]
 }
 
@@ -571,6 +577,7 @@ fn table_border(s: &str) -> MarkdownSpan {
     MarkdownSpan {
         text: s.to_string(),
         style: MarkdownStyle::role(MarkdownRole::Border),
+        link: None,
     }
 }
 
@@ -578,6 +585,7 @@ fn normal_spaces(width: usize) -> MarkdownSpan {
     MarkdownSpan {
         text: " ".repeat(width),
         style: MarkdownStyle::normal(),
+        link: None,
     }
 }
 
@@ -606,10 +614,19 @@ mod tests {
         let md = build_markdown_preview("README.md", source).unwrap();
         let rendered = texts(&md);
         assert!(rendered.iter().any(|l| l == "Title"));
+        assert!(rendered.iter().any(|l| l.contains("• bold site")));
+        let link = md
+            .rows
+            .iter()
+            .flatten()
+            .find(|span| span.text == "site")
+            .expect("link span");
+        assert_eq!(link.link.as_deref(), Some("https://x.test"));
         assert!(
-            rendered
-                .iter()
-                .any(|l| l.contains("• bold site (https://x.test)"))
+            link.styled_text(&crate::ui::theme::Theme::dark())
+                .0
+                .add_modifier
+                .contains(Modifier::UNDERLINED)
         );
         assert!(rendered.iter().any(|l| l == "│ quote"));
         assert!(rendered.iter().any(|l| l == " rs "));

--- a/src/ui/file_preview_panel.rs
+++ b/src/ui/file_preview_panel.rs
@@ -4,6 +4,7 @@ use crate::find_widget::FindTarget;
 use crate::i18n::{Msg, t};
 use crate::search::SearchTarget;
 use crate::ui::focus::header_title_style;
+use crate::ui::mouse::ClickAction;
 use crate::ui::text::{clip_spans, overlay_match_highlight, overlay_selection_highlight, spaces};
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -542,8 +543,20 @@ fn render_markdown(
             break;
         }
         let real_idx = app.preview_scroll + i;
-        let base_tokens: Vec<(Style, std::borrow::Cow<'_, str>)> =
-            row.iter().map(|s| s.styled_text(&th)).collect();
+        let base_tokens: Vec<(Style, std::borrow::Cow<'_, str>)> = row
+            .iter()
+            .scan(0usize, |pos, span| {
+                let start = *pos;
+                *pos += UnicodeWidthStr::width(span.text.as_str());
+                let (mut style, text) = span.styled_text(&th);
+                if span.link.is_some()
+                    && markdown_span_hovered(app, area.x, cy, start, *pos, h, content_w)
+                {
+                    style = markdown_link_hover_style(style, &th);
+                }
+                Some((style, text))
+            })
+            .collect();
         let (ranges, cur) = if app.find_widget.target == Some(FindTarget::FilePreview) {
             app.find_widget
                 .ranges_on_row(FindTarget::FilePreview, real_idx)
@@ -572,8 +585,72 @@ fn render_markdown(
         };
         let mut spans = clip_spans(&tokens, h, content_w);
         pad_markdown_row_bg(&mut spans, content_w, markdown_row_bg(row, &th));
+        register_markdown_links(app, row, area.x, cy, h, content_w);
         let rendered = Line::from(spans);
         f.render_widget(rendered, Rect::new(area.x, cy, area.width, 1));
+    }
+}
+
+fn register_markdown_links(
+    app: &mut App,
+    row: &[crate::markdown::MarkdownSpan],
+    x: u16,
+    y: u16,
+    h_scroll: usize,
+    content_w: usize,
+) {
+    let mut pos = 0usize;
+    for span in row {
+        let width = UnicodeWidthStr::width(span.text.as_str());
+        if let Some(link) = span.link.as_ref() {
+            let start = pos.saturating_sub(h_scroll);
+            let end = (pos + width).saturating_sub(h_scroll).min(content_w);
+            if start < end {
+                app.hit_registry.register_row(
+                    x + start as u16,
+                    y,
+                    (end - start) as u16,
+                    ClickAction::OpenMarkdownLink(link.clone()),
+                );
+            }
+        }
+        pos += width;
+    }
+}
+
+fn markdown_span_hovered(
+    app: &App,
+    x: u16,
+    y: u16,
+    start: usize,
+    end: usize,
+    h_scroll: usize,
+    content_w: usize,
+) -> bool {
+    let Some((hover_x, hover_y)) = app.hover_col.zip(app.hover_row) else {
+        return false;
+    };
+    if hover_y != y {
+        return false;
+    }
+    let screen_start = start.saturating_sub(h_scroll).min(content_w);
+    let screen_end = end.saturating_sub(h_scroll).min(content_w);
+    screen_start < screen_end
+        && hover_x >= x + screen_start as u16
+        && hover_x < x + screen_end as u16
+}
+
+fn markdown_link_hover_style(style: Style, th: &crate::ui::theme::Theme) -> Style {
+    style
+        .fg(markdown_link_hover_fg(th))
+        .add_modifier(Modifier::BOLD)
+}
+
+fn markdown_link_hover_fg(th: &crate::ui::theme::Theme) -> Color {
+    if th.is_dark {
+        Color::Rgb(255, 220, 120)
+    } else {
+        Color::Rgb(130, 80, 223)
     }
 }
 
@@ -622,5 +699,17 @@ mod tests {
         assert_eq!(spans[1].content.as_ref(), "    ");
         assert_eq!(spans[1].style.bg, Some(bg));
         assert_eq!(bg, Color::Rgb(246, 248, 250));
+    }
+
+    #[test]
+    fn markdown_link_hover_changes_foreground_color() {
+        let th = crate::ui::theme::Theme::dark();
+        let base = Style::default().fg(th.accent);
+        let hovered = markdown_link_hover_style(base, &th);
+
+        assert_ne!(hovered.fg, Some(th.accent));
+        assert_eq!(hovered.fg, Some(Color::Rgb(255, 220, 120)));
+        assert!(hovered.add_modifier.contains(Modifier::BOLD));
+        assert!(hovered.bg.is_none());
     }
 }

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -166,6 +166,8 @@ pub enum ClickAction {
     /// Registered panel-wide beneath the open candidates popup; a
     /// click that misses every row dismisses without picking.
     NavCandidatesClose,
+    /// Click a rendered Markdown link in the file preview.
+    OpenMarkdownLink(String),
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
- underline rendered Markdown links and add foreground-only hover feedback
- open rendered Markdown links on click, including file links relative to the preview file
- resolve remote absolute Markdown file links under the remote workdir without local canonicalization

## Tests
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p reef markdown